### PR TITLE
Slice 7: CardLayout + multi-card grid + collisions (#7)

### DIFF
--- a/web/src/physics/CardLayout.test.ts
+++ b/web/src/physics/CardLayout.test.ts
@@ -1,0 +1,116 @@
+import { describe, test, expect } from 'vitest'
+import { cardLayout, type CardSpec, type MeasureFn } from './CardLayout'
+
+const fixedMeasure: MeasureFn = (_text, _fontKey, maxWidth) => ({
+  width: Math.min(200, maxWidth),
+  height: 60,
+})
+
+const SPEC_A: CardSpec = { id: 'a', text: 'Card A', fontKey: 'body' }
+const SPEC_B: CardSpec = { id: 'b', text: 'Card B', fontKey: 'body' }
+const SPEC_C: CardSpec = { id: 'c', text: 'Card C', fontKey: 'body' }
+const SPEC_D: CardSpec = { id: 'd', text: 'Card D', fontKey: 'body' }
+
+describe('cardLayout — basic', () => {
+  test('returns one anchor per spec with matching id', () => {
+    const anchors = cardLayout([SPEC_A, SPEC_B], { width: 1200, height: 800 }, fixedMeasure)
+    expect(anchors).toHaveLength(2)
+    expect(anchors[0]!.id).toBe('a')
+    expect(anchors[1]!.id).toBe('b')
+  })
+
+  test('returns width, height, and maxWidth on each anchor', () => {
+    const [anchor] = cardLayout([SPEC_A], { width: 1200, height: 800 }, fixedMeasure)
+    expect(anchor!.width).toBeGreaterThan(0)
+    expect(anchor!.height).toBeGreaterThan(0)
+    expect(anchor!.maxWidth).toBeGreaterThan(0)
+  })
+})
+
+describe('cardLayout — breakpoints', () => {
+  test('desktop (≥1024px) uses 3 columns: first 3 cards have distinct x values', () => {
+    const anchors = cardLayout(
+      [SPEC_A, SPEC_B, SPEC_C],
+      { width: 1200, height: 800 },
+      fixedMeasure,
+    )
+    const xs = anchors.map((a) => a.x)
+    expect(new Set(xs).size).toBe(3)
+  })
+
+  test('tablet (480–1023px) uses 2 columns: first 2 cards have distinct x, 3rd shares with 1st', () => {
+    const anchors = cardLayout(
+      [SPEC_A, SPEC_B, SPEC_C],
+      { width: 768, height: 1024 },
+      fixedMeasure,
+    )
+    expect(anchors[0]!.x).not.toBe(anchors[1]!.x)
+    expect(anchors[2]!.x).toBe(anchors[0]!.x)
+  })
+
+  test('mobile (<480px) uses 1 column: all cards share the same x', () => {
+    const anchors = cardLayout(
+      [SPEC_A, SPEC_B, SPEC_C],
+      { width: 375, height: 812 },
+      fixedMeasure,
+    )
+    const xs = anchors.map((a) => a.x)
+    expect(new Set(xs).size).toBe(1)
+  })
+
+  test('single-column layout stacks cards top-to-bottom', () => {
+    const anchors = cardLayout(
+      [SPEC_A, SPEC_B, SPEC_C],
+      { width: 375, height: 812 },
+      fixedMeasure,
+    )
+    expect(anchors[0]!.y).toBeLessThan(anchors[1]!.y)
+    expect(anchors[1]!.y).toBeLessThan(anchors[2]!.y)
+  })
+})
+
+describe('cardLayout — stability', () => {
+  test('positions are identical across two calls with the same inputs', () => {
+    const specs = [SPEC_A, SPEC_B, SPEC_C]
+    const viewport = { width: 1200, height: 800 }
+    const first = cardLayout(specs, viewport, fixedMeasure)
+    const second = cardLayout(specs, viewport, fixedMeasure)
+    expect(first).toEqual(second)
+  })
+})
+
+describe('cardLayout — non-overlap', () => {
+  test('no two anchors overlap at rest (bounding boxes are disjoint)', () => {
+    const anchors = cardLayout(
+      [SPEC_A, SPEC_B, SPEC_C, SPEC_D],
+      { width: 1200, height: 800 },
+      fixedMeasure,
+    )
+    for (let i = 0; i < anchors.length; i++) {
+      for (let j = i + 1; j < anchors.length; j++) {
+        const a = anchors[i]!
+        const b = anchors[j]!
+        const xOverlap = Math.abs(a.x - b.x) < (a.width + b.width) / 2
+        const yOverlap = Math.abs(a.y - b.y) < (a.height + b.height) / 2
+        expect(xOverlap && yOverlap).toBe(false)
+      }
+    }
+  })
+
+  test('no two anchors overlap at rest on a mobile viewport', () => {
+    const anchors = cardLayout(
+      [SPEC_A, SPEC_B, SPEC_C, SPEC_D],
+      { width: 375, height: 812 },
+      fixedMeasure,
+    )
+    for (let i = 0; i < anchors.length; i++) {
+      for (let j = i + 1; j < anchors.length; j++) {
+        const a = anchors[i]!
+        const b = anchors[j]!
+        const xOverlap = Math.abs(a.x - b.x) < (a.width + b.width) / 2
+        const yOverlap = Math.abs(a.y - b.y) < (a.height + b.height) / 2
+        expect(xOverlap && yOverlap).toBe(false)
+      }
+    }
+  })
+})

--- a/web/src/physics/CardLayout.ts
+++ b/web/src/physics/CardLayout.ts
@@ -1,0 +1,54 @@
+export interface CardSpec {
+  id: string
+  text: string
+  fontKey: string
+}
+
+export interface CardAnchor {
+  id: string
+  x: number
+  y: number
+  width: number
+  height: number
+  maxWidth: number
+}
+
+export type MeasureFn = (text: string, fontKey: string, maxWidth: number) => { width: number; height: number }
+
+const CARD_PADDING = 24
+const GUTTER = 16
+const TOP_MARGIN = 80
+
+function colsForWidth(viewportWidth: number): number {
+  if (viewportWidth >= 1024) return 3
+  if (viewportWidth >= 480) return 2
+  return 1
+}
+
+export function cardLayout(
+  specs: CardSpec[],
+  viewport: { width: number; height: number },
+  measure: MeasureFn,
+): CardAnchor[] {
+  const numCols = colsForWidth(viewport.width)
+  const colWidth = viewport.width / numCols
+  // maxWidth for text content: column width minus gutters and card padding on both sides
+  const textMaxWidth = Math.max(1, colWidth - GUTTER * 2 - CARD_PADDING * 2)
+
+  // Track the next y position for each column independently (masonry-style)
+  const colY = Array<number>(numCols).fill(TOP_MARGIN)
+
+  return specs.map((spec, i) => {
+    const col = i % numCols
+    const measured = measure(spec.text, spec.fontKey, textMaxWidth)
+    const w = measured.width + CARD_PADDING * 2
+    const h = measured.height + CARD_PADDING * 2
+
+    const cx = col * colWidth + colWidth / 2
+    const cy = colY[col]! + h / 2
+
+    colY[col] = colY[col]! + h + GUTTER
+
+    return { id: spec.id, x: cx, y: cy, width: w, height: h, maxWidth: textMaxWidth }
+  })
+}

--- a/web/src/physics/PhysicsCard.tsx
+++ b/web/src/physics/PhysicsCard.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react'
 import { usePhysicsWorld } from './PhysicsContext'
 import { registry as pretextRegistry } from '../text/registry'
+import type { PhysicsHandle } from './PhysicsWorld'
 import './PhysicsCard.css'
 
 export interface PhysicsCardProps {
@@ -15,28 +16,37 @@ const CARD_PADDING_PX = 24
 export function PhysicsCard({ text, fontKey, maxWidth, anchor }: PhysicsCardProps) {
   const world = usePhysicsWorld()
   const elRef = useRef<HTMLElement | null>(null)
+  const handleRef = useRef<PhysicsHandle | null>(null)
+  // Keep a ref to the current anchor so the registration effect can read the
+  // latest value without taking it as a dependency (avoids re-registering on
+  // every resize tick while the spring update is handled separately).
+  const anchorRef = useRef(anchor)
+  anchorRef.current = anchor
 
+  // Registration: only re-runs when text content or font changes.
   useEffect(() => {
     const el = elRef.current
     if (!el) return
 
+    const { x, y } = anchorRef.current
     const measured = pretextRegistry.measure(text, fontKey, maxWidth)
     const w = measured.width + CARD_PADDING_PX * 2
     const h = measured.height + CARD_PADDING_PX * 2
 
     el.style.width = `${w}px`
     el.style.height = `${h}px`
-    el.style.transform = `translate(${anchor.x - w / 2}px, ${anchor.y - h / 2}px)`
+    el.style.transform = `translate(${x - w / 2}px, ${y - h / 2}px)`
 
     const handle = world.register(
-      anchor,
+      { x, y },
       { width: w, height: h },
       {
-        onTransform: ({ x, y, rotation }) => {
-          el.style.transform = `translate(${x - w / 2}px, ${y - h / 2}px) rotate(${rotation}rad)`
+        onTransform: ({ x: px, y: py, rotation }) => {
+          el.style.transform = `translate(${px - w / 2}px, ${py - h / 2}px) rotate(${rotation}rad)`
         },
       },
     )
+    handleRef.current = handle
 
     let dragging = false
     let lastX = 0
@@ -46,6 +56,7 @@ export function PhysicsCard({ text, fontKey, maxWidth, anchor }: PhysicsCardProp
     let velY = 0
     const FLING_VELOCITY_SCALE = 16
     const FLING_PAUSE_MS = 50
+
     const onPointerDown = (e: PointerEvent) => {
       e.preventDefault()
       dragging = true
@@ -94,11 +105,18 @@ export function PhysicsCard({ text, fontKey, maxWidth, anchor }: PhysicsCardProp
 
     return () => {
       world.unregister(handle)
+      handleRef.current = null
       el.removeEventListener('pointerdown', onPointerDown)
       window.removeEventListener('pointermove', onPointerMove)
       window.removeEventListener('pointerup', onPointerUp)
     }
-  }, [world, text, fontKey, maxWidth, anchor.x, anchor.y])
+  }, [world, text, fontKey, maxWidth])
+
+  // Anchor update: moves the spring target when the grid re-flows (e.g. resize).
+  useEffect(() => {
+    if (handleRef.current === null) return
+    world.setAnchor(handleRef.current, anchor)
+  }, [world, anchor.x, anchor.y])
 
   return (
     <article ref={elRef} className="physics-card">

--- a/web/src/physics/PhysicsWorld.test.ts
+++ b/web/src/physics/PhysicsWorld.test.ts
@@ -194,3 +194,15 @@ describe('PhysicsWorld card modes', () => {
     expect(pos.x).toBeGreaterThan(150)
   })
 })
+
+describe('PhysicsWorld setAnchor', () => {
+  test('after setAnchor, the body springs to the new anchor position', () => {
+    const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
+    const handle = world.register({ x: 100, y: 100 }, { width: 100, height: 50 })
+    world.setAnchor(handle, { x: 500, y: 400 })
+    for (let i = 0; i < 600; i++) world.tick(FIXED_DT_MS)
+    const pos = world.getPosition(handle)
+    expect(Math.abs(pos.x - 500)).toBeLessThan(1)
+    expect(Math.abs(pos.y - 400)).toBeLessThan(1)
+  })
+})

--- a/web/src/physics/PhysicsWorld.ts
+++ b/web/src/physics/PhysicsWorld.ts
@@ -160,6 +160,14 @@ export class PhysicsWorld {
     Matter.Body.setStatic(reg.body, dragging)
   }
 
+  setAnchor(handle: PhysicsHandle, anchor: Vec2): void {
+    const reg = this.registrations.get(handle)
+    if (!reg) throw new Error(`PhysicsWorld: unknown handle ${handle}`)
+    reg.anchor = { ...anchor }
+    reg.spring.pointA!.x = anchor.x
+    reg.spring.pointA!.y = anchor.y
+  }
+
   setMode(handle: PhysicsHandle, mode: CardMode): void {
     const reg = this.registrations.get(handle)
     if (!reg) throw new Error(`PhysicsWorld: unknown handle ${handle}`)

--- a/web/src/routes/Home.tsx
+++ b/web/src/routes/Home.tsx
@@ -1,51 +1,65 @@
+import { useState, useEffect } from 'react'
 import { PhysicsCard } from '../physics/PhysicsCard'
+import { cardLayout, type CardSpec, type CardAnchor } from '../physics/CardLayout'
+import { registry as pretextRegistry } from '../text/registry'
+
+const CARD_SPECS: CardSpec[] = [
+  {
+    id: 'hero',
+    text: 'chaipalaka.com — personal site of Chai Palaka, frontend engineer and creative coder.',
+    fontKey: 'body',
+  },
+  {
+    id: 'about',
+    text: 'Building interfaces at the intersection of craft and code. Physics-driven UI, generative art, and the web as a creative medium.',
+    fontKey: 'body',
+  },
+  {
+    id: 'blog',
+    text: '/blog — writing on frontend architecture, creative coding, and the open web.',
+    fontKey: 'body',
+  },
+  {
+    id: 'portfolio',
+    text: '/portfolio — Flash-era stick-figure animations and interactive experiments, playable in-browser.',
+    fontKey: 'body',
+  },
+]
+
+function computeAnchors(): CardAnchor[] {
+  const vp = { width: window.innerWidth, height: window.innerHeight }
+  return cardLayout(CARD_SPECS, vp, (text, fontKey, maxWidth) =>
+    pretextRegistry.measure(text, fontKey, maxWidth),
+  )
+}
 
 export default function Home() {
+  // Anchors are computed client-side only: canvas text measurement is not
+  // available in the SSR (Node.js) prerender environment.
+  const [anchors, setAnchors] = useState<CardAnchor[]>([])
+
+  useEffect(() => {
+    setAnchors(computeAnchors())
+
+    const onResize = () => setAnchors(computeAnchors())
+    window.addEventListener('resize', onResize, { passive: true })
+    return () => window.removeEventListener('resize', onResize)
+  }, [])
+
   return (
     <>
-      <main>
-        <h1>chaipalaka.com</h1>
-        <p>
-          Personal site of Chai Palaka — a physics-driven, generative-art-backed
-          home on the internet that doubles as a portfolio of frontend craft.
-        </p>
-        <p>
-          This page is still a placeholder. It exercises the typographic baseline
-          shipped in slice&nbsp;3 — Newsreader for body text, JetBrains Mono for
-          code, design tokens defined as CSS custom properties so the site can
-          be re-skinned by editing one stylesheet. The canvas, the physics, and
-          the actual content land in later slices.
-        </p>
-
-        <hr />
-
-        <h2>What's coming</h2>
-        <p>
-          The eventual site has two layout shells: a canvas-mode shell with a
-          persistent R3F background and matter.js-driven foreground cards, and a
-          plain-mode shell for long-form reading. Routes include <code>/blog</code>,{' '}
-          <code>/portfolio</code>, <code>/lifelog</code>, and a 404 in playground
-          mode with gravity on. See <code>PRD.md</code> in the repo for the full
-          design.
-        </p>
-        <p>
-          Source: <a href="https://github.com/cpalaka/chaipalaka.com">github.com/cpalaka/chaipalaka.com</a>.
-        </p>
-
-        <blockquote>
-          <p>
-            The site must succeed on three axes simultaneously: aesthetic identity,
-            content utility, and graceful degradation — and each axis tends to pull
-            against the others.
-          </p>
-        </blockquote>
-      </main>
-      <PhysicsCard
-        text="drag me — i spring back. slice 5 lands the physics primitive."
-        fontKey="body"
-        maxWidth={280}
-        anchor={{ x: typeof window !== 'undefined' ? window.innerWidth - 220 : 800, y: 220 }}
-      />
+      {anchors.map((anchor) => {
+        const spec = CARD_SPECS.find((s) => s.id === anchor.id)!
+        return (
+          <PhysicsCard
+            key={anchor.id}
+            text={spec.text}
+            fontKey={spec.fontKey}
+            maxWidth={anchor.maxWidth}
+            anchor={{ x: anchor.x, y: anchor.y }}
+          />
+        )
+      })}
     </>
   )
 }


### PR DESCRIPTION
## Summary

- **`CardLayout.ts`** — pure layout function `(specs, viewport, measure) → CardAnchor[]`. Responsive 1/2/3-column grid at breakpoints < 480 / 480–1023 / ≥ 1024 px. 9 tests: shape, breakpoints (all three), stability, non-overlap (desktop and mobile).
- **`PhysicsWorld.setAnchor`** — mutates the Matter.js constraint `pointA` in-place so cards spring to new grid positions on resize without unregistering/re-registering. 1 new test.
- **`PhysicsCard` refactor** — separates registration from anchor updates: registration effect depends only on `text/fontKey/maxWidth`; a second lightweight effect calls `setAnchor` when `anchor.x/y` change (via ref pattern to avoid stale closures, per Vercel re-render guidelines `rerender-use-ref-transient-values`).
- **Homepage** now renders 4 physics cards (hero, about, blog, portfolio) laid out via `CardLayout`. Passive resize listener re-flows anchors. Inter-card collisions work via Matter.js default solid-body collision (no extra code needed).

## Notes / deviations

- Anchor computation is deferred to `useEffect` (not during render). `@chenglou/pretext` uses the Canvas API, which is unavailable in the vite-react-ssg Node.js prerender environment. SSR renders no cards; they appear on hydration.
- `CardAnchor` carries the `maxWidth` used for measurement so `PhysicsCard` uses the identical value — prevents any mis-sized physics bodies.

## Acceptance criteria

- [x] `CardLayout` is a pure function with no side effects; can be called outside React
- [x] `CardLayout` tests: positions for various viewport breakpoints; positions stable across re-renders with the same input; cards never overlap at rest
- [x] Homepage shows 3-4 cards in the grid produced by `CardLayout`
- [ ] Dragging one card into another causes both to push apart via collision — **needs manual browser verification** (matter.js solid bodies, should work by construction; reviewer: drag two cards together to confirm)
- [ ] Resizing the browser re-flows anchors — **needs manual browser verification** (resize listener wired; reviewer: resize window and confirm cards spring to new positions)

## Test plan

```
cd web
npm run typecheck    # 0 errors
npm run test         # 40 tests, all pass
npm run build        # SSG prerender succeeds
npm run dev          # open localhost:5173, verify 4 cards render, drag cards into each other
```

Closes #7