### PR TITLE
Fix systemd User= and SECRETS.md username (#30)

### DIFF
--- a/deploy/SECRETS.md
+++ b/deploy/SECRETS.md
@@ -24,7 +24,7 @@ The systemd unit for the Bun service references this file via `EnvironmentFile=`
 [Service]
 EnvironmentFile=/etc/chaipalaka.env
 ExecStart=/opt/chaipalaka-api/server
-User=chaipalaka
+User=chai
 ```
 
 Format (one `KEY=value` per line, no quoting):

--- a/deploy/chaipalaka-api.service
+++ b/deploy/chaipalaka-api.service
@@ -16,7 +16,7 @@ Wants=network-online.target
 
 [Service]
 Type=simple
-User=chaipalaka
+User=chai
 WorkingDirectory=/opt/chaipalaka-api
 EnvironmentFile=/etc/chaipalaka.env
 ExecStart=/opt/chaipalaka-api/server


### PR DESCRIPTION
## Summary

- `deploy/chaipalaka-api.service` line 19: `User=chaipalaka` → `User=chai`.
- `deploy/SECRETS.md` line 27 (example systemd block): same.

These are the only two places `chaipalaka` was being used as a real Linux account name. Without this fix, the first `systemctl start chaipalaka-api` on the server fails with `Failed to determine user credentials: No such process` because systemd refuses to spawn under a UID that does not exist.

## Notes / why this happened

`chaipalaka` correctly appears throughout the repo as project name, domain, install path (`/opt/chaipalaka-api/`), SSH alias, env-file name (`/etc/chaipalaka.env`), systemd service name (`chaipalaka-api.service`), and last.fm/Letterboxd account names. Slice 4 propagated `User=chaipalaka` from `deploy/SECRETS.md`'s slice-1 example block into the unit file without verifying that token referred to a real OS account. It does not — the actual server user is `chai`.

PR #29's test-plan section also had two pre-existing problems (now superseded by the corrected sequence below): `systemctl daemon-reload` was placed *after* `make deploy-api`, but `make deploy-api` ends with `systemctl restart chaipalaka-api`, which fails until daemon-reload has run. And the prep steps for directory ownership, env-file creation, and a NOPASSWD sudoers entry were missing.

## Acceptance criteria (from #30)

- [x] `deploy/chaipalaka-api.service` `User=` matches the actual Hetzner user (`chai`)
- [x] `deploy/SECRETS.md` example systemd block matches the unit file
- [x] PR body documents the corrected first-time setup sequence (below)

## Corrected first-time setup

This supersedes PR #29's test plan. Run once on a freshly-set-up Hetzner box.

### Phase 1 — Server prep (one-time)

From your Mac, get the two deploy files onto the server:

```sh
scp deploy/chaipalaka-api.service deploy/Caddyfile chaipalaka:~/
ssh chaipalaka
```

Then on the server:

```sh
# 1a. Create the install directory the rsync will write into,
#     and hand it to the service user so a non-root rsync can write it.
sudo mkdir -p /opt/chaipalaka-api
sudo chown chai:chai /opt/chaipalaka-api

# 1b. Create the env file (empty for now — adapter slices will fill it).
#     The systemd unit's EnvironmentFile= directive refuses to start
#     the service if this file is missing.
sudo touch /etc/chaipalaka.env
sudo chown root:root /etc/chaipalaka.env
sudo chmod 600 /etc/chaipalaka.env

# 1c. Install the systemd unit and Caddyfile.
sudo mv ~/chaipalaka-api.service /etc/systemd/system/
sudo mv ~/Caddyfile /etc/caddy/Caddyfile

# 1d. Validate Caddy *before* reloading — finds typos while the old
#     config is still serving traffic.
sudo caddy validate --config /etc/caddy/Caddyfile

# 1e. Tell systemd a new unit exists. Without this, restart fails.
sudo systemctl daemon-reload

# 1f. Mark the unit to auto-start on boot. Don't --now yet — there is
#     no binary at /opt/chaipalaka-api/server until make deploy-api runs.
sudo systemctl enable chaipalaka-api

# 1g. Allow chai to restart the API and reload Caddy without a
#     password. make deploy-api ends with
#     `ssh chaipalaka "sudo systemctl restart chaipalaka-api"`
#     and would otherwise hang on a password prompt.
echo 'chai ALL=(ALL) NOPASSWD: /bin/systemctl restart chaipalaka-api, /bin/systemctl reload caddy' \
  | sudo tee /etc/sudoers.d/chai-deploy
sudo chmod 440 /etc/sudoers.d/chai-deploy

exit
```

### Phase 2 — First deploy (from the Mac)

```sh
make deploy-api
```

This builds, rsyncs the binary to `/opt/chaipalaka-api/server`, and does `systemctl restart chaipalaka-api`. With the unit enabled and daemon-reload already done, restart starts it for the first time.

### Phase 3 — Reload Caddy + verify

```sh
ssh chaipalaka 'sudo systemctl reload caddy && systemctl status chaipalaka-api --no-pager'
exit

curl -s https://chaipalaka.com/api/health
# expect: {"ok":true,"version":"<short-sha-of-this-PR-once-merged-and-deployed>"}
```

### Subsequent deploys

Just `make deploy-api`. Phase 1 is permanent; Phase 3's caddy reload only matters when `deploy/Caddyfile` itself changes.

## Test plan

This PR has no source-code changes — `bun run typecheck` and `bun run test` in `api/` (11 tests) still pass, verified locally. The real verification is the corrected first-time setup above; once merged + deployed, `curl -s https://chaipalaka.com/api/health` should return `{"ok":true,"version":"<sha>"}` instead of failing at the systemd start step.

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)