### PR TITLE
Fix: PhysicsCard drag — stop spring during hold, fling on release

### DIFF
--- a/web/src/physics/PhysicsCard.tsx
+++ b/web/src/physics/PhysicsCard.tsx
@@ -41,11 +41,20 @@ export function PhysicsCard({ text, fontKey, maxWidth, anchor }: PhysicsCardProp
     let dragging = false
     let lastX = 0
     let lastY = 0
+    let lastT = 0
+    let velX = 0
+    let velY = 0
+    const FLING_VELOCITY_SCALE = 16
+    const FLING_PAUSE_MS = 50
     const onPointerDown = (e: PointerEvent) => {
       e.preventDefault()
       dragging = true
       lastX = e.clientX
       lastY = e.clientY
+      lastT = e.timeStamp
+      velX = 0
+      velY = 0
+      world.setDragging(handle, true)
       el.setPointerCapture(e.pointerId)
       el.style.cursor = 'grabbing'
     }
@@ -53,14 +62,28 @@ export function PhysicsCard({ text, fontKey, maxWidth, anchor }: PhysicsCardProp
       if (!dragging) return
       const dx = e.clientX - lastX
       const dy = e.clientY - lastY
+      const dt = Math.max(e.timeStamp - lastT, 1)
+      velX = dx / dt
+      velY = dy / dt
       const cur = world.getPosition(handle)
       world.setPosition(handle, { x: cur.x + dx, y: cur.y + dy })
       lastX = e.clientX
       lastY = e.clientY
+      lastT = e.timeStamp
     }
     const onPointerUp = (e: PointerEvent) => {
       if (!dragging) return
       dragging = false
+      world.setDragging(handle, false)
+      const sinceLastMove = e.timeStamp - lastT
+      if (sinceLastMove > FLING_PAUSE_MS) {
+        velX = 0
+        velY = 0
+      }
+      world.setVelocity(handle, {
+        x: velX * FLING_VELOCITY_SCALE,
+        y: velY * FLING_VELOCITY_SCALE,
+      })
       el.releasePointerCapture(e.pointerId)
       el.style.cursor = 'grab'
     }

--- a/web/src/physics/PhysicsWorld.test.ts
+++ b/web/src/physics/PhysicsWorld.test.ts
@@ -120,6 +120,66 @@ describe('PhysicsWorld transform callback', () => {
   })
 })
 
+describe('PhysicsWorld dragging', () => {
+  test('while dragging, the body stays where setPosition places it across many ticks', () => {
+    const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
+    const handle = world.register(
+      { x: 100, y: 100 },
+      { width: 100, height: 50 },
+    )
+    world.setDragging(handle, true)
+    world.setPosition(handle, { x: 400, y: 300 })
+    for (let i = 0; i < 60; i++) world.tick(FIXED_DT_MS)
+    const pos = world.getPosition(handle)
+    expect(pos.x).toBeCloseTo(400, 1)
+    expect(pos.y).toBeCloseTo(300, 1)
+  })
+
+  test('on release, the breathing-mode spring returns the body to its anchor', () => {
+    const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
+    const handle = world.register(
+      { x: 100, y: 100 },
+      { width: 100, height: 50 },
+    )
+    world.setDragging(handle, true)
+    world.setPosition(handle, { x: 400, y: 300 })
+    world.setDragging(handle, false)
+    for (let i = 0; i < 600; i++) world.tick(FIXED_DT_MS)
+    const pos = world.getPosition(handle)
+    expect(Math.abs(pos.x - 100)).toBeLessThan(1)
+    expect(Math.abs(pos.y - 100)).toBeLessThan(1)
+  })
+
+  test('setVelocity directly sets the body velocity (mass-independent)', () => {
+    const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
+    const handle = world.register(
+      { x: 400, y: 100 },
+      { width: 100, height: 50 },
+    )
+    world.setVelocity(handle, { x: 5, y: 0 })
+    world.tick(FIXED_DT_MS)
+    const pos = world.getPosition(handle)
+    expect(pos.x).toBeGreaterThan(401)
+  })
+
+  test('after release, applyImpulse adds velocity to a body that was dragged', () => {
+    const release = (impulseX: number) => {
+      const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
+      const handle = world.register(
+        { x: 100, y: 100 },
+        { width: 100, height: 50 },
+      )
+      world.setDragging(handle, true)
+      world.setPosition(handle, { x: 200, y: 100 })
+      world.setDragging(handle, false)
+      if (impulseX !== 0) world.applyImpulse(handle, { x: impulseX, y: 0 })
+      world.tick(FIXED_DT_MS)
+      return world.getPosition(handle).x
+    }
+    expect(release(100)).toBeGreaterThan(release(0))
+  })
+})
+
 describe('PhysicsWorld card modes', () => {
   test('setMode("playground") relaxes the spring so the card stays where pushed', () => {
     const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })

--- a/web/src/physics/PhysicsWorld.ts
+++ b/web/src/physics/PhysicsWorld.ts
@@ -148,6 +148,18 @@ export class PhysicsWorld {
     }
   }
 
+  setVelocity(handle: PhysicsHandle, velocity: Vec2): void {
+    const reg = this.registrations.get(handle)
+    if (!reg) throw new Error(`PhysicsWorld: unknown handle ${handle}`)
+    Matter.Body.setVelocity(reg.body, velocity)
+  }
+
+  setDragging(handle: PhysicsHandle, dragging: boolean): void {
+    const reg = this.registrations.get(handle)
+    if (!reg) throw new Error(`PhysicsWorld: unknown handle ${handle}`)
+    Matter.Body.setStatic(reg.body, dragging)
+  }
+
   setMode(handle: PhysicsHandle, mode: CardMode): void {
     const reg = this.registrations.get(handle)
     if (!reg) throw new Error(`PhysicsWorld: unknown handle ${handle}`)


### PR DESCRIPTION
## Summary

- Cards used to drift back toward their anchor *while you were still holding the mouse down* — the breathing-mode spring kept pulling on every engine tick, and `setPosition` was racing it. PRD §147 says drag should be free, spring back on release.
- `PhysicsWorld` gains `setDragging(handle, dragging)` (freezes the body via `Matter.Body.setStatic`) and `setVelocity(handle, vec)` (mass-independent primitive for the release fling).
- `PhysicsCard` now: freezes the body on pointerdown, samples pointer velocity on pointermove, releases on pointerup with `setVelocity` derived from the last sample. A pause of >50 ms before release zeroes the fling so static releases don't accidentally throw.

## Notes / deviations

- Chose `setVelocity` over `applyImpulse` for the fling because impulse divides by mass — bigger cards would fling less than smaller cards for the same drag motion, which felt wrong. `setVelocity` is mass-independent.
- `FLING_VELOCITY_SCALE = 16` (px/ms → matter.js px/timestep at ~60Hz). It's a feel constant, not a physical conversion — easy to tweak.
- `setDragging` uses `Matter.Body.setStatic` rather than disabling the spring constraint. Side benefit: dragged cards also ignore gravity and collisions, so dragging mid-`gravity-on` works the way you'd expect.
- No tracked GitHub issue for this — bug was reported in chat. Filing post-hoc didn't seem worth the round-trip.

## Acceptance criteria

- [x] Drag a PhysicsCard and the card stays under the cursor — no drift toward anchor while held.
  - Covered by \`PhysicsWorld dragging > while dragging, the body stays where setPosition places it across many ticks\`.
- [x] Release the card and it springs back to its anchor with overshoot/damping (breathing mode).
  - Covered by \`PhysicsWorld dragging > on release, the breathing-mode spring returns the body to its anchor\`.
- [x] A dragged card is still dynamic after release (impulse/velocity affects it).
  - Covered by \`PhysicsWorld dragging > after release, applyImpulse adds velocity to a body that was dragged\`.
- [ ] **Manual: fling feels right.** I couldn't run the dev server in-sandbox, so the \`FLING_VELOCITY_SCALE = 16\` constant is unverified by feel. Please flick a card and tell me if it's too fast/slow/floaty and I'll tune it.

## Test plan

\`\`\`sh
cd web
npm run typecheck   # passes
npm run test        # 30/30 passes incl. 4 new dragging tests
npm run build       # passes, prerender intact (data-server-rendered=true)
npm run dev         # then visit / and try:
                    #   1. slow drag → card under cursor, no spring fight
                    #   2. release → card springs back with overshoot
                    #   3. fast flick → card flies, then spring catches it
                    #   4. drag, pause, release → no fling (velocity reset)
\`\`\`

Closes the chat-reported drag-spring bug.