### PR TITLE
Slice 4: Bun backend + Caddy proxy + /api/health + CacheLayer (#4)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,19 +13,23 @@ WEB_DIR    := web
 API_DIR    := api
 ASSETS_DIR := assets
 
-.PHONY: help deploy deploy-web deploy-api assets-sync web-install web-build web-dev web-test clean
+.PHONY: help deploy deploy-web deploy-api assets-sync web-install web-build web-dev web-test api-install api-test api-typecheck api-dev clean
 
 help:
 	@echo "Targets:"
 	@echo "  deploy        — deploy-web + deploy-api"
 	@echo "  deploy-web    — build web/ and rsync dist/ to $(SSH_HOST):$(WEB_REMOTE_DIR)"
-	@echo "  deploy-api    — (stub) build and restart the Bun API service"
+	@echo "  deploy-api    — build api/ (bake BUILD_SHA), rsync, restart $(API_SERVICE)"
 	@echo "  assets-sync   — rsync local assets/ to $(SSH_HOST):$(ASSETS_REMOTE_DIR)"
 	@echo "  web-install   — npm install inside web/"
 	@echo "  web-build     — build web/ locally (dist/ output)"
 	@echo "  web-dev       — run vite dev server"
-	@echo "  web-test      — run vitest"
-	@echo "  clean         — remove web/dist and web/node_modules"
+	@echo "  web-test      — run vitest in web/"
+	@echo "  api-install   — bun install inside api/"
+	@echo "  api-test      — run vitest in api/"
+	@echo "  api-typecheck — tsc --noEmit in api/"
+	@echo "  api-dev       — run the Bun API in watch mode locally"
+	@echo "  clean         — remove web/dist, web/node_modules, api/dist, api/node_modules"
 
 deploy: deploy-web deploy-api
 
@@ -37,16 +41,15 @@ deploy-web:
 		$(SSH_HOST):$(WEB_REMOTE_DIR)/
 	@echo "deploy-web complete → https://www.chaipalaka.com"
 
-# Slice 1 stub — fleshed out when api/ ships (slice for backend).
 deploy-api:
-	@if [ -f $(API_DIR)/package.json ]; then \
-		echo "Building api/..."; \
-		cd $(API_DIR) && bun install && bun run build; \
-		rsync -avz --delete $(API_DIR)/dist/ $(SSH_HOST):/opt/chaipalaka-api/; \
-		ssh $(SSH_HOST) "sudo systemctl restart $(API_SERVICE)"; \
-	else \
-		echo "deploy-api: api/ has no package.json yet — skipping (stub)"; \
-	fi
+	@BUILD_SHA=$$(git rev-parse --short HEAD); \
+	echo "Building api/ (BUILD_SHA=$$BUILD_SHA)..."; \
+	cd $(API_DIR) && bun install --frozen-lockfile && \
+	bun build --compile --target=bun-linux-x64 --outfile dist/server src/server.ts \
+		--define "process.env.BUILD_SHA=\"$$BUILD_SHA\""
+	rsync -avz --delete $(API_DIR)/dist/ $(SSH_HOST):/opt/chaipalaka-api/
+	ssh $(SSH_HOST) "sudo systemctl restart $(API_SERVICE)"
+	@echo "deploy-api complete"
 
 assets-sync:
 	@if [ ! -d $(ASSETS_DIR) ]; then \
@@ -69,5 +72,17 @@ web-dev:
 web-test:
 	cd $(WEB_DIR) && npm run test
 
+api-install:
+	cd $(API_DIR) && bun install
+
+api-test:
+	cd $(API_DIR) && bun run test
+
+api-typecheck:
+	cd $(API_DIR) && bun run typecheck
+
+api-dev:
+	cd $(API_DIR) && bun run dev
+
 clean:
-	rm -rf $(WEB_DIR)/dist $(WEB_DIR)/node_modules
+	rm -rf $(WEB_DIR)/dist $(WEB_DIR)/node_modules $(API_DIR)/dist $(API_DIR)/node_modules

--- a/api/.env.example
+++ b/api/.env.example
@@ -1,0 +1,12 @@
+# Local development env for the Bun API service.
+# Copy to api/.env and fill in (api/.env is gitignored).
+# Production secrets live in /etc/chaipalaka.env on the server (see deploy/SECRETS.md).
+
+# Build-time injected by `make deploy-api`; falls back to "dev" locally.
+BUILD_SHA=dev
+
+# Upstream sources (not used yet — adapter slices land later).
+# LASTFM_API_KEY=
+# LASTFM_USER=chaipalaka
+# LETTERBOXD_USER=chaipalaka
+# GITHUB_TOKEN=

--- a/api/README.md
+++ b/api/README.md
@@ -1,9 +1,51 @@
 # api/
 
-Stub directory for the Bun backend that will mediate live data sources
-(last.fm, Letterboxd, GitHub) for the lifelog and audio-reactive background.
+Bun backend for chaipalaka.com. Runs on `localhost:3000` behind Caddy
+(`/api/*` is reverse-proxied to it). On the server, runs as the
+`chaipalaka-api` systemd unit — see `deploy/chaipalaka-api.service`.
 
-Empty in slice 1. Implementation lands in a later slice — see issue tracker
-for the `bun-api` slice.
+## Endpoints (v1)
 
-Secrets pattern (already documented): see `deploy/SECRETS.md`.
+- `GET /api/health` — `{ ok: true, version: "<git-sha>" }`. The version is
+  baked into the binary at compile time by `make deploy-api`.
+
+Adapter endpoints (`/api/now-playing`, `/api/films`, `/api/books`,
+`/api/github`, `/api/notes`) land in later slices on top of `CacheLayer`.
+
+## Modules
+
+- `src/server.ts` — Bun HTTP server + route handler.
+- `src/cache/CacheLayer.ts` — generic stale-while-revalidate cache. Every
+  upcoming endpoint wraps its upstream fetch in `cache.get(key, fetcher,
+  { ttl })`. Returns `{ value, stale }`; `stale: true` means the upstream
+  failed and we're serving last-good. Concurrent `get`s for the same key
+  coalesce into one fetch.
+
+## Running locally
+
+```sh
+bun install
+bun run dev          # watch mode on :3000, BUILD_SHA defaults to "dev"
+bun run test         # vitest
+bun run typecheck    # tsc --noEmit
+```
+
+Or via the repo-root Makefile: `make api-install`, `make api-test`,
+`make api-typecheck`, `make api-dev`.
+
+For local secrets, copy `.env.example` to `.env` (gitignored). Adapter
+slices will start consuming these.
+
+## Deploy
+
+`make deploy-api` from the repo root:
+
+1. `git rev-parse --short HEAD` → `BUILD_SHA`
+2. `bun build --compile --target=bun-linux-x64 ...
+   --define process.env.BUILD_SHA="<sha>"`
+3. `rsync api/dist/ → /opt/chaipalaka-api/`
+4. `ssh ... systemctl restart chaipalaka-api`
+
+Production secrets live in `/etc/chaipalaka.env` on the server (root:root,
+mode 600) and are loaded into the unit via `EnvironmentFile=`. See
+`deploy/SECRETS.md`.

--- a/api/bun.lock
+++ b/api/bun.lock
@@ -1,0 +1,227 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "chaipalaka-api",
+      "devDependencies": {
+        "@types/bun": "^1.3.0",
+        "typescript": "^5.9.3",
+        "vitest": "^3.2.4",
+      },
+    },
+  },
+  "packages": {
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.27.7", "", { "os": "android", "cpu": "arm" }, "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.7", "", { "os": "android", "cpu": "arm64" }, "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.27.7", "", { "os": "android", "cpu": "x64" }, "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.7", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.7", "", { "os": "freebsd", "cpu": "x64" }, "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.7", "", { "os": "linux", "cpu": "arm" }, "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.7", "", { "os": "linux", "cpu": "ia32" }, "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.7", "", { "os": "linux", "cpu": "ppc64" }, "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.7", "", { "os": "linux", "cpu": "s390x" }, "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.7", "", { "os": "linux", "cpu": "x64" }, "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.7", "", { "os": "none", "cpu": "x64" }, "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.7", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.7", "", { "os": "openbsd", "cpu": "x64" }, "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.7", "", { "os": "sunos", "cpu": "x64" }, "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.7", "", { "os": "win32", "cpu": "arm64" }, "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.7", "", { "os": "win32", "cpu": "ia32" }, "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.7", "", { "os": "win32", "cpu": "x64" }, "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.60.3", "", { "os": "android", "cpu": "arm" }, "sha512-x35CNW/ANXG3hE/EZpRU8MXX1JDN86hBb2wMGAtltkz7pc6cxgjpy1OMMfDosOQ+2hWqIkag/fGok1Yady9nGw=="],
+
+    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.60.3", "", { "os": "android", "cpu": "arm64" }, "sha512-xw3xtkDApIOGayehp2+Rz4zimfkaX65r4t47iy+ymQB2G4iJCBBfj0ogVg5jpvjpn8UWn/+q9tprxleYeNp3Hw=="],
+
+    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.60.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-vo6Y5Qfpx7/5EaamIwi0WqW2+zfiusVihKatLvtN1VFVy3D13uERk/6gZLU1UiHRL6fDXqj/ELIeVRGnvcTE1g=="],
+
+    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.60.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-D+0QGcZhBzTN82weOnsSlY7V7+RMmPuF1CkbxyMAGE8+ZHeUjyb76ZiWmBlCu//AQQONvxcqRbwZTajZKqjuOw=="],
+
+    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.60.3", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-6HnvHCT7fDyj6R0Ph7A6x8dQS/S38MClRWeDLqc0MdfWkxjiu1HSDYrdPhqSILzjTIC/pnXbbJbo+ft+gy/9hQ=="],
+
+    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.60.3", "", { "os": "freebsd", "cpu": "x64" }, "sha512-KHLgC3WKlUYW3ShFKnnosZDOJ0xjg9zp7au3sIm2bs/tGBeC2ipmvRh/N7JKi0t9Ue20C0dpEshi8WUubg+cnA=="],
+
+    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.60.3", "", { "os": "linux", "cpu": "arm" }, "sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g=="],
+
+    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.60.3", "", { "os": "linux", "cpu": "arm" }, "sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w=="],
+
+    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.60.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA=="],
+
+    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.60.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg=="],
+
+    "@rollup/rollup-linux-loong64-gnu": ["@rollup/rollup-linux-loong64-gnu@4.60.3", "", { "os": "linux", "cpu": "none" }, "sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA=="],
+
+    "@rollup/rollup-linux-loong64-musl": ["@rollup/rollup-linux-loong64-musl@4.60.3", "", { "os": "linux", "cpu": "none" }, "sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg=="],
+
+    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.60.3", "", { "os": "linux", "cpu": "ppc64" }, "sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ=="],
+
+    "@rollup/rollup-linux-ppc64-musl": ["@rollup/rollup-linux-ppc64-musl@4.60.3", "", { "os": "linux", "cpu": "ppc64" }, "sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA=="],
+
+    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.60.3", "", { "os": "linux", "cpu": "none" }, "sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw=="],
+
+    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.60.3", "", { "os": "linux", "cpu": "none" }, "sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ=="],
+
+    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.60.3", "", { "os": "linux", "cpu": "s390x" }, "sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig=="],
+
+    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.60.3", "", { "os": "linux", "cpu": "x64" }, "sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA=="],
+
+    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.60.3", "", { "os": "linux", "cpu": "x64" }, "sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA=="],
+
+    "@rollup/rollup-openbsd-x64": ["@rollup/rollup-openbsd-x64@4.60.3", "", { "os": "openbsd", "cpu": "x64" }, "sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q=="],
+
+    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.60.3", "", { "os": "none", "cpu": "arm64" }, "sha512-AaXwSvUi3QIPtroAUw1t5yHGIyqKEXwH54WUocFolZhpGDruJcs8c+xPNDRn4XiQsS7MEwnYsHW2l0MBLDMkWg=="],
+
+    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.60.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-65LAKM/bAWDqKNEelHlcHvm2V+Vfb8C6INFxQXRHCvaVN1rJfwr4NvdP4FyzUaLqWfaCGaadf6UbTm8xJeYfEg=="],
+
+    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.60.3", "", { "os": "win32", "cpu": "ia32" }, "sha512-EEM2gyhBF5MFnI6vMKdX1LAosE627RGBzIoGMdLloPZkXrUN0Ckqgr2Qi8+J3zip/8NVVro3/FjB+tjhZUgUHA=="],
+
+    "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.60.3", "", { "os": "win32", "cpu": "x64" }, "sha512-E5Eb5H/DpxaoXH++Qkv28RcUJboMopmdDUALBczvHMf7hNIxaDZqwY5lK12UK1BHacSmvupoEWGu+n993Z0y1A=="],
+
+    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.60.3", "", { "os": "win32", "cpu": "x64" }, "sha512-hPt/bgL5cE+Qp+/TPHBqptcAgPzgj46mPcg/16zNUmbQk0j+mOEQV/+Lqu8QRtDV3Ek95Q6FeFITpuhl6OTsAA=="],
+
+    "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
+
+    "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
+
+    "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
+
+    "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
+
+    "@types/node": ["@types/node@25.6.2", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw=="],
+
+    "@vitest/expect": ["@vitest/expect@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig=="],
+
+    "@vitest/mocker": ["@vitest/mocker@3.2.4", "", { "dependencies": { "@vitest/spy": "3.2.4", "estree-walker": "^3.0.3", "magic-string": "^0.30.17" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "optionalPeers": ["msw", "vite"] }, "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@3.2.4", "", { "dependencies": { "tinyrainbow": "^2.0.0" } }, "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA=="],
+
+    "@vitest/runner": ["@vitest/runner@3.2.4", "", { "dependencies": { "@vitest/utils": "3.2.4", "pathe": "^2.0.3", "strip-literal": "^3.0.0" } }, "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "magic-string": "^0.30.17", "pathe": "^2.0.3" } }, "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ=="],
+
+    "@vitest/spy": ["@vitest/spy@3.2.4", "", { "dependencies": { "tinyspy": "^4.0.3" } }, "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw=="],
+
+    "@vitest/utils": ["@vitest/utils@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA=="],
+
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
+    "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+
+    "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
+
+    "chai": ["chai@5.3.3", "", { "dependencies": { "assertion-error": "^2.0.1", "check-error": "^2.1.1", "deep-eql": "^5.0.1", "loupe": "^3.1.0", "pathval": "^2.0.0" } }, "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw=="],
+
+    "check-error": ["check-error@2.1.3", "", {}, "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "deep-eql": ["deep-eql@5.0.2", "", {}, "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q=="],
+
+    "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
+
+    "esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
+
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
+    "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "js-tokens": ["js-tokens@9.0.1", "", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
+
+    "loupe": ["loupe@3.2.1", "", {}, "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
+
+    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "pathval": ["pathval@2.0.1", "", {}, "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
+    "postcss": ["postcss@8.5.14", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg=="],
+
+    "rollup": ["rollup@4.60.3", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.3", "@rollup/rollup-android-arm64": "4.60.3", "@rollup/rollup-darwin-arm64": "4.60.3", "@rollup/rollup-darwin-x64": "4.60.3", "@rollup/rollup-freebsd-arm64": "4.60.3", "@rollup/rollup-freebsd-x64": "4.60.3", "@rollup/rollup-linux-arm-gnueabihf": "4.60.3", "@rollup/rollup-linux-arm-musleabihf": "4.60.3", "@rollup/rollup-linux-arm64-gnu": "4.60.3", "@rollup/rollup-linux-arm64-musl": "4.60.3", "@rollup/rollup-linux-loong64-gnu": "4.60.3", "@rollup/rollup-linux-loong64-musl": "4.60.3", "@rollup/rollup-linux-ppc64-gnu": "4.60.3", "@rollup/rollup-linux-ppc64-musl": "4.60.3", "@rollup/rollup-linux-riscv64-gnu": "4.60.3", "@rollup/rollup-linux-riscv64-musl": "4.60.3", "@rollup/rollup-linux-s390x-gnu": "4.60.3", "@rollup/rollup-linux-x64-gnu": "4.60.3", "@rollup/rollup-linux-x64-musl": "4.60.3", "@rollup/rollup-openbsd-x64": "4.60.3", "@rollup/rollup-openharmony-arm64": "4.60.3", "@rollup/rollup-win32-arm64-msvc": "4.60.3", "@rollup/rollup-win32-ia32-msvc": "4.60.3", "@rollup/rollup-win32-x64-gnu": "4.60.3", "@rollup/rollup-win32-x64-msvc": "4.60.3", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A=="],
+
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
+
+    "strip-literal": ["strip-literal@3.1.0", "", { "dependencies": { "js-tokens": "^9.0.1" } }, "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg=="],
+
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
+    "tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
+
+    "tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
+
+    "tinypool": ["tinypool@1.1.1", "", {}, "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg=="],
+
+    "tinyrainbow": ["tinyrainbow@2.0.0", "", {}, "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw=="],
+
+    "tinyspy": ["tinyspy@4.0.4", "", {}, "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+
+    "vite": ["vite@7.3.3", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA=="],
+
+    "vite-node": ["vite-node@3.2.4", "", { "dependencies": { "cac": "^6.7.14", "debug": "^4.4.1", "es-module-lexer": "^1.7.0", "pathe": "^2.0.3", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0" }, "bin": { "vite-node": "vite-node.mjs" } }, "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg=="],
+
+    "vitest": ["vitest@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/expect": "3.2.4", "@vitest/mocker": "3.2.4", "@vitest/pretty-format": "^3.2.4", "@vitest/runner": "3.2.4", "@vitest/snapshot": "3.2.4", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "debug": "^4.4.1", "expect-type": "^1.2.1", "magic-string": "^0.30.17", "pathe": "^2.0.3", "picomatch": "^4.0.2", "std-env": "^3.9.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.14", "tinypool": "^1.1.1", "tinyrainbow": "^2.0.0", "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0", "vite-node": "3.2.4", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/debug": "^4.1.12", "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "@vitest/browser": "3.2.4", "@vitest/ui": "3.2.4", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@types/debug", "@types/node", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A=="],
+
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
+
+    "rollup/@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+  }
+}

--- a/api/package.json
+++ b/api/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "chaipalaka-api",
+  "private": true,
+  "version": "0.0.1",
+  "type": "module",
+  "description": "chaipalaka.com — Bun backend for /api/* endpoints (lifelog data sources, cached).",
+  "scripts": {
+    "dev": "bun run --watch src/server.ts",
+    "start": "bun run src/server.ts",
+    "build": "bun build --compile --target=bun-linux-x64 --outfile dist/server src/server.ts",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@types/bun": "^1.3.0",
+    "typescript": "^5.9.3",
+    "vitest": "^3.2.4"
+  }
+}

--- a/api/src/cache/CacheLayer.test.ts
+++ b/api/src/cache/CacheLayer.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { CacheLayer } from './CacheLayer';
+
+describe('CacheLayer', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('calls the fetcher on a cold key and returns its value (not stale)', async () => {
+    const cache = new CacheLayer();
+    const fetcher = vi.fn(async () => 'hello');
+
+    const result = await cache.get('k', fetcher, { ttl: 1000 });
+
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ value: 'hello', stale: false });
+  });
+
+  it('returns cached value on a within-TTL hit without calling the fetcher again', async () => {
+    const cache = new CacheLayer();
+    const fetcher = vi.fn(async () => 'hello');
+
+    await cache.get('k', fetcher, { ttl: 1000 });
+    vi.advanceTimersByTime(500);
+    const second = await cache.get('k', fetcher, { ttl: 1000 });
+
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    expect(second).toEqual({ value: 'hello', stale: false });
+  });
+
+  it('refetches and returns the new value when TTL has expired', async () => {
+    const cache = new CacheLayer();
+    let n = 0;
+    const fetcher = vi.fn(async () => {
+      n += 1;
+      return `v${n}`;
+    });
+
+    const first = await cache.get('k', fetcher, { ttl: 1000 });
+    vi.advanceTimersByTime(1001);
+    const second = await cache.get('k', fetcher, { ttl: 1000 });
+
+    expect(first).toEqual({ value: 'v1', stale: false });
+    expect(second).toEqual({ value: 'v2', stale: false });
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns last-good with stale:true when a post-TTL refetch fails', async () => {
+    const cache = new CacheLayer();
+    let attempt = 0;
+    const fetcher = vi.fn(async () => {
+      attempt += 1;
+      if (attempt === 1) return 'good';
+      throw new Error('upstream down');
+    });
+
+    const first = await cache.get('k', fetcher, { ttl: 1000 });
+    vi.advanceTimersByTime(1001);
+    const second = await cache.get('k', fetcher, { ttl: 1000 });
+
+    expect(first).toEqual({ value: 'good', stale: false });
+    expect(second).toEqual({ value: 'good', stale: true });
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws when the very first fetch fails (no last-good to fall back to)', async () => {
+    const cache = new CacheLayer();
+    const fetcher = vi.fn(async () => {
+      throw new Error('upstream down');
+    });
+
+    await expect(cache.get('k', fetcher, { ttl: 1000 })).rejects.toThrow(
+      'upstream down',
+    );
+  });
+
+  it('set(key, value) replaces the cached fresh value (within-TTL get returns the set value, no fetch)', async () => {
+    const cache = new CacheLayer();
+    const fetcher = vi.fn(async () => 'good');
+
+    await cache.get('k', fetcher, { ttl: 1000 });
+    cache.set('k', 'forced');
+    const after = await cache.get('k', fetcher, { ttl: 1000 });
+
+    expect(after).toEqual({ value: 'forced', stale: false });
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it('set(key, value) overrides last-good cleanly — stale fallback returns the set value, not the previous fetched value', async () => {
+    const cache = new CacheLayer();
+    let attempt = 0;
+    const fetcher = vi.fn(async () => {
+      attempt += 1;
+      if (attempt === 1) return 'good';
+      throw new Error('upstream down');
+    });
+
+    await cache.get('k', fetcher, { ttl: 1000 });
+    cache.set('k', 'replacement');
+    vi.advanceTimersByTime(1001);
+    const after = await cache.get('k', fetcher, { ttl: 1000 });
+
+    expect(after).toEqual({ value: 'replacement', stale: true });
+  });
+
+  it('coalesces concurrent gets for the same key into a single fetch', async () => {
+    const cache = new CacheLayer();
+    let resolveFetch!: (v: string) => void;
+    const fetcher = vi.fn(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveFetch = resolve;
+        }),
+    );
+
+    const a = cache.get('k', fetcher, { ttl: 1000 });
+    const b = cache.get('k', fetcher, { ttl: 1000 });
+    const c = cache.get('k', fetcher, { ttl: 1000 });
+
+    expect(fetcher).toHaveBeenCalledTimes(1);
+
+    resolveFetch('shared');
+    const [ra, rb, rc] = await Promise.all([a, b, c]);
+
+    expect(ra).toEqual({ value: 'shared', stale: false });
+    expect(rb).toEqual({ value: 'shared', stale: false });
+    expect(rc).toEqual({ value: 'shared', stale: false });
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+});

--- a/api/src/cache/CacheLayer.ts
+++ b/api/src/cache/CacheLayer.ts
@@ -1,0 +1,46 @@
+export type CacheGetOpts = { ttl: number };
+export type CacheResult<T> = { value: T; stale: boolean };
+
+type Entry = { value: unknown; expiresAt: number };
+
+export class CacheLayer {
+  private readonly entries = new Map<string, Entry>();
+  private readonly inFlight = new Map<string, Promise<CacheResult<unknown>>>();
+
+  async get<T>(
+    key: string,
+    fetcher: () => Promise<T>,
+    opts: CacheGetOpts,
+  ): Promise<CacheResult<T>> {
+    const existing = this.entries.get(key);
+    if (existing && Date.now() < existing.expiresAt) {
+      return { value: existing.value as T, stale: false };
+    }
+    const inFlight = this.inFlight.get(key);
+    if (inFlight) {
+      return inFlight as Promise<CacheResult<T>>;
+    }
+    const p = (async () => {
+      try {
+        const value = await fetcher();
+        this.entries.set(key, { value, expiresAt: Date.now() + opts.ttl });
+        return { value, stale: false } as CacheResult<unknown>;
+      } catch (err) {
+        if (existing) {
+          return { value: existing.value, stale: true } as CacheResult<unknown>;
+        }
+        throw err;
+      } finally {
+        this.inFlight.delete(key);
+      }
+    })();
+    this.inFlight.set(key, p);
+    return p as Promise<CacheResult<T>>;
+  }
+
+  set<T>(key: string, value: T): void {
+    const existing = this.entries.get(key);
+    const expiresAt = existing?.expiresAt ?? Date.now();
+    this.entries.set(key, { value, expiresAt });
+  }
+}

--- a/api/src/server.test.ts
+++ b/api/src/server.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { handle } from './server';
+
+describe('handle', () => {
+  it('GET /api/health → 200 with {ok: true, version}', async () => {
+    const res = await handle(
+      new Request('http://localhost/api/health'),
+      { version: 'abc1234' },
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toMatch(/application\/json/);
+    expect(await res.json()).toEqual({ ok: true, version: 'abc1234' });
+  });
+
+  it('falls back to "dev" when no version is configured', async () => {
+    const res = await handle(new Request('http://localhost/api/health'), {});
+
+    expect(await res.json()).toEqual({ ok: true, version: 'dev' });
+  });
+
+  it('unknown route → 404', async () => {
+    const res = await handle(
+      new Request('http://localhost/api/does-not-exist'),
+      { version: 'abc1234' },
+    );
+
+    expect(res.status).toBe(404);
+  });
+});

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -1,0 +1,21 @@
+export type ServerConfig = { version?: string };
+
+export async function handle(
+  req: Request,
+  config: ServerConfig,
+): Promise<Response> {
+  const url = new URL(req.url);
+  if (url.pathname === '/api/health') {
+    return Response.json({ ok: true, version: config.version ?? 'dev' });
+  }
+  return new Response('not found', { status: 404 });
+}
+
+if (import.meta.main) {
+  const config: ServerConfig = { version: process.env.BUILD_SHA };
+  Bun.serve({
+    port: 3000,
+    hostname: '127.0.0.1',
+    fetch: (req) => handle(req, config),
+  });
+}

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "types": ["bun", "node"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "resolveJsonModule": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/api/vitest.config.ts
+++ b/api/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+    environment: 'node',
+  },
+});

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -1,0 +1,25 @@
+# Canonical Caddyfile for chaipalaka.com.
+#
+# Lives at /etc/caddy/Caddyfile on the Hetzner box. After editing here,
+# copy and reload:
+#   sudo cp deploy/Caddyfile /etc/caddy/Caddyfile
+#   sudo caddy validate --config /etc/caddy/Caddyfile
+#   sudo systemctl reload caddy
+#
+# Caddy handles automatic TLS via Let's Encrypt — no certificate config
+# in this file by design.
+
+chaipalaka.com, www.chaipalaka.com {
+	encode zstd gzip
+
+	# Bun API backend (see deploy/chaipalaka-api.service).
+	handle /api/* {
+		reverse_proxy localhost:3000
+	}
+
+	# Static site (vite-react-ssg output rsync'd by `make deploy-web`).
+	handle {
+		root * /var/www/chaipalaka
+		file_server
+	}
+}

--- a/deploy/chaipalaka-api.service
+++ b/deploy/chaipalaka-api.service
@@ -1,0 +1,41 @@
+# systemd unit for the Bun API backend.
+#
+# Install on the Hetzner box:
+#   sudo cp deploy/chaipalaka-api.service /etc/systemd/system/
+#   sudo systemctl daemon-reload
+#   sudo systemctl enable --now chaipalaka-api
+#
+# The compiled binary is rsync'd into /opt/chaipalaka-api/server by
+# `make deploy-api`. Secrets are read from /etc/chaipalaka.env (root:root,
+# mode 600) — see deploy/SECRETS.md.
+
+[Unit]
+Description=chaipalaka.com Bun API backend
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=chaipalaka
+WorkingDirectory=/opt/chaipalaka-api
+EnvironmentFile=/etc/chaipalaka.env
+ExecStart=/opt/chaipalaka-api/server
+Restart=on-failure
+RestartSec=2
+
+# Hardening — service only needs to bind a local port and read env.
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+PrivateDevices=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+RestrictNamespaces=true
+LockPersonality=true
+MemoryDenyWriteExecute=false
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

- Bun backend in `api/` — single endpoint `GET /api/health` returns `{ok: true, version: <sha>}` with the SHA baked into the compiled binary via `bun --define` (no runtime env required).
- `CacheLayer` deep module with all four required behaviors covered by tests using `vi.useFakeTimers()`: TTL-expiry refetch, last-good fallback on refetch failure (`stale: true`), concurrent-get coalescing, clean `set()` override of last-good. 8 tests / 11 total in `api/`.
- Deploy artifacts in `deploy/`: hardened `chaipalaka-api.service` systemd unit (EnvironmentFile=/etc/chaipalaka.env, User=chaipalaka, ProtectSystem=strict, etc.) and a canonical `Caddyfile` adding `reverse_proxy /api/* localhost:3000` alongside the existing `file_server` block.
- Makefile `deploy-api` fleshed out — bakes `BUILD_SHA` from `git rev-parse --short HEAD` into the cross-compiled `bun-linux-x64` binary, rsyncs to `/opt/chaipalaka-api/`, restarts the unit. Plus `api-install` / `api-test` / `api-typecheck` / `api-dev` for local work.

## Notes / deviations

- **Install path is `/opt/chaipalaka-api/`, not `/srv/chaipalaka-api/`** as the issue body says. Confirmed with the owner: `/opt` is FHS-conventional for add-on application packages, matches the existing `Makefile` stub and `deploy/SECRETS.md`, and avoids touching unrelated docs. The systemd unit's `ExecStart=` and the Makefile's `rsync` destination both reflect this.
- **Caddyfile is the full canonical file** (`deploy/Caddyfile`), not just a snippet — easier to diff against the live `/etc/caddy/Caddyfile` and easier for future slices (subdomains, etc.) to extend. It includes both `chaipalaka.com` and `www.chaipalaka.com` since `make deploy-web` already targets `www`. Reconcile against the live server file when copying over.
- **`BUILD_SHA` baked at compile time, not loaded at runtime.** Verified locally: a darwin-arm64 cross-compile with `--define 'process.env.BUILD_SHA=\"testsha123\"'` reports `version: \"testsha123\"` from `/api/health`. The alternative (read from `/etc/chaipalaka.env`) would force an env-file edit on every deploy.
- **No `console.log` in production code paths** (per CLAUDE.md). The Bun bootstrap just calls `Bun.serve` and exits silently — `systemctl status chaipalaka-api` is the source of truth that it's up; `/api/health` is the source of truth that it's responding.
- **The `api/` scaffold files** (`package.json`, `tsconfig.json`, `vitest.config.ts`, `.env.example`) were already on disk untracked from earlier slice 1 prep — they got committed as part of this slice since this is the first slice that exercises them.

## Acceptance criteria (from issue #4)

- [ ] Bun service runs as a systemd unit on Hetzner; `systemctl status chaipalaka-api` shows active — **left for the human**: install via `sudo cp deploy/chaipalaka-api.service /etc/systemd/system/ && sudo systemctl daemon-reload && sudo systemctl enable --now chaipalaka-api`. (After the first \`make deploy-api\` lands the binary at \`/opt/chaipalaka-api/server\`.)
- [ ] Caddyfile updated with \`reverse_proxy /api/* localhost:3000\`; existing \`file_server\` block preserved — **left for the human**: \`sudo cp deploy/Caddyfile /etc/caddy/Caddyfile && sudo caddy validate && sudo systemctl reload caddy\`. Reconcile against the live file first.
- [ ] \`GET https://chaipalaka.com/api/health\` returns \`{ok: true, version: \"<sha>\"}\` — verifiable post-deploy with the curl in the test plan.
- [x] Secrets read from \`/etc/chaipalaka.env\` (root:root, mode 600) — systemd unit's \`EnvironmentFile=\` references it; \`deploy/SECRETS.md\` already documents the file's perms.
- [x] \`make deploy-api\` builds, deploys, and restarts the unit.
- [x] \`CacheLayer\` module: public interface \`get(key, fetcher, opts)\` + \`set(key, value)\`; tests cover TTL expiry triggers refetch, refetch failure returns last-good with \`stale: true\`, concurrent gets coalesce to one fetch.
- [x] \`CacheLayer\` tests use Vitest's fake timers for determinism.

## Test plan

Local (verified in this session):

\`\`\`sh
cd api
bun install
bun run typecheck    # tsc --noEmit, clean
bun run test         # 11 tests pass (8 CacheLayer + 3 server)
bun run build        # cross-compiles to dist/server (bun-linux-x64)

# also verified the BUILD_SHA bake works end-to-end on darwin-arm64:
bun build --compile --target=bun-darwin-arm64 --outfile /tmp/server-test \\
  src/server.ts --define 'process.env.BUILD_SHA=\"testsha123\"'
/tmp/server-test &
curl -s http://127.0.0.1:3000/api/health
# → {\"ok\":true,\"version\":\"testsha123\"}
\`\`\`

Post-deploy (one-time setup):

\`\`\`sh
# 1. Copy systemd unit + Caddyfile into place
sudo cp deploy/chaipalaka-api.service /etc/systemd/system/
sudo cp deploy/Caddyfile /etc/caddy/Caddyfile
sudo caddy validate --config /etc/caddy/Caddyfile

# 2. Build + deploy the API
make deploy-api    # this also rsyncs to /opt/chaipalaka-api/

# 3. Enable + start the unit (first time only)
sudo systemctl daemon-reload
sudo systemctl enable --now chaipalaka-api
sudo systemctl status chaipalaka-api

# 4. Reload Caddy
sudo systemctl reload caddy

# 5. Verify end-to-end
curl -s https://chaipalaka.com/api/health
# expect: {\"ok\":true,\"version\":\"<short-sha>\"}
\`\`\`

For subsequent deploys, just \`make deploy-api\`.

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)