### PR TITLE
Slice 18: ControlsPanel as gravity-exempt physics card (#18)

### DIFF
--- a/web/src/controls/ControlsPanel.css
+++ b/web/src/controls/ControlsPanel.css
@@ -1,0 +1,135 @@
+.controls-panel {
+    position: fixed;
+    top: 0;
+    left: 0;
+    background: var(--color-bg-raised);
+    color: var(--color-fg);
+    border: 1px solid var(--color-rule);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-md);
+    font-family: var(--font-body);
+    cursor: grab;
+    user-select: none;
+    touch-action: none;
+    will-change: transform;
+    z-index: 100;
+    overflow: hidden;
+    transition: width 0.2s ease, height 0.2s ease;
+}
+
+.controls-panel--expanded {
+    width: 200px;
+}
+
+.controls-panel--collapsed {
+    width: 48px;
+}
+
+.controls-panel__handle {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: var(--space-2) var(--space-3);
+    border-bottom: 1px solid var(--color-rule);
+    min-height: 48px;
+}
+
+.controls-panel--collapsed .controls-panel__handle {
+    border-bottom: none;
+    justify-content: center;
+}
+
+.controls-panel__collapse-btn {
+    background: none;
+    border: none;
+    color: var(--color-fg-muted);
+    cursor: pointer;
+    padding: var(--space-1);
+    font-size: var(--font-size-sm);
+    line-height: 1;
+    border-radius: var(--radius-sm);
+    display: flex;
+    align-items: center;
+}
+
+.controls-panel__collapse-btn:hover {
+    color: var(--color-fg);
+    background: var(--color-rule);
+}
+
+.controls-panel__body {
+    padding: var(--space-3);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+}
+
+.controls-panel__section {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+}
+
+.controls-panel__label {
+    font-size: var(--font-size-xs);
+    color: var(--color-fg-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    font-weight: var(--font-weight-medium);
+}
+
+/* Background picker */
+.controls-panel__bg-row {
+    display: flex;
+    gap: var(--space-2);
+    align-items: center;
+}
+
+.controls-panel__bg-dot {
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    border: 2px solid transparent;
+    cursor: pointer;
+    padding: 0;
+    transition: border-color 0.15s ease, transform 0.1s ease;
+}
+
+.controls-panel__bg-dot:hover {
+    transform: scale(1.15);
+}
+
+.controls-panel__bg-dot--active {
+    border-color: var(--color-fg);
+}
+
+/* Theme / gravity buttons */
+.controls-panel__icon-btn {
+    background: none;
+    border: 1px solid var(--color-rule);
+    border-radius: var(--radius-sm);
+    color: var(--color-fg);
+    cursor: pointer;
+    padding: var(--space-2);
+    font-size: var(--font-size-base);
+    line-height: 1;
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    width: 100%;
+    transition: background 0.15s ease;
+}
+
+.controls-panel__icon-btn:hover {
+    background: var(--color-rule);
+}
+
+.controls-panel__icon-btn--active {
+    color: var(--color-accent);
+    border-color: var(--color-accent);
+}
+
+.controls-panel__icon-btn span {
+    font-size: var(--font-size-sm);
+    color: var(--color-fg-muted);
+}

--- a/web/src/controls/ControlsPanel.css
+++ b/web/src/controls/ControlsPanel.css
@@ -78,32 +78,25 @@
     font-weight: var(--font-weight-medium);
 }
 
-/* Background picker */
-.controls-panel__bg-row {
-    display: flex;
-    gap: var(--space-2);
-    align-items: center;
-}
-
-.controls-panel__bg-dot {
-    width: 24px;
-    height: 24px;
-    border-radius: 50%;
-    border: 2px solid transparent;
+/* Dropdowns */
+.controls-panel__select {
+    width: 100%;
+    padding: var(--space-1) var(--space-2);
+    background: var(--color-bg);
+    color: var(--color-fg);
+    border: 1px solid var(--color-rule);
+    border-radius: var(--radius-sm);
+    font-family: var(--font-body);
+    font-size: var(--font-size-sm);
     cursor: pointer;
-    padding: 0;
-    transition: border-color 0.15s ease, transform 0.1s ease;
 }
 
-.controls-panel__bg-dot:hover {
-    transform: scale(1.15);
+.controls-panel__select:focus {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 2px;
 }
 
-.controls-panel__bg-dot--active {
-    border-color: var(--color-fg);
-}
-
-/* Theme / gravity buttons */
+/* Gravity button */
 .controls-panel__icon-btn {
     background: none;
     border: 1px solid var(--color-rule);
@@ -111,7 +104,7 @@
     color: var(--color-fg);
     cursor: pointer;
     padding: var(--space-2);
-    font-size: var(--font-size-base);
+    font-size: var(--font-size-sm);
     line-height: 1;
     display: flex;
     align-items: center;
@@ -127,9 +120,4 @@
 .controls-panel__icon-btn--active {
     color: var(--color-accent);
     border-color: var(--color-accent);
-}
-
-.controls-panel__icon-btn span {
-    font-size: var(--font-size-sm);
-    color: var(--color-fg-muted);
 }

--- a/web/src/controls/ControlsPanel.tsx
+++ b/web/src/controls/ControlsPanel.tsx
@@ -39,22 +39,11 @@ function savePosition(pos: SavedPosition) {
     }
 }
 
-const THEME_ICONS: Record<string, string> = {
-    dark: '🌙',
-    light: '☀️',
-    system: '⚙️',
-}
-
-const THEME_LABELS: Record<string, string> = {
-    dark: 'Dark',
-    light: 'Light',
-    system: 'System',
-}
 
 export function ControlsPanel() {
     const world = usePhysicsWorld()
     const { active, setActive } = useGallery()
-    const { theme, cycleTheme } = useTheme()
+    const { theme, setTheme } = useTheme()
     const [collapsed, setCollapsed] = useState(false)
     const [gravityOn] = useState(false)
 
@@ -88,7 +77,7 @@ export function ControlsPanel() {
         let lastY = 0
 
         const onPointerDown = (e: PointerEvent) => {
-            if ((e.target as Element | null)?.closest('button')) return
+            if ((e.target as Element | null)?.closest('button, select')) return
             e.preventDefault()
             dragging = true
             lastX = e.clientX
@@ -157,31 +146,47 @@ export function ControlsPanel() {
             {!collapsed && (
                 <div className="controls-panel__body">
                     <div className="controls-panel__section">
-                        <div className="controls-panel__label">Background</div>
-                        <div className="controls-panel__bg-row">
+                        <label
+                            className="controls-panel__label"
+                            htmlFor="cp-background"
+                        >
+                            Background
+                        </label>
+                        <select
+                            id="cp-background"
+                            className="controls-panel__select"
+                            value={active.id}
+                            onChange={(e) => setActive(e.target.value)}
+                        >
                             {manifest.map((scene) => (
-                                <button
-                                    key={scene.id}
-                                    className={`controls-panel__bg-dot${active.id === scene.id ? ' controls-panel__bg-dot--active' : ''}`}
-                                    style={{ background: scene.accentColor }}
-                                    onClick={() => setActive(scene.id)}
-                                    aria-label={`Switch to ${scene.id} background`}
-                                    aria-pressed={active.id === scene.id}
-                                />
+                                <option key={scene.id} value={scene.id}>
+                                    {scene.id}
+                                </option>
                             ))}
-                        </div>
+                        </select>
                     </div>
 
                     <div className="controls-panel__section">
-                        <div className="controls-panel__label">Theme</div>
-                        <button
-                            className="controls-panel__icon-btn"
-                            onClick={cycleTheme}
-                            aria-label={`Current theme: ${theme}. Click to cycle.`}
+                        <label
+                            className="controls-panel__label"
+                            htmlFor="cp-theme"
                         >
-                            {THEME_ICONS[theme]}{' '}
-                            <span>{THEME_LABELS[theme]}</span>
-                        </button>
+                            Theme
+                        </label>
+                        <select
+                            id="cp-theme"
+                            className="controls-panel__select"
+                            value={theme}
+                            onChange={(e) =>
+                                setTheme(
+                                    e.target.value as 'dark' | 'light' | 'system',
+                                )
+                            }
+                        >
+                            <option value="system">System</option>
+                            <option value="dark">Dark</option>
+                            <option value="light">Light</option>
+                        </select>
                     </div>
 
                     <div className="controls-panel__section">

--- a/web/src/controls/ControlsPanel.tsx
+++ b/web/src/controls/ControlsPanel.tsx
@@ -1,0 +1,201 @@
+import { useEffect, useRef, useState } from 'react'
+import { usePhysicsWorld } from '../physics/PhysicsContext'
+import { useGallery } from '../canvas/useGallery'
+import { useTheme } from './useTheme'
+import type { PhysicsHandle } from '../physics/PhysicsWorld'
+import manifest from '../canvas/scenes/manifest.json'
+import './ControlsPanel.css'
+
+const POSITION_STORAGE_KEY = 'chaipalaka.controls.position'
+const PANEL_W = 200
+const PANEL_H_EXPANDED = 220
+const PANEL_H_COLLAPSED = 48
+const EDGE_MARGIN = 20
+
+type SavedPosition = { x: number; y: number }
+
+function defaultPosition(): SavedPosition {
+    if (typeof window === 'undefined') return { x: 200, y: 500 }
+    return {
+        x: window.innerWidth - PANEL_W / 2 - EDGE_MARGIN,
+        y: window.innerHeight - PANEL_H_EXPANDED / 2 - EDGE_MARGIN,
+    }
+}
+
+function loadPosition(): SavedPosition {
+    if (typeof localStorage === 'undefined') return defaultPosition()
+    try {
+        const raw = localStorage.getItem(POSITION_STORAGE_KEY)
+        if (raw) return JSON.parse(raw) as SavedPosition
+    } catch {
+        // ignore
+    }
+    return defaultPosition()
+}
+
+function savePosition(pos: SavedPosition) {
+    if (typeof localStorage !== 'undefined') {
+        localStorage.setItem(POSITION_STORAGE_KEY, JSON.stringify(pos))
+    }
+}
+
+const THEME_ICONS: Record<string, string> = {
+    dark: '🌙',
+    light: '☀️',
+    system: '⚙️',
+}
+
+const THEME_LABELS: Record<string, string> = {
+    dark: 'Dark',
+    light: 'Light',
+    system: 'System',
+}
+
+export function ControlsPanel() {
+    const world = usePhysicsWorld()
+    const { active, setActive } = useGallery()
+    const { theme, cycleTheme } = useTheme()
+    const [collapsed, setCollapsed] = useState(false)
+    const [gravityOn] = useState(false)
+
+    const elRef = useRef<HTMLDivElement | null>(null)
+    const handleRef = useRef<PhysicsHandle | null>(null)
+    const posRef = useRef<SavedPosition>(loadPosition())
+
+    useEffect(() => {
+        const el = elRef.current
+        if (!el) return
+
+        const { x, y } = posRef.current
+        const h = collapsed ? PANEL_H_COLLAPSED : PANEL_H_EXPANDED
+        el.style.width = `${PANEL_W}px`
+        el.style.height = `${h}px`
+        el.style.transform = `translate(${x - PANEL_W / 2}px, ${y - h / 2}px)`
+
+        const handle = world.registerStatic(
+            { x, y },
+            { width: PANEL_W, height: h },
+            {
+                onTransform: ({ x: px, y: py }) => {
+                    el.style.transform = `translate(${px - PANEL_W / 2}px, ${py - h / 2}px)`
+                },
+            },
+        )
+        handleRef.current = handle
+
+        let dragging = false
+        let lastX = 0
+        let lastY = 0
+
+        const onPointerDown = (e: PointerEvent) => {
+            if ((e.target as Element | null)?.closest('button')) return
+            e.preventDefault()
+            dragging = true
+            lastX = e.clientX
+            lastY = e.clientY
+            el.setPointerCapture(e.pointerId)
+            el.style.cursor = 'grabbing'
+        }
+        const onPointerMove = (e: PointerEvent) => {
+            if (!dragging) return
+            const dx = e.clientX - lastX
+            const dy = e.clientY - lastY
+            const cur = world.getPosition(handle)
+            const next = { x: cur.x + dx, y: cur.y + dy }
+            world.setPosition(handle, next)
+            lastX = e.clientX
+            lastY = e.clientY
+        }
+        const onPointerUp = (e: PointerEvent) => {
+            if (!dragging) return
+            dragging = false
+            el.releasePointerCapture(e.pointerId)
+            el.style.cursor = 'grab'
+            const final = world.getPosition(handle)
+            posRef.current = { x: final.x, y: final.y }
+            savePosition(posRef.current)
+        }
+
+        el.addEventListener('pointerdown', onPointerDown)
+        window.addEventListener('pointermove', onPointerMove)
+        window.addEventListener('pointerup', onPointerUp)
+
+        return () => {
+            world.unregister(handle)
+            handleRef.current = null
+            el.removeEventListener('pointerdown', onPointerDown)
+            window.removeEventListener('pointermove', onPointerMove)
+            window.removeEventListener('pointerup', onPointerUp)
+        }
+    }, [world, collapsed])
+
+    return (
+        <div
+            ref={elRef}
+            className={`controls-panel ${collapsed ? 'controls-panel--collapsed' : 'controls-panel--expanded'}`}
+            role="toolbar"
+            aria-label="Site controls"
+        >
+            <div className="controls-panel__handle">
+                {!collapsed && (
+                    <span
+                        className="controls-panel__label"
+                        style={{ fontSize: 'var(--font-size-xs)' }}
+                    >
+                        Controls
+                    </span>
+                )}
+                <button
+                    className="controls-panel__collapse-btn"
+                    onClick={() => setCollapsed((c) => !c)}
+                    aria-label={collapsed ? 'Expand controls' : 'Collapse controls'}
+                >
+                    {collapsed ? '⊞' : '✕'}
+                </button>
+            </div>
+
+            {!collapsed && (
+                <div className="controls-panel__body">
+                    <div className="controls-panel__section">
+                        <div className="controls-panel__label">Background</div>
+                        <div className="controls-panel__bg-row">
+                            {manifest.map((scene) => (
+                                <button
+                                    key={scene.id}
+                                    className={`controls-panel__bg-dot${active.id === scene.id ? ' controls-panel__bg-dot--active' : ''}`}
+                                    style={{ background: scene.accentColor }}
+                                    onClick={() => setActive(scene.id)}
+                                    aria-label={`Switch to ${scene.id} background`}
+                                    aria-pressed={active.id === scene.id}
+                                />
+                            ))}
+                        </div>
+                    </div>
+
+                    <div className="controls-panel__section">
+                        <div className="controls-panel__label">Theme</div>
+                        <button
+                            className="controls-panel__icon-btn"
+                            onClick={cycleTheme}
+                            aria-label={`Current theme: ${theme}. Click to cycle.`}
+                        >
+                            {THEME_ICONS[theme]}{' '}
+                            <span>{THEME_LABELS[theme]}</span>
+                        </button>
+                    </div>
+
+                    <div className="controls-panel__section">
+                        <div className="controls-panel__label">Gravity</div>
+                        <button
+                            className={`controls-panel__icon-btn${gravityOn ? ' controls-panel__icon-btn--active' : ''}`}
+                            onClick={() => {/* slice 19 */}}
+                            aria-label={`Gravity ${gravityOn ? 'on' : 'off'} (coming soon)`}
+                        >
+                            ⚖️ <span>{gravityOn ? 'On' : 'Off'}</span>
+                        </button>
+                    </div>
+                </div>
+            )}
+        </div>
+    )
+}

--- a/web/src/controls/theme.test.ts
+++ b/web/src/controls/theme.test.ts
@@ -1,0 +1,102 @@
+import { describe, test, expect } from 'vitest'
+import { createThemeController, THEME_STORAGE_KEY } from './theme'
+
+type Storage = Map<string, string>
+
+function fakeStorage(init: Record<string, string> = {}): Storage {
+    return new Map(Object.entries(init))
+}
+
+describe('theme controller initialisation', () => {
+    test('defaults to "system" when storage is empty', () => {
+        const ctrl = createThemeController({ storage: fakeStorage() })
+        expect(ctrl.getTheme()).toBe('system')
+    })
+
+    test('reads persisted "dark" from storage', () => {
+        const ctrl = createThemeController({
+            storage: fakeStorage({ [THEME_STORAGE_KEY]: 'dark' }),
+        })
+        expect(ctrl.getTheme()).toBe('dark')
+    })
+
+    test('reads persisted "light" from storage', () => {
+        const ctrl = createThemeController({
+            storage: fakeStorage({ [THEME_STORAGE_KEY]: 'light' }),
+        })
+        expect(ctrl.getTheme()).toBe('light')
+    })
+
+    test('falls back to "system" for an unrecognised storage value', () => {
+        const ctrl = createThemeController({
+            storage: fakeStorage({ [THEME_STORAGE_KEY]: 'neon' }),
+        })
+        expect(ctrl.getTheme()).toBe('system')
+    })
+})
+
+describe('theme controller cycle', () => {
+    test('cycles system → dark → light → system', () => {
+        const ctrl = createThemeController({ storage: fakeStorage() })
+        expect(ctrl.getTheme()).toBe('system')
+        ctrl.cycleTheme()
+        expect(ctrl.getTheme()).toBe('dark')
+        ctrl.cycleTheme()
+        expect(ctrl.getTheme()).toBe('light')
+        ctrl.cycleTheme()
+        expect(ctrl.getTheme()).toBe('system')
+    })
+
+    test('cycleTheme persists the new value to storage', () => {
+        const storage = fakeStorage()
+        const ctrl = createThemeController({ storage })
+        ctrl.cycleTheme()
+        expect(storage.get(THEME_STORAGE_KEY)).toBe('dark')
+        ctrl.cycleTheme()
+        expect(storage.get(THEME_STORAGE_KEY)).toBe('light')
+        ctrl.cycleTheme()
+        expect(storage.get(THEME_STORAGE_KEY)).toBe('system')
+    })
+})
+
+describe('theme controller getDataTheme', () => {
+    test('returns empty string for "system"', () => {
+        const ctrl = createThemeController({ storage: fakeStorage() })
+        expect(ctrl.getDataTheme()).toBe('')
+    })
+
+    test('returns "dark" for dark', () => {
+        const ctrl = createThemeController({
+            storage: fakeStorage({ [THEME_STORAGE_KEY]: 'dark' }),
+        })
+        expect(ctrl.getDataTheme()).toBe('dark')
+    })
+
+    test('returns "light" for light', () => {
+        const ctrl = createThemeController({
+            storage: fakeStorage({ [THEME_STORAGE_KEY]: 'light' }),
+        })
+        expect(ctrl.getDataTheme()).toBe('light')
+    })
+})
+
+describe('theme controller subscribe', () => {
+    test('listener fires on each cycleTheme call with the new theme', () => {
+        const ctrl = createThemeController({ storage: fakeStorage() })
+        const seen: string[] = []
+        ctrl.subscribe((t) => seen.push(t))
+        ctrl.cycleTheme()
+        ctrl.cycleTheme()
+        expect(seen).toEqual(['dark', 'light'])
+    })
+
+    test('unsubscribe stops future notifications', () => {
+        const ctrl = createThemeController({ storage: fakeStorage() })
+        const seen: string[] = []
+        const unsub = ctrl.subscribe((t) => seen.push(t))
+        ctrl.cycleTheme()
+        unsub()
+        ctrl.cycleTheme()
+        expect(seen).toEqual(['dark'])
+    })
+})

--- a/web/src/controls/theme.ts
+++ b/web/src/controls/theme.ts
@@ -1,0 +1,54 @@
+export type Theme = 'dark' | 'light' | 'system'
+
+export const THEME_STORAGE_KEY = 'chaipalaka.theme'
+
+const CYCLE: readonly Theme[] = ['system', 'dark', 'light']
+
+export interface ThemeController {
+    getTheme(): Theme
+    cycleTheme(): void
+    getDataTheme(): string
+    subscribe(listener: (theme: Theme) => void): () => void
+}
+
+export interface ThemeControllerDeps {
+    storage: Map<string, string>
+}
+
+function readTheme(storage: Map<string, string>): Theme {
+    const stored = storage.get(THEME_STORAGE_KEY)
+    if (stored === 'dark' || stored === 'light' || stored === 'system') {
+        return stored
+    }
+    return 'system'
+}
+
+export function createThemeController(
+    deps: ThemeControllerDeps,
+): ThemeController {
+    const { storage } = deps
+    let current: Theme = readTheme(storage)
+    const listeners = new Set<(theme: Theme) => void>()
+
+    return {
+        getTheme() {
+            return current
+        },
+
+        cycleTheme() {
+            const idx = CYCLE.indexOf(current)
+            current = CYCLE[(idx + 1) % CYCLE.length]!
+            storage.set(THEME_STORAGE_KEY, current)
+            for (const l of listeners) l(current)
+        },
+
+        getDataTheme() {
+            return current === 'system' ? '' : current
+        },
+
+        subscribe(listener) {
+            listeners.add(listener)
+            return () => listeners.delete(listener)
+        },
+    }
+}

--- a/web/src/controls/theme.ts
+++ b/web/src/controls/theme.ts
@@ -6,6 +6,7 @@ const CYCLE: readonly Theme[] = ['system', 'dark', 'light']
 
 export interface ThemeController {
     getTheme(): Theme
+    setTheme(theme: Theme): void
     cycleTheme(): void
     getDataTheme(): string
     subscribe(listener: (theme: Theme) => void): () => void
@@ -33,6 +34,12 @@ export function createThemeController(
     return {
         getTheme() {
             return current
+        },
+
+        setTheme(theme: Theme) {
+            current = theme
+            storage.set(THEME_STORAGE_KEY, current)
+            for (const l of listeners) l(current)
         },
 
         cycleTheme() {

--- a/web/src/controls/useTheme.ts
+++ b/web/src/controls/useTheme.ts
@@ -1,0 +1,59 @@
+import { useEffect, useState } from 'react'
+import { createThemeController, THEME_STORAGE_KEY } from './theme'
+import type { Theme } from './theme'
+
+function makeStorage(): Map<string, string> {
+    const m = new Map<string, string>()
+    if (typeof localStorage !== 'undefined') {
+        const persisted = localStorage.getItem(THEME_STORAGE_KEY)
+        if (persisted) m.set(THEME_STORAGE_KEY, persisted)
+        const original = m.set.bind(m)
+        m.set = (k, v) => {
+            localStorage.setItem(k, v)
+            return original(k, v)
+        }
+    }
+    return m
+}
+
+let controllerInstance: ReturnType<typeof createThemeController> | null = null
+
+function getController() {
+    if (!controllerInstance) {
+        controllerInstance = createThemeController({ storage: makeStorage() })
+    }
+    return controllerInstance
+}
+
+export function useTheme(): { theme: Theme; cycleTheme: () => void } {
+    const ctrl = getController()
+    const [theme, setTheme] = useState(() => ctrl.getTheme())
+
+    useEffect(() => {
+        const unsub = ctrl.subscribe((t) => {
+            setTheme(t)
+            if (typeof document !== 'undefined') {
+                const dt = ctrl.getDataTheme()
+                if (dt) {
+                    document.documentElement.dataset.theme = dt
+                } else {
+                    delete document.documentElement.dataset.theme
+                }
+            }
+        })
+        // Apply on mount too
+        const dt = ctrl.getDataTheme()
+        if (typeof document !== 'undefined') {
+            if (dt) {
+                document.documentElement.dataset.theme = dt
+            } else {
+                delete document.documentElement.dataset.theme
+            }
+        }
+        return unsub
+    }, [ctrl])
+
+    return { theme, cycleTheme: () => ctrl.cycleTheme() }
+}
+
+export type { Theme }

--- a/web/src/controls/useTheme.ts
+++ b/web/src/controls/useTheme.ts
@@ -25,13 +25,17 @@ function getController() {
     return controllerInstance
 }
 
-export function useTheme(): { theme: Theme; cycleTheme: () => void } {
+export function useTheme(): {
+    theme: Theme
+    setTheme: (t: Theme) => void
+    cycleTheme: () => void
+} {
     const ctrl = getController()
-    const [theme, setTheme] = useState(() => ctrl.getTheme())
+    const [theme, setThemeState] = useState(() => ctrl.getTheme())
 
     useEffect(() => {
         const unsub = ctrl.subscribe((t) => {
-            setTheme(t)
+            setThemeState(t)
             if (typeof document !== 'undefined') {
                 const dt = ctrl.getDataTheme()
                 if (dt) {
@@ -53,7 +57,11 @@ export function useTheme(): { theme: Theme; cycleTheme: () => void } {
         return unsub
     }, [ctrl])
 
-    return { theme, cycleTheme: () => ctrl.cycleTheme() }
+    return {
+        theme,
+        setTheme: (t: Theme) => ctrl.setTheme(t),
+        cycleTheme: () => ctrl.cycleTheme(),
+    }
 }
 
 export type { Theme }

--- a/web/src/layouts/CanvasLayout.tsx
+++ b/web/src/layouts/CanvasLayout.tsx
@@ -2,6 +2,7 @@ import { Outlet } from 'react-router-dom'
 import { BackgroundCanvas } from '../canvas/BackgroundCanvas'
 import { CANVAS_ONLY_BUNDLE_MARKER } from '../lib/canvas-only-marker'
 import { PhysicsProvider } from '../physics/PhysicsContext'
+import { ControlsPanel } from '../controls/ControlsPanel'
 
 export default function CanvasLayout() {
     return (
@@ -11,6 +12,7 @@ export default function CanvasLayout() {
                 data-canvas-marker={CANVAS_ONLY_BUNDLE_MARKER}
             >
                 <BackgroundCanvas />
+                <ControlsPanel />
                 <Outlet />
             </div>
         </PhysicsProvider>

--- a/web/src/physics/PhysicsWorld.test.ts
+++ b/web/src/physics/PhysicsWorld.test.ts
@@ -331,3 +331,66 @@ describe('PhysicsWorld angular spring back', () => {
         expect(pos.rotation).toBeGreaterThan(0.25)
     })
 })
+
+describe('PhysicsWorld static registration (gravity-exempt)', () => {
+    test('registerStatic returns a handle that can be queried and unregistered', () => {
+        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
+        const handle = world.registerStatic(
+            { x: 200, y: 500 },
+            { width: 120, height: 60 },
+        )
+        expect(handle).toBeDefined()
+        expect(world.has(handle)).toBe(true)
+        world.unregister(handle)
+        expect(world.has(handle)).toBe(false)
+    })
+
+    test('a static body sits at its initial position', () => {
+        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
+        const handle = world.registerStatic(
+            { x: 200, y: 500 },
+            { width: 120, height: 60 },
+        )
+        const pos = world.getPosition(handle)
+        expect(pos.x).toBeCloseTo(200, 5)
+        expect(pos.y).toBeCloseTo(500, 5)
+    })
+
+    test('a static body does not fall when gravity is on', () => {
+        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
+        const handle = world.registerStatic(
+            { x: 200, y: 200 },
+            { width: 120, height: 60 },
+        )
+        world.setGravity(true)
+        for (let i = 0; i < 60; i++) world.tick(FIXED_DT_MS)
+        const pos = world.getPosition(handle)
+        expect(pos.y).toBeCloseTo(200, 1)
+    })
+
+    test('setPosition moves a static body to the target immediately', () => {
+        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
+        const handle = world.registerStatic(
+            { x: 200, y: 500 },
+            { width: 120, height: 60 },
+        )
+        world.setPosition(handle, { x: 400, y: 300 })
+        const pos = world.getPosition(handle)
+        expect(pos.x).toBeCloseTo(400, 5)
+        expect(pos.y).toBeCloseTo(300, 5)
+    })
+
+    test('a static body stays put after setPosition across many ticks with gravity', () => {
+        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
+        const handle = world.registerStatic(
+            { x: 200, y: 500 },
+            { width: 120, height: 60 },
+        )
+        world.setGravity(true)
+        world.setPosition(handle, { x: 400, y: 300 })
+        for (let i = 0; i < 120; i++) world.tick(FIXED_DT_MS)
+        const pos = world.getPosition(handle)
+        expect(pos.x).toBeCloseTo(400, 1)
+        expect(pos.y).toBeCloseTo(300, 1)
+    })
+})

--- a/web/src/physics/PhysicsWorld.ts
+++ b/web/src/physics/PhysicsWorld.ts
@@ -34,9 +34,10 @@ export interface RegisterOptions {
 
 interface Registration {
     body: Matter.Body
-    spring: Matter.Constraint
+    spring?: Matter.Constraint
     anchor: Vec2
     mode: CardMode
+    isStatic: boolean
     onTransform?: (state: BodyState) => void
 }
 
@@ -111,6 +112,32 @@ export class PhysicsWorld {
             spring,
             anchor: { ...anchor },
             mode,
+            isStatic: false,
+            onTransform: opts.onTransform,
+        })
+        return id
+    }
+
+    registerStatic(
+        position: Vec2,
+        size: CardSize,
+        opts: RegisterOptions = {},
+    ): PhysicsHandle {
+        const body = Matter.Bodies.rectangle(
+            position.x,
+            position.y,
+            size.width,
+            size.height,
+            { isStatic: true },
+        )
+        Matter.Composite.add(this.world, body)
+        const id = this.nextId++
+        this.registrations.set(id, {
+            body,
+            spring: undefined,
+            anchor: { ...position },
+            mode: 'breathing',
+            isStatic: true,
             onTransform: opts.onTransform,
         })
         return id
@@ -120,7 +147,7 @@ export class PhysicsWorld {
         const reg = this.registrations.get(handle)
         if (!reg) return
         Matter.Composite.remove(this.world, reg.body)
-        Matter.Composite.remove(this.world, reg.spring)
+        if (reg.spring) Matter.Composite.remove(this.world, reg.spring)
         this.registrations.delete(handle)
     }
 
@@ -158,6 +185,7 @@ export class PhysicsWorld {
         this.gravityOn = on
         this.engine.gravity.y = on ? GRAVITY_Y : 0
         for (const reg of this.registrations.values()) {
+            if (reg.isStatic || !reg.spring) continue
             reg.spring.stiffness = on
                 ? GRAVITY_RELAXED_STIFFNESS
                 : MODE_STIFFNESS[reg.mode]
@@ -173,12 +201,18 @@ export class PhysicsWorld {
     setDragging(handle: PhysicsHandle, dragging: boolean): void {
         const reg = this.registrations.get(handle)
         if (!reg) throw new Error(`PhysicsWorld: unknown handle ${handle}`)
+        if (reg.isStatic) return
         Matter.Body.setStatic(reg.body, dragging)
     }
 
     setAnchor(handle: PhysicsHandle, anchor: Vec2): void {
         const reg = this.registrations.get(handle)
         if (!reg) throw new Error(`PhysicsWorld: unknown handle ${handle}`)
+        if (reg.isStatic || !reg.spring) {
+            Matter.Body.setPosition(reg.body, anchor)
+            reg.anchor = { ...anchor }
+            return
+        }
         reg.anchor = { ...anchor }
         reg.spring.pointA!.x = anchor.x
         reg.spring.pointA!.y = anchor.y
@@ -187,6 +221,7 @@ export class PhysicsWorld {
     setMode(handle: PhysicsHandle, mode: CardMode): void {
         const reg = this.registrations.get(handle)
         if (!reg) throw new Error(`PhysicsWorld: unknown handle ${handle}`)
+        if (reg.isStatic || !reg.spring) return
         reg.mode = mode
         reg.spring.damping = MODE_DAMPING[mode]
         if (!this.gravityOn) {


### PR DESCRIPTION
## Summary

- **`PhysicsWorld.registerStatic()`** — new method creating a `isStatic: true` Matter.js body with no spring. Guards added to `setGravity`, `setDragging`, `setMode`, `setAnchor`, and `unregister` for static registrations so they stay pinned regardless of gravity state.
- **`controls/theme.ts`** — pure `createThemeController` factory: `system → dark → light → system` cycle, localStorage persistence (`chaipalaka.theme` key), subscribe API. Fully unit-tested (11 tests).
- **`controls/useTheme.ts`** — singleton React hook wrapping the controller; writes `document.documentElement.dataset.theme` on each cycle, clearing it for `system` so the CSS media-query fallback takes over (matching the three-layer token resolution already in `tokens.css`).
- **`controls/ControlsPanel.tsx`** — gravity-exempt physics card mounted in `CanvasLayout`. Default position: bottom-right corner (thumb-reachable). Drag uses `setPosition` directly rather than `setDragging`/toggle (static bodies must never be made dynamic). Final drag position persisted to `localStorage` (`chaipalaka.controls.position`). Panel contains: 4-dot background gallery picker (accent colours from manifest, active dot highlighted), theme cycle button, and gravity toggle stub (no-op; mechanic in slice 19). Collapse/expand via handle chip.

## Notes / deviations

- **Drag on static body**: `PhysicsCard` uses `setDragging(handle, true/false)` which toggles `isStatic`. For a static-registered body we cannot do that (would un-static it). `ControlsPanel` instead calls `setPosition` directly on `pointermove`, skipping `setDragging` entirely. `setDragging` is guarded to be a no-op for static handles.
- **`useTheme` singleton**: mirrors the `useGallery` pattern — one controller per module load, guarded for SSR. `document.documentElement.dataset.theme` is deleted (not set to `""`) for `system` so the `@media (prefers-color-scheme)` rule in `tokens.css` continues to win.
- **Collapse height**: panel registers at `PANEL_H_EXPANDED` or `PANEL_H_COLLAPSED`; collapse/expand tears down and re-registers the physics body so the Matter.js size stays in sync. Position is preserved via `posRef`.

## Acceptance criteria

- [x] `ControlsPanel` renders as a physics card, gravity-exempt
- [x] Position persists in `localStorage`
- [x] Background picker switches the active background; state persists across navigation (gallery is a singleton)
- [x] Theme toggle cycles dark / light / system; respects `prefers-color-scheme` for system (CSS token layer handles it)
- [x] Gravity toggle UI exists; clicking it is a no-op for now (mechanic in slice 19)
- [x] Collapse/expand works via a handle/chip
- [x] On mobile, default position is in thumb reach (bottom-right, 20px from edges)
- [ ] When gravity is on (after slice 19), this card stays put while everything else falls — static body is already in place; slice 19 wires the toggle

## Test plan

```sh
cd web
npm run typecheck   # clean
npm run test        # 90/90 pass (11 new theme tests, 5 new PhysicsWorld static tests)
npm run build       # SSG prerender clean
npm run dev         # open http://localhost:5173 — controls panel in bottom-right
                    # drag panel, reload — position persists
                    # click accent dots — background switches
                    # click theme button — cycles dark/light/system, <html data-theme> updates
                    # click gravity button — no-op (no error)
                    # click ✕ — panel collapses to chip; click ⊞ — expands
```

Closes #18