### PR TITLE
feat: softer bouncy spring + angular self-righting for physics cards

### DIFF
--- a/web/src/physics/PhysicsWorld.test.ts
+++ b/web/src/physics/PhysicsWorld.test.ts
@@ -206,3 +206,73 @@ describe('PhysicsWorld setAnchor', () => {
     expect(Math.abs(pos.y - 400)).toBeLessThan(1)
   })
 })
+
+describe('breathing spring overshoot (underdamped)', () => {
+  test('overshoots anchor at least once after a horizontal impulse', () => {
+    const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
+    const anchor = { x: 200, y: 200 }
+    const handle = world.register(anchor, { width: 100, height: 50 })
+    world.applyImpulse(handle, { x: 50, y: 0 })
+
+    let signFlips = 0
+    let prevSign = 0
+    for (let i = 0; i < 400; i++) {
+      world.tick(FIXED_DT_MS)
+      const pos = world.getPosition(handle)
+      const sign = Math.sign(pos.x - anchor.x)
+      if (sign !== 0 && prevSign !== 0 && sign !== prevSign) signFlips++
+      if (sign !== 0) prevSign = sign
+    }
+
+    expect(signFlips).toBeGreaterThanOrEqual(1)
+  })
+})
+
+describe('PhysicsWorld angular spring back', () => {
+  test('a rotated card self-rights to horizontal in breathing mode', () => {
+    const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
+    const handle = world.register({ x: 200, y: 200 }, { width: 100, height: 50 })
+    world.setAngle(handle, 0.5)
+    for (let i = 0; i < 600; i++) world.tick(FIXED_DT_MS)
+    const pos = world.getPosition(handle)
+    expect(Math.abs(pos.rotation)).toBeLessThan(0.02)
+  })
+
+  test('angular self-righting overshoots horizontal at least once (elastic)', () => {
+    const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
+    const handle = world.register({ x: 200, y: 200 }, { width: 100, height: 50 })
+    world.setAngle(handle, 0.5)
+
+    let signFlips = 0
+    let prevSign = 0
+    for (let i = 0; i < 300; i++) {
+      world.tick(FIXED_DT_MS)
+      const pos = world.getPosition(handle)
+      const sign = Math.sign(pos.rotation)
+      if (sign !== 0 && prevSign !== 0 && sign !== prevSign) signFlips++
+      if (sign !== 0) prevSign = sign
+    }
+
+    expect(signFlips).toBeGreaterThanOrEqual(1)
+  })
+
+  test('does not self-right while being dragged', () => {
+    const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
+    const handle = world.register({ x: 200, y: 200 }, { width: 100, height: 50 })
+    world.setAngle(handle, 0.3)
+    world.setDragging(handle, true)
+    for (let i = 0; i < 60; i++) world.tick(FIXED_DT_MS)
+    const pos = world.getPosition(handle)
+    expect(Math.abs(pos.rotation - 0.3)).toBeLessThan(0.001)
+  })
+
+  test('does not self-right in playground mode', () => {
+    const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
+    const handle = world.register({ x: 200, y: 200 }, { width: 100, height: 50 })
+    world.setMode(handle, 'playground')
+    world.setAngle(handle, 0.3)
+    for (let i = 0; i < 60; i++) world.tick(FIXED_DT_MS)
+    const pos = world.getPosition(handle)
+    expect(pos.rotation).toBeGreaterThan(0.25)
+  })
+})

--- a/web/src/physics/PhysicsWorld.ts
+++ b/web/src/physics/PhysicsWorld.ts
@@ -41,17 +41,19 @@ interface Registration {
 }
 
 const MODE_STIFFNESS: Record<CardMode, number> = {
-  breathing: 0.1,
+  breathing: 0.03,
   playground: 1e-9,
 }
 const MODE_DAMPING: Record<CardMode, number> = {
-  breathing: 0.3,
+  breathing: 0.06,
   playground: 0,
 }
 const GRAVITY_RELAXED_STIFFNESS = 1e-9
 const GRAVITY_Y = 0.7
 const BODY_FRICTION_AIR = 0.05
 const FLOOR_THICKNESS = 60
+const ANGULAR_STIFFNESS_BREATHING = 0.002
+const ANGULAR_DAMPING_BREATHING = 0
 
 export class PhysicsWorld {
   private engine: Matter.Engine
@@ -178,7 +180,22 @@ export class PhysicsWorld {
     }
   }
 
+  setAngle(handle: PhysicsHandle, angle: number): void {
+    const reg = this.registrations.get(handle)
+    if (!reg) throw new Error(`PhysicsWorld: unknown handle ${handle}`)
+    Matter.Body.setAngle(reg.body, angle)
+    Matter.Body.setAngularVelocity(reg.body, 0)
+  }
+
   tick(dtMs: number): void {
+    for (const reg of this.registrations.values()) {
+      if (reg.body.isStatic) continue
+      if (reg.mode !== 'breathing') continue
+      const angle = reg.body.angle
+      const angVel = reg.body.angularVelocity
+      const delta = -ANGULAR_STIFFNESS_BREATHING * angle - ANGULAR_DAMPING_BREATHING * angVel
+      Matter.Body.setAngularVelocity(reg.body, angVel + delta)
+    }
     Matter.Engine.update(this.engine, dtMs)
     for (const reg of this.registrations.values()) {
       if (!reg.onTransform) continue


### PR DESCRIPTION
## Summary

- **Linear spring retuned**: `MODE_STIFFNESS.breathing` 0.1→0.03, `MODE_DAMPING.breathing` 0.3→0.06 — position spring is now underdamped; cards drift back slowly and overshoot 1–2 times before settling instead of snapping back.
- **Angular self-righting added**: per-tick angular restoring impulse in `tick()` pulls each card's rotation back toward horizontal. Active only in `breathing` mode, skipped while dragging — same scope as the position spring. frictionAir provides natural angular damping so rotation also overshoots slightly before settling.
- **`setAngle()` method**: deterministic angle setter for tests (mirrors existing `setPosition`/`setVelocity` pattern; no production callers).

## Notes / deviations

- Angular spring is implemented as a per-tick impulse rather than a second matter.js constraint. Attaching an off-centroid constraint for torque would induce position drift without a 2-point pin; the per-tick approach fits the project's existing imperative style.
- `ANGULAR_DAMPING_BREATHING = 0`: explicit extra angular damping is zero — frictionAir (0.05) already puts the system in the underdamped region for `ANGULAR_STIFFNESS = 0.002`. Adding more damping would push the system toward critically-damped (no overshoot).
- Starting constants (0.03/0.06 linear, 0.002 angular) are calibrated starting points — worth a visual feel-pass before shipping.

## Acceptance criteria

- [x] Drag-and-release feels slower and more bouncy (linear overshoot test passes; verify visually at `/`)
- [x] Cards self-right to horizontal after collisions with elastic bounce (angular settle + overshoot tests pass)
- [x] Cards do NOT self-right while being held (drag-freeze test passes)
- [x] Playground mode cards stay free-rotating (playground-skip test passes)

## Test plan

```sh
cd web
npm run test          # 19 tests, all pass
npm run typecheck     # clean
npm run build         # SSG build succeeds, data-server-rendered in dist/index.html
npm run dev           # open / — drag a card hard and release; watch for overshoot + slow return
                      # slam cards together; watch them spin then self-right
```