### PR TITLE
Slice 5: PhysicsWorld + PretextRegistry + first PhysicsCard on home (#5)

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,13 +8,16 @@
       "name": "chaipalaka-web",
       "version": "0.0.1",
       "dependencies": {
+        "@chenglou/pretext": "^0.0.6",
         "@fontsource-variable/jetbrains-mono": "^5.2.8",
         "@fontsource-variable/newsreader": "^5.2.10",
+        "matter-js": "^0.20.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-router-dom": "^6.30.0"
       },
       "devDependencies": {
+        "@types/matter-js": "^0.20.2",
         "@types/node": "^25.6.2",
         "@types/react": "^19.2.0",
         "@types/react-dom": "^19.2.0",
@@ -337,6 +340,12 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@chenglou/pretext": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@chenglou/pretext/-/pretext-0.0.6.tgz",
+      "integrity": "sha512-U10s4tFeyu3oVHfXuNWwZSKqHXefhaigpcBkGj60qQFRJ+yUoQ+ez3cGJelP7BWDAB58HCgjcTSmOcg+77afBQ==",
+      "license": "MIT"
     },
     "node_modules/@csstools/color-helpers": {
       "version": "5.1.0",
@@ -1396,6 +1405,13 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/matter-js": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@types/matter-js/-/matter-js-0.20.2.tgz",
+      "integrity": "sha512-3PPKy3QxvZ89h9+wdBV2488I1JLVs7DEpIkPvgO8JC1mUdiVSO37ZIvVctOTD7hIq8OAL2gJ3ugGSuUip6DhCw==",
       "dev": true,
       "license": "MIT"
     },
@@ -2486,6 +2502,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/matter-js": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/matter-js/-/matter-js-0.20.0.tgz",
+      "integrity": "sha512-iC9fYR7zVT3HppNnsFsp9XOoQdQN2tUyfaKg4CHLH8bN+j6GT4Gw7IH2rP0tflAebrHFw730RR3DkVSZRX8hwA==",
+      "license": "MIT"
     },
     "node_modules/mime-db": {
       "version": "1.52.0",

--- a/web/package.json
+++ b/web/package.json
@@ -14,13 +14,16 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@chenglou/pretext": "^0.0.6",
     "@fontsource-variable/jetbrains-mono": "^5.2.8",
     "@fontsource-variable/newsreader": "^5.2.10",
+    "matter-js": "^0.20.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-router-dom": "^6.30.0"
   },
   "devDependencies": {
+    "@types/matter-js": "^0.20.2",
     "@types/node": "^25.6.2",
     "@types/react": "^19.2.0",
     "@types/react-dom": "^19.2.0",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,11 +1,23 @@
 import type { RouteRecord } from 'vite-react-ssg'
-import Home from './routes/Home'
 
 export const routes: RouteRecord[] = [
   {
     path: '/',
-    Component: Home,
-    entry: 'src/routes/Home.tsx',
+    lazy: async () => {
+      const { default: CanvasLayout } = await import('./layouts/CanvasLayout')
+      return { Component: CanvasLayout }
+    },
+    entry: 'src/layouts/CanvasLayout.tsx',
+    children: [
+      {
+        index: true,
+        lazy: async () => {
+          const { default: Home } = await import('./routes/Home')
+          return { Component: Home }
+        },
+        entry: 'src/routes/Home.tsx',
+      },
+    ],
   },
   {
     path: '/test/canvas',

--- a/web/src/layouts/CanvasLayout.tsx
+++ b/web/src/layouts/CanvasLayout.tsx
@@ -1,10 +1,13 @@
 import { Outlet } from 'react-router-dom'
 import { CANVAS_ONLY_BUNDLE_MARKER } from '../lib/canvas-only-marker'
+import { PhysicsProvider } from '../physics/PhysicsContext'
 
 export default function CanvasLayout() {
   return (
-    <div data-layout="canvas" data-canvas-marker={CANVAS_ONLY_BUNDLE_MARKER}>
-      <Outlet />
-    </div>
+    <PhysicsProvider>
+      <div data-layout="canvas" data-canvas-marker={CANVAS_ONLY_BUNDLE_MARKER}>
+        <Outlet />
+      </div>
+    </PhysicsProvider>
   )
 }

--- a/web/src/physics/PhysicsCard.css
+++ b/web/src/physics/PhysicsCard.css
@@ -1,0 +1,20 @@
+.physics-card {
+  position: fixed;
+  top: 0;
+  left: 0;
+  padding: 24px;
+  margin: 0;
+  background: var(--color-bg-raised);
+  color: var(--color-fg);
+  border: 1px solid var(--color-rule);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md);
+  font-family: var(--font-body);
+  font-size: var(--font-size-base);
+  line-height: var(--line-height-base);
+  cursor: grab;
+  user-select: none;
+  touch-action: none;
+  will-change: transform;
+  z-index: 10;
+}

--- a/web/src/physics/PhysicsCard.tsx
+++ b/web/src/physics/PhysicsCard.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useRef } from 'react'
+import { usePhysicsWorld } from './PhysicsContext'
+import { registry as pretextRegistry } from '../text/registry'
+import './PhysicsCard.css'
+
+export interface PhysicsCardProps {
+  text: string
+  fontKey: string
+  maxWidth: number
+  anchor: { x: number; y: number }
+}
+
+const CARD_PADDING_PX = 24
+
+export function PhysicsCard({ text, fontKey, maxWidth, anchor }: PhysicsCardProps) {
+  const world = usePhysicsWorld()
+  const elRef = useRef<HTMLElement | null>(null)
+
+  useEffect(() => {
+    const el = elRef.current
+    if (!el) return
+
+    const measured = pretextRegistry.measure(text, fontKey, maxWidth)
+    const w = measured.width + CARD_PADDING_PX * 2
+    const h = measured.height + CARD_PADDING_PX * 2
+
+    el.style.width = `${w}px`
+    el.style.height = `${h}px`
+    el.style.transform = `translate(${anchor.x - w / 2}px, ${anchor.y - h / 2}px)`
+
+    const handle = world.register(
+      anchor,
+      { width: w, height: h },
+      {
+        onTransform: ({ x, y, rotation }) => {
+          el.style.transform = `translate(${x - w / 2}px, ${y - h / 2}px) rotate(${rotation}rad)`
+        },
+      },
+    )
+
+    let dragging = false
+    let lastX = 0
+    let lastY = 0
+    const onPointerDown = (e: PointerEvent) => {
+      e.preventDefault()
+      dragging = true
+      lastX = e.clientX
+      lastY = e.clientY
+      el.setPointerCapture(e.pointerId)
+      el.style.cursor = 'grabbing'
+    }
+    const onPointerMove = (e: PointerEvent) => {
+      if (!dragging) return
+      const dx = e.clientX - lastX
+      const dy = e.clientY - lastY
+      const cur = world.getPosition(handle)
+      world.setPosition(handle, { x: cur.x + dx, y: cur.y + dy })
+      lastX = e.clientX
+      lastY = e.clientY
+    }
+    const onPointerUp = (e: PointerEvent) => {
+      if (!dragging) return
+      dragging = false
+      el.releasePointerCapture(e.pointerId)
+      el.style.cursor = 'grab'
+    }
+
+    el.addEventListener('pointerdown', onPointerDown)
+    window.addEventListener('pointermove', onPointerMove)
+    window.addEventListener('pointerup', onPointerUp)
+
+    return () => {
+      world.unregister(handle)
+      el.removeEventListener('pointerdown', onPointerDown)
+      window.removeEventListener('pointermove', onPointerMove)
+      window.removeEventListener('pointerup', onPointerUp)
+    }
+  }, [world, text, fontKey, maxWidth, anchor.x, anchor.y])
+
+  return (
+    <article ref={elRef} className="physics-card">
+      {text}
+    </article>
+  )
+}

--- a/web/src/physics/PhysicsContext.tsx
+++ b/web/src/physics/PhysicsContext.tsx
@@ -1,0 +1,48 @@
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from 'react'
+import { PhysicsWorld } from './PhysicsWorld'
+
+const PhysicsContext = createContext<PhysicsWorld | null>(null)
+
+export function usePhysicsWorld(): PhysicsWorld {
+  const w = useContext(PhysicsContext)
+  if (!w) throw new Error('usePhysicsWorld: must be used inside <PhysicsProvider>')
+  return w
+}
+
+interface PhysicsProviderProps {
+  children: ReactNode
+}
+
+export function PhysicsProvider({ children }: PhysicsProviderProps) {
+  const [world] = useState(
+    () =>
+      new PhysicsWorld({
+        viewport:
+          typeof window !== 'undefined'
+            ? { width: window.innerWidth, height: window.innerHeight }
+            : { width: 1024, height: 768 },
+      }),
+  )
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    let raf = 0
+    let last = performance.now()
+    const frame = (now: number) => {
+      const dt = Math.min(now - last, 50)
+      last = now
+      world.tick(dt)
+      raf = requestAnimationFrame(frame)
+    }
+    raf = requestAnimationFrame(frame)
+    return () => cancelAnimationFrame(raf)
+  }, [world])
+
+  return <PhysicsContext.Provider value={world}>{children}</PhysicsContext.Provider>
+}

--- a/web/src/physics/PhysicsWorld.test.ts
+++ b/web/src/physics/PhysicsWorld.test.ts
@@ -1,0 +1,136 @@
+import { describe, test, expect } from 'vitest'
+import { PhysicsWorld } from './PhysicsWorld'
+
+const FIXED_DT_MS = 1000 / 60
+
+describe('PhysicsWorld registration', () => {
+  test('register returns a handle that can be unregistered', () => {
+    const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
+    const handle = world.register(
+      { x: 100, y: 100 },
+      { width: 200, height: 80 },
+    )
+    expect(handle).toBeDefined()
+    expect(world.has(handle)).toBe(true)
+    world.unregister(handle)
+    expect(world.has(handle)).toBe(false)
+  })
+})
+
+describe('PhysicsWorld dynamics', () => {
+  test('a freshly registered body sits exactly at its anchor', () => {
+    const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
+    const handle = world.register(
+      { x: 250, y: 175 },
+      { width: 100, height: 50 },
+    )
+    const pos = world.getPosition(handle)
+    expect(pos.x).toBeCloseTo(250, 5)
+    expect(pos.y).toBeCloseTo(175, 5)
+  })
+
+  test('applyImpulse moves the body in the impulse direction on the next tick', () => {
+    const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
+    const handle = world.register(
+      { x: 100, y: 100 },
+      { width: 100, height: 50 },
+    )
+    world.applyImpulse(handle, { x: 5, y: 0 })
+    world.tick(FIXED_DT_MS)
+    const pos = world.getPosition(handle)
+    expect(pos.x).toBeGreaterThan(100)
+    expect(Math.abs(pos.y - 100)).toBeLessThan(1)
+  })
+
+  test('after an impulse, the breathing-mode spring returns the body to its anchor', () => {
+    const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
+    const handle = world.register(
+      { x: 200, y: 200 },
+      { width: 100, height: 50 },
+    )
+    world.applyImpulse(handle, { x: 50, y: 0 })
+    for (let i = 0; i < 600; i++) world.tick(FIXED_DT_MS)
+    const pos = world.getPosition(handle)
+    expect(Math.abs(pos.x - 200)).toBeLessThan(1)
+    expect(Math.abs(pos.y - 200)).toBeLessThan(1)
+  })
+})
+
+describe('PhysicsWorld gravity', () => {
+  test('setGravity(true) lets a card fall; setGravity(false) springs it back', () => {
+    const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
+    const handle = world.register(
+      { x: 100, y: 100 },
+      { width: 100, height: 50 },
+    )
+
+    world.setGravity(true)
+    for (let i = 0; i < 30; i++) world.tick(FIXED_DT_MS)
+    const fellTo = world.getPosition(handle)
+    expect(fellTo.y).toBeGreaterThan(100)
+
+    world.setGravity(false)
+    for (let i = 0; i < 600; i++) world.tick(FIXED_DT_MS)
+    const restored = world.getPosition(handle)
+    expect(Math.abs(restored.x - 100)).toBeLessThan(1)
+    expect(Math.abs(restored.y - 100)).toBeLessThan(1)
+  })
+
+  test('with gravity on, the floor body catches a falling card (no escape)', () => {
+    const viewport = { width: 800, height: 400 }
+    const world = new PhysicsWorld({ viewport })
+    const handle = world.register({ x: 100, y: 50 }, { width: 100, height: 50 })
+
+    world.setGravity(true)
+    for (let i = 0; i < 600; i++) world.tick(FIXED_DT_MS)
+
+    const pos = world.getPosition(handle)
+    expect(pos.y).toBeLessThanOrEqual(viewport.height)
+  })
+})
+
+describe('PhysicsWorld drag handles', () => {
+  test('setPosition moves the body to the target coordinates immediately', () => {
+    const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
+    const handle = world.register(
+      { x: 100, y: 100 },
+      { width: 100, height: 50 },
+    )
+    world.applyImpulse(handle, { x: 20, y: 0 })
+    world.setPosition(handle, { x: 300, y: 250 })
+    const pos = world.getPosition(handle)
+    expect(pos.x).toBeCloseTo(300, 5)
+    expect(pos.y).toBeCloseTo(250, 5)
+  })
+})
+
+describe('PhysicsWorld transform callback', () => {
+  test('register with onTransform: callback fires each tick with current body state', () => {
+    const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
+    const states: Array<{ x: number; y: number }> = []
+    world.register(
+      { x: 100, y: 100 },
+      { width: 100, height: 50 },
+      { onTransform: (s) => states.push({ x: s.x, y: s.y }) },
+    )
+    world.tick(FIXED_DT_MS)
+    world.tick(FIXED_DT_MS)
+    expect(states.length).toBe(2)
+    expect(states[0]!.x).toBeCloseTo(100, 1)
+  })
+})
+
+describe('PhysicsWorld card modes', () => {
+  test('setMode("playground") relaxes the spring so the card stays where pushed', () => {
+    const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
+    const handle = world.register(
+      { x: 100, y: 100 },
+      { width: 100, height: 50 },
+    )
+    world.setMode(handle, 'playground')
+    world.applyImpulse(handle, { x: 30, y: 0 })
+    for (let i = 0; i < 600; i++) world.tick(FIXED_DT_MS)
+    const pos = world.getPosition(handle)
+    expect(pos.x).toBeGreaterThan(150)
+  })
+})

--- a/web/src/physics/PhysicsWorld.ts
+++ b/web/src/physics/PhysicsWorld.ts
@@ -1,0 +1,172 @@
+import Matter from 'matter-js'
+
+export interface Vec2 {
+  x: number
+  y: number
+}
+
+export interface CardSize {
+  width: number
+  height: number
+}
+
+export interface Viewport {
+  width: number
+  height: number
+}
+
+export interface PhysicsWorldOptions {
+  viewport: Viewport
+}
+
+export type PhysicsHandle = number
+export type CardMode = 'breathing' | 'playground'
+
+export interface BodyState {
+  x: number
+  y: number
+  rotation: number
+}
+
+export interface RegisterOptions {
+  onTransform?: (state: BodyState) => void
+}
+
+interface Registration {
+  body: Matter.Body
+  spring: Matter.Constraint
+  anchor: Vec2
+  mode: CardMode
+  onTransform?: (state: BodyState) => void
+}
+
+const MODE_STIFFNESS: Record<CardMode, number> = {
+  breathing: 0.1,
+  playground: 1e-9,
+}
+const MODE_DAMPING: Record<CardMode, number> = {
+  breathing: 0.3,
+  playground: 0,
+}
+const GRAVITY_RELAXED_STIFFNESS = 1e-9
+const GRAVITY_Y = 0.7
+const BODY_FRICTION_AIR = 0.05
+const FLOOR_THICKNESS = 60
+
+export class PhysicsWorld {
+  private engine: Matter.Engine
+  private world: Matter.World
+  private floor: Matter.Body
+  private nextId: PhysicsHandle = 1
+  private registrations = new Map<PhysicsHandle, Registration>()
+  private gravityOn = false
+
+  constructor(opts: PhysicsWorldOptions) {
+    this.engine = Matter.Engine.create()
+    this.world = this.engine.world
+    this.engine.gravity.x = 0
+    this.engine.gravity.y = 0
+
+    this.floor = Matter.Bodies.rectangle(
+      opts.viewport.width / 2,
+      opts.viewport.height + FLOOR_THICKNESS / 2,
+      opts.viewport.width,
+      FLOOR_THICKNESS,
+      { isStatic: true },
+    )
+    Matter.Composite.add(this.world, this.floor)
+  }
+
+  register(anchor: Vec2, size: CardSize, opts: RegisterOptions = {}): PhysicsHandle {
+    const body = Matter.Bodies.rectangle(anchor.x, anchor.y, size.width, size.height, {
+      frictionAir: BODY_FRICTION_AIR,
+    })
+    const mode: CardMode = 'breathing'
+    const spring = Matter.Constraint.create({
+      pointA: { x: anchor.x, y: anchor.y },
+      bodyB: body,
+      pointB: { x: 0, y: 0 },
+      stiffness: this.gravityOn ? GRAVITY_RELAXED_STIFFNESS : MODE_STIFFNESS[mode],
+      damping: MODE_DAMPING[mode],
+      length: 0,
+    })
+    Matter.Composite.add(this.world, [body, spring])
+    const id = this.nextId++
+    this.registrations.set(id, {
+      body,
+      spring,
+      anchor: { ...anchor },
+      mode,
+      onTransform: opts.onTransform,
+    })
+    return id
+  }
+
+  unregister(handle: PhysicsHandle): void {
+    const reg = this.registrations.get(handle)
+    if (!reg) return
+    Matter.Composite.remove(this.world, reg.body)
+    Matter.Composite.remove(this.world, reg.spring)
+    this.registrations.delete(handle)
+  }
+
+  has(handle: PhysicsHandle): boolean {
+    return this.registrations.has(handle)
+  }
+
+  getPosition(handle: PhysicsHandle): BodyState {
+    const reg = this.registrations.get(handle)
+    if (!reg) throw new Error(`PhysicsWorld: unknown handle ${handle}`)
+    return {
+      x: reg.body.position.x,
+      y: reg.body.position.y,
+      rotation: reg.body.angle,
+    }
+  }
+
+  applyImpulse(handle: PhysicsHandle, impulse: Vec2): void {
+    const reg = this.registrations.get(handle)
+    if (!reg) throw new Error(`PhysicsWorld: unknown handle ${handle}`)
+    Matter.Body.setVelocity(reg.body, {
+      x: reg.body.velocity.x + impulse.x / reg.body.mass,
+      y: reg.body.velocity.y + impulse.y / reg.body.mass,
+    })
+  }
+
+  setPosition(handle: PhysicsHandle, position: Vec2): void {
+    const reg = this.registrations.get(handle)
+    if (!reg) throw new Error(`PhysicsWorld: unknown handle ${handle}`)
+    Matter.Body.setPosition(reg.body, position)
+    Matter.Body.setVelocity(reg.body, { x: 0, y: 0 })
+  }
+
+  setGravity(on: boolean): void {
+    this.gravityOn = on
+    this.engine.gravity.y = on ? GRAVITY_Y : 0
+    for (const reg of this.registrations.values()) {
+      reg.spring.stiffness = on ? GRAVITY_RELAXED_STIFFNESS : MODE_STIFFNESS[reg.mode]
+    }
+  }
+
+  setMode(handle: PhysicsHandle, mode: CardMode): void {
+    const reg = this.registrations.get(handle)
+    if (!reg) throw new Error(`PhysicsWorld: unknown handle ${handle}`)
+    reg.mode = mode
+    reg.spring.damping = MODE_DAMPING[mode]
+    if (!this.gravityOn) {
+      reg.spring.stiffness = MODE_STIFFNESS[mode]
+    }
+  }
+
+  tick(dtMs: number): void {
+    Matter.Engine.update(this.engine, dtMs)
+    for (const reg of this.registrations.values()) {
+      if (!reg.onTransform) continue
+      reg.onTransform({
+        x: reg.body.position.x,
+        y: reg.body.position.y,
+        rotation: reg.body.angle,
+      })
+    }
+  }
+}

--- a/web/src/routes/Home.tsx
+++ b/web/src/routes/Home.tsx
@@ -1,41 +1,51 @@
+import { PhysicsCard } from '../physics/PhysicsCard'
+
 export default function Home() {
   return (
-    <main>
-      <h1>chaipalaka.com</h1>
-      <p>
-        Personal site of Chai Palaka — a physics-driven, generative-art-backed
-        home on the internet that doubles as a portfolio of frontend craft.
-      </p>
-      <p>
-        This page is still a placeholder. It exercises the typographic baseline
-        shipped in slice&nbsp;3 — Newsreader for body text, JetBrains Mono for
-        code, design tokens defined as CSS custom properties so the site can
-        be re-skinned by editing one stylesheet. The canvas, the physics, and
-        the actual content land in later slices.
-      </p>
-
-      <hr />
-
-      <h2>What's coming</h2>
-      <p>
-        The eventual site has two layout shells: a canvas-mode shell with a
-        persistent R3F background and matter.js-driven foreground cards, and a
-        plain-mode shell for long-form reading. Routes include <code>/blog</code>,{' '}
-        <code>/portfolio</code>, <code>/lifelog</code>, and a 404 in playground
-        mode with gravity on. See <code>PRD.md</code> in the repo for the full
-        design.
-      </p>
-      <p>
-        Source: <a href="https://github.com/cpalaka/chaipalaka.com">github.com/cpalaka/chaipalaka.com</a>.
-      </p>
-
-      <blockquote>
+    <>
+      <main>
+        <h1>chaipalaka.com</h1>
         <p>
-          The site must succeed on three axes simultaneously: aesthetic identity,
-          content utility, and graceful degradation — and each axis tends to pull
-          against the others.
+          Personal site of Chai Palaka — a physics-driven, generative-art-backed
+          home on the internet that doubles as a portfolio of frontend craft.
         </p>
-      </blockquote>
-    </main>
+        <p>
+          This page is still a placeholder. It exercises the typographic baseline
+          shipped in slice&nbsp;3 — Newsreader for body text, JetBrains Mono for
+          code, design tokens defined as CSS custom properties so the site can
+          be re-skinned by editing one stylesheet. The canvas, the physics, and
+          the actual content land in later slices.
+        </p>
+
+        <hr />
+
+        <h2>What's coming</h2>
+        <p>
+          The eventual site has two layout shells: a canvas-mode shell with a
+          persistent R3F background and matter.js-driven foreground cards, and a
+          plain-mode shell for long-form reading. Routes include <code>/blog</code>,{' '}
+          <code>/portfolio</code>, <code>/lifelog</code>, and a 404 in playground
+          mode with gravity on. See <code>PRD.md</code> in the repo for the full
+          design.
+        </p>
+        <p>
+          Source: <a href="https://github.com/cpalaka/chaipalaka.com">github.com/cpalaka/chaipalaka.com</a>.
+        </p>
+
+        <blockquote>
+          <p>
+            The site must succeed on three axes simultaneously: aesthetic identity,
+            content utility, and graceful degradation — and each axis tends to pull
+            against the others.
+          </p>
+        </blockquote>
+      </main>
+      <PhysicsCard
+        text="drag me — i spring back. slice 5 lands the physics primitive."
+        fontKey="body"
+        maxWidth={280}
+        anchor={{ x: typeof window !== 'undefined' ? window.innerWidth - 220 : 800, y: 220 }}
+      />
+    </>
   )
 }

--- a/web/src/text/PretextRegistry.test.ts
+++ b/web/src/text/PretextRegistry.test.ts
@@ -1,0 +1,31 @@
+import { describe, test, expect } from 'vitest'
+import { PretextRegistry } from './PretextRegistry'
+
+describe('PretextRegistry', () => {
+  test('registered fonts are queryable as a canvas font string', () => {
+    const r = new PretextRegistry()
+    r.register('body', {
+      family: 'Newsreader',
+      size: 16,
+      weight: 400,
+      lineHeight: 1.4,
+    })
+    expect(r.getFont('body')).toBe('400 16px Newsreader')
+  })
+
+  test('getFont throws on an unregistered key', () => {
+    const r = new PretextRegistry()
+    expect(() => r.getFont('mono')).toThrow(/unknown/i)
+  })
+
+  test('getLineHeight returns line-height in pixels for a registered key', () => {
+    const r = new PretextRegistry()
+    r.register('body', {
+      family: 'Newsreader',
+      size: 16,
+      weight: 400,
+      lineHeight: 1.4,
+    })
+    expect(r.getLineHeight('body')).toBeCloseTo(22.4)
+  })
+})

--- a/web/src/text/PretextRegistry.ts
+++ b/web/src/text/PretextRegistry.ts
@@ -1,0 +1,57 @@
+import * as pretext from '@chenglou/pretext'
+
+export interface FontMetrics {
+  family: string
+  size: number
+  weight: number
+  lineHeight: number
+}
+
+export interface MeasuredText {
+  width: number
+  height: number
+  lines: number
+}
+
+interface RegisteredFont {
+  metrics: FontMetrics
+  fontString: string
+  lineHeightPx: number
+}
+
+function toCanvasFontString(m: FontMetrics): string {
+  return `${m.weight} ${m.size}px ${m.family}`
+}
+
+export class PretextRegistry {
+  private fonts = new Map<string, RegisteredFont>()
+
+  register(key: string, metrics: FontMetrics): void {
+    this.fonts.set(key, {
+      metrics,
+      fontString: toCanvasFontString(metrics),
+      lineHeightPx: metrics.size * metrics.lineHeight,
+    })
+  }
+
+  getFont(key: string): string {
+    const f = this.fonts.get(key)
+    if (!f) throw new Error(`PretextRegistry: unknown font key '${key}'`)
+    return f.fontString
+  }
+
+  getLineHeight(key: string): number {
+    const f = this.fonts.get(key)
+    if (!f) throw new Error(`PretextRegistry: unknown font key '${key}'`)
+    return f.lineHeightPx
+  }
+
+  measure(text: string, key: string, maxWidth: number): MeasuredText {
+    const f = this.fonts.get(key)
+    if (!f) throw new Error(`PretextRegistry: unknown font key '${key}'`)
+    const prepared = pretext.prepareWithSegments(text, f.fontString)
+    const { height, lineCount } = pretext.layout(prepared, maxWidth, f.lineHeightPx)
+    const { maxLineWidth } = pretext.measureLineStats(prepared, maxWidth)
+    return { width: maxLineWidth, height, lines: lineCount }
+  }
+}

--- a/web/src/text/registry.ts
+++ b/web/src/text/registry.ts
@@ -1,0 +1,16 @@
+import { PretextRegistry } from './PretextRegistry'
+
+export const registry = new PretextRegistry()
+
+registry.register('body', {
+  family: 'Newsreader Variable',
+  size: 16,
+  weight: 400,
+  lineHeight: 1.6,
+})
+registry.register('mono', {
+  family: 'JetBrains Mono Variable',
+  size: 14,
+  weight: 400,
+  lineHeight: 1.6,
+})


### PR DESCRIPTION
## Summary

- **`PhysicsWorld`** (`web/src/physics/PhysicsWorld.ts`) — deep module hiding matter.js entirely. Public interface per PRD: `register / unregister / setGravity / applyImpulse / setMode`, plus `tick / getPosition / setPosition` for fixed-timestep tests and pointer-drag mechanics. Floor body, gravity vector, registration table, and per-tick `onTransform` callback dispatch all live here.
- **`PretextRegistry`** (`web/src/text/PretextRegistry.ts`) — wraps `@chenglou/pretext`. Maps font keys (`body`, `mono`) to canvas font strings and per-key line-height in pixels; `measure(text, key, maxWidth)` returns `{width, height, lines}` via `prepareWithSegments` + `layout` + `measureLineStats`.
- **`PhysicsCard`** (`web/src/physics/PhysicsCard.tsx`) — React component. Pre-sizes via `PretextRegistry`, registers with the world, writes per-frame transforms imperatively via ref (state would re-render at 60fps; vercel-react-best-practices `rerender-use-ref-transient-values`). Mouse-pointer drag + breathing-mode spring snap-back.
- **CanvasLayout** now mounts `<PhysicsProvider>`; `/` is wrapped by CanvasLayout (it previously wasn't), so Home — and any future canvas-mode route — gets the world for free.
- One PhysicsCard sits in the top-right of the homepage as the slice-5 demo (matches the user's "standalone demo card" preference).

## Notes / deviations

- **PRD vs reality on \`setMode(\"playground\")\` stiffness.** The PRD says \"spring stiffness near zero\". I started at \`0.0001\`; matter.js's constraint solver still pulled the body all the way back to the anchor over 600 ticks. \`1e-9\` gives the intended drift behaviour without removing the constraint object (so re-attaching to anchor on mode-flip back to breathing is just a stiffness change). True \`stiffness=0\` made the body refuse to move at all — apparently matter.js's position correction does something unexpected with zero-stiffness, zero-length point constraints. Documented in the commit body for future archeology.
- **Pretext \"verified once via snapshot test, then trusted\"** (PRD Testing Decisions). Per a clarifying call before I started: automated tests cover the wrapper logic only (registration round-trip, error on unknown key, line-height arithmetic). Pretext requires \`OffscreenCanvas\` / a real canvas context — it errors in the node test env. Re-verifying its own measurement fidelity in our suite has low ROI; the manual once-over happens in browser. If we later want CI-level dim coverage, the option is to add the \`canvas\` native dep + a node-side snapshot.
- **No release momentum on drag.** Drag works (pointerdown → setPosition stream → pointerup → spring takeover). Throwable cards with release momentum belong to playground mode and slice 18+; breathing-mode \"springs back with overshoot\" is handled by the spring damping alone, which is what AC #6 asks for.
- **Manual dev smoke test deferred to reviewer.** The static prerender in \`dist/index.html\` already includes the rendered \`<article class=\"physics-card\">\` markup, so the SSG / hydration code path is verified end-to-end. The vite dev server requires \`listen()\` permission, which the current sandbox blocks — the *next* session will have it after the sandbox config edits land. Drag interaction needs human eyes either way.
- **\`api/.env.example\` and friends** are pre-existing untracked files in the working tree, not part of this slice. Left untracked deliberately.

## Acceptance criteria

- [x] \`PhysicsWorld\` module exists with the public interface above; matter.js is not imported anywhere outside this module *(verified by \`grep -rn \"matter-js\" src/\` → only \`src/physics/PhysicsWorld.ts:1\`)*
- [x] \`PhysicsWorld\` tests: registration round-trip; spring-anchored body converges to anchor under fixed timestep; gravity-on/off mode switches stiffness atomically; impulse application moves the body in the expected direction; floor body catches falling cards
- [x] \`PretextRegistry\` exists; tests verify registered fonts produce dimensions consistent with DOM measurement *(snapshot test deferred per the note above; wrapper-logic tests cover registration semantics)*
- [x] \`PhysicsCard\` component exists in breathing mode with drag and spring-back
- [ ] Homepage shows one draggable card; pushing it returns it to its anchor with overshoot *(SSG'd markup confirmed; **drag interaction needs human verification** in browser since sandbox blocks the dev server in-session)*
- [x] No \`getBoundingClientRect()\` calls on cards; sizing flows through \`PretextRegistry\` *(verified by \`grep -rn \"getBoundingClientRect\" src/\` → no matches)*

## Test plan

\`\`\`sh
cd web
npm run test       # 17 tests across 4 files
npm run typecheck  # clean
npm run build      # vite-react-ssg prerender; dist/index.html should have data-server-rendered=\"true\" and <article class=\"physics-card\">
npm run dev        # then open http://localhost:5173 and verify:
                   #   - one card visible top-right
                   #   - mousedown + drag moves it
                   #   - release → spring snaps back to anchor with overshoot
                   #   - pushing far away → returns with damping
\`\`\`

Bundle-split verification (also runs as part of \`npm run test\`):
- \`dist/test/plain/index.html\` must NOT contain \`__CHAIPALAKA_CANVAS_ONLY_BUNDLE_MARKER_4f7c2b9a__\` *(0 matches confirmed)*
- No \`Matter.\` references in any plain-mode JS chunk *(grep clean)*
- matter.js (87 kB chunk) and pretext (~46 kB in Home chunk) load only via the canvas-mode lazy chain

Closes #5