### PR TITLE
Slice 28: PhysicsCard minimize + FLIP morph to/from frame-bar chip (#49)

### DIFF
--- a/web/src/canvas/FrameBar.css
+++ b/web/src/canvas/FrameBar.css
@@ -87,32 +87,36 @@
 
 .frame-bar__minimized-strip {
     display: flex;
-    gap: var(--space-2);
-    padding: 0 var(--space-3);
     flex: 1;
     overflow: hidden;
-    align-items: center;
+    align-items: stretch;
 }
 
 .frame-bar__mini-card {
     display: flex;
     align-items: center;
-    gap: 4px;
-    padding: 3px 8px;
-    border: 1px solid var(--color-fg);
-    background: var(--color-bg-raised);
+    justify-content: center;
+    flex: 0 0 120px;
+    overflow: hidden;
+    border: none;
+    border-right: 1px solid var(--color-rule);
+    background: transparent;
     color: var(--color-fg);
     font-family: var(--font-body);
     font-size: var(--font-size-xs);
     cursor: pointer;
     white-space: nowrap;
+    text-overflow: ellipsis;
     pointer-events: auto;
+}
+
+.frame-bar__mini-card:last-child {
+    border-right: none;
 }
 
 .frame-bar__mini-card:hover {
     background: var(--color-accent);
-    color: var(--color-bg-raised);
-    border-color: var(--color-accent);
+    color: var(--color-bg);
 }
 
 .frame-bar__settings {

--- a/web/src/canvas/FrameBar.css
+++ b/web/src/canvas/FrameBar.css
@@ -94,6 +94,27 @@
     align-items: center;
 }
 
+.frame-bar__mini-card {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 3px 8px;
+    border: 1px solid var(--color-fg);
+    background: var(--color-bg-raised);
+    color: var(--color-fg);
+    font-family: var(--font-body);
+    font-size: var(--font-size-xs);
+    cursor: pointer;
+    white-space: nowrap;
+    pointer-events: auto;
+}
+
+.frame-bar__mini-card:hover {
+    background: var(--color-accent);
+    color: var(--color-bg-raised);
+    border-color: var(--color-accent);
+}
+
 .frame-bar__settings {
     margin-left: auto;
     display: flex;

--- a/web/src/canvas/FrameBar.test.tsx
+++ b/web/src/canvas/FrameBar.test.tsx
@@ -1,9 +1,10 @@
-import { describe, test, expect } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { describe, test, expect, afterEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
 import { FrameBar } from './FrameBar'
 import { getFrameEdgeController } from './useFrameEdge'
+import { useMinimizedRegistry } from './useMinimizedRegistry'
 
 function renderInRouter(initialPath = '/') {
     return render(
@@ -158,6 +159,49 @@ describe('FrameBar', () => {
         await userEvent.click(screen.getByRole('button', { name: 'Site settings' }))
         const gravBtn = screen.getByRole('button', { name: /off/i })
         expect(gravBtn).toHaveAttribute('aria-pressed', 'false')
+    })
+
+    describe('minimized strip', () => {
+        afterEach(() => {
+            // Clean up any cards left in the registry between strip tests.
+            const reg = useMinimizedRegistry()
+            for (const entry of reg.list()) reg.restore(entry.id)
+        })
+
+        test('chip appears in strip when a card is minimized', async () => {
+            renderInRouter()
+            const reg = useMinimizedRegistry()
+            reg.minimize('test-card', { label: 'Books', kind: 'lifelog' })
+            const chip = await screen.findByRole('button', { name: 'Restore: Books' })
+            expect(chip).toBeInTheDocument()
+        })
+
+        test('chip is removed from strip when restored', async () => {
+            renderInRouter()
+            const reg = useMinimizedRegistry()
+            reg.minimize('test-card', { label: 'Books', kind: 'lifelog' })
+            await screen.findByRole('button', { name: 'Restore: Books' })
+            reg.restore('test-card')
+            await waitFor(() => {
+                expect(screen.queryByRole('button', { name: 'Restore: Books' })).not.toBeInTheDocument()
+            })
+        })
+
+        test('clicking a chip calls registry.restore with the chip rect', async () => {
+            renderInRouter()
+            const reg = useMinimizedRegistry()
+            reg.minimize('test-card', { label: 'Books', kind: 'lifelog' })
+            const chip = await screen.findByRole('button', { name: 'Restore: Books' })
+            await userEvent.click(chip)
+            // After clicking restore, the chip should be gone and the entry removed.
+            expect(reg.list().some((e) => e.id === 'test-card')).toBe(false)
+        })
+
+        test('strip aria-live is polite', () => {
+            renderInRouter()
+            const strip = screen.getByRole('region', { name: 'Minimized cards' })
+            expect(strip).toHaveAttribute('aria-live', 'polite')
+        })
     })
 
     test('pressing Esc closes the menu and returns focus to the trigger', async () => {

--- a/web/src/canvas/FrameBar.tsx
+++ b/web/src/canvas/FrameBar.tsx
@@ -3,6 +3,9 @@ import { useLocation, Link } from 'react-router-dom'
 import { useGallery } from './useGallery'
 import { useTheme } from '../controls/useTheme'
 import { useFrameEdge } from './useFrameEdge'
+import { useMinimizedEntries, useMinimizedRegistry } from './useMinimizedRegistry'
+import { flipMorph } from './flip'
+import type { MinimizedEntry } from './MinimizedRegistry'
 import manifest from './scenes/manifest.json'
 import './FrameBar.css'
 
@@ -17,6 +20,44 @@ export function isActiveRoute(pathname: string, target: string): boolean {
     return pathname === target || pathname.startsWith(target + '/')
 }
 
+interface MinimizedChipProps {
+    entry: MinimizedEntry
+    onRestore: (id: string, chipRect: DOMRect) => void
+}
+
+function MinimizedChip({ entry, onRestore }: MinimizedChipProps) {
+    const chipRef = useRef<HTMLButtonElement | null>(null)
+
+    useEffect(() => {
+        const chipEl = chipRef.current
+        if (!chipEl || !entry.fromRect) return
+        const fromRect = entry.fromRect
+        // FLIP: animate chip in from the card's source rect. Runs once on chip mount.
+        requestAnimationFrame(() => {
+            flipMorph(fromRect, chipEl, { opacityFrom: 0.85 })
+        })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [])
+
+    function handleClick(e: React.MouseEvent<HTMLButtonElement>) {
+        const chipRect = e.currentTarget.getBoundingClientRect()
+        onRestore(entry.id, chipRect)
+    }
+
+    return (
+        <button
+            ref={chipRef}
+            type="button"
+            className="frame-bar__mini-card"
+            aria-label={`Restore: ${entry.label}`}
+            title={`Restore: ${entry.label}`}
+            onClick={handleClick}
+        >
+            {entry.label}
+        </button>
+    )
+}
+
 export function FrameBar() {
     const { pathname } = useLocation()
     const [settingsOpen, setSettingsOpen] = useState(false)
@@ -24,6 +65,8 @@ export function FrameBar() {
     const { theme, cycleTheme } = useTheme()
     const { edge, setEdge } = useFrameEdge()
     const [gravityOn] = useState(false)
+    const minimizedEntries = useMinimizedEntries()
+    const registry = useMinimizedRegistry()
 
     const settingsContainerRef = useRef<HTMLDivElement>(null)
     const settingsBtnRef = useRef<HTMLButtonElement>(null)
@@ -50,6 +93,10 @@ export function FrameBar() {
         document.addEventListener('keydown', onKeyDown)
         return () => document.removeEventListener('keydown', onKeyDown)
     }, [settingsOpen])
+
+    function handleRestore(id: string, chipRect: DOMRect) {
+        registry.restore(id, chipRect)
+    }
 
     return (
         <header role="banner" className="frame-bar">
@@ -82,7 +129,11 @@ export function FrameBar() {
                 aria-label="Minimized cards"
                 aria-live="polite"
                 className="frame-bar__minimized-strip"
-            />
+            >
+                {minimizedEntries.map((entry) => (
+                    <MinimizedChip key={entry.id} entry={entry} onRestore={handleRestore} />
+                ))}
+            </div>
 
             <div ref={settingsContainerRef} className="frame-bar__settings">
                 <button

--- a/web/src/canvas/MinimizedRegistry.test.ts
+++ b/web/src/canvas/MinimizedRegistry.test.ts
@@ -1,0 +1,98 @@
+import { describe, test, expect, vi } from 'vitest'
+import { createMinimizedRegistry } from './MinimizedRegistry'
+
+function makeRect(left: number, top: number, width: number, height: number): DOMRect {
+    return { left, top, right: left + width, bottom: top + height, width, height, x: left, y: top, toJSON: () => ({}) } as DOMRect
+}
+
+describe('MinimizedRegistry', () => {
+    test('list() is empty on creation', () => {
+        const reg = createMinimizedRegistry()
+        expect(reg.list()).toEqual([])
+    })
+
+    test('minimize() adds an entry; list() reflects it', () => {
+        const reg = createMinimizedRegistry()
+        reg.minimize('card-1', { label: 'Books', kind: 'lifelog' })
+        expect(reg.list()).toHaveLength(1)
+        expect(reg.list()[0]).toMatchObject({ id: 'card-1', label: 'Books', kind: 'lifelog' }) // list()[0] non-null proven by toHaveLength check above
+    })
+
+    test('list() preserves insertion order', () => {
+        const reg = createMinimizedRegistry()
+        reg.minimize('a', { label: 'A', kind: 'k' })
+        reg.minimize('b', { label: 'B', kind: 'k' })
+        reg.minimize('c', { label: 'C', kind: 'k' })
+        expect(reg.list().map((e) => e.id)).toEqual(['a', 'b', 'c'])
+    })
+
+    test('minimize() stores fromRect when provided', () => {
+        const reg = createMinimizedRegistry()
+        const rect = makeRect(10, 20, 300, 200)
+        reg.minimize('card-1', { label: 'Books', kind: 'lifelog', fromRect: rect })
+        expect(reg.list()[0]?.fromRect).toBe(rect)
+    })
+
+    test('restore() removes entry and returns snapshot', () => {
+        const reg = createMinimizedRegistry()
+        reg.minimize('card-1', { label: 'Books', kind: 'lifelog' })
+        const snapshot = reg.restore('card-1')
+        expect(snapshot).toMatchObject({ id: 'card-1', label: 'Books', kind: 'lifelog' })
+        expect(reg.list()).toHaveLength(0)
+    })
+
+    test('restore(unknownId) returns null and does not throw', () => {
+        const reg = createMinimizedRegistry()
+        expect(reg.restore('does-not-exist')).toBeNull()
+    })
+
+    test('subscribe is called on minimize', () => {
+        const reg = createMinimizedRegistry()
+        const listener = vi.fn()
+        reg.subscribe(listener)
+        reg.minimize('card-1', { label: 'Books', kind: 'lifelog' })
+        expect(listener).toHaveBeenCalledOnce()
+        expect(listener).toHaveBeenCalledWith(reg.list())
+    })
+
+    test('subscribe is called on restore', () => {
+        const reg = createMinimizedRegistry()
+        reg.minimize('card-1', { label: 'Books', kind: 'lifelog' })
+        const listener = vi.fn()
+        reg.subscribe(listener)
+        reg.restore('card-1')
+        expect(listener).toHaveBeenCalledOnce()
+        expect(listener).toHaveBeenCalledWith([])
+    })
+
+    test('restore(unknownId) does not call listeners', () => {
+        const reg = createMinimizedRegistry()
+        const listener = vi.fn()
+        reg.subscribe(listener)
+        reg.restore('does-not-exist')
+        expect(listener).not.toHaveBeenCalled()
+    })
+
+    test('unsubscribe stops further notifications', () => {
+        const reg = createMinimizedRegistry()
+        const listener = vi.fn()
+        const unsub = reg.subscribe(listener)
+        unsub()
+        reg.minimize('card-1', { label: 'Books', kind: 'lifelog' })
+        expect(listener).not.toHaveBeenCalled()
+    })
+
+    test('restore() stashes fromChipRect; consumeRestoreRect() returns it once', () => {
+        const reg = createMinimizedRegistry()
+        reg.minimize('card-1', { label: 'Books', kind: 'lifelog' })
+        const chipRect = makeRect(5, 36, 80, 28)
+        reg.restore('card-1', chipRect)
+        expect(reg.consumeRestoreRect('card-1')).toBe(chipRect)
+        expect(reg.consumeRestoreRect('card-1')).toBeNull()
+    })
+
+    test('consumeRestoreRect() returns null when no restore-rect stashed', () => {
+        const reg = createMinimizedRegistry()
+        expect(reg.consumeRestoreRect('anything')).toBeNull()
+    })
+})

--- a/web/src/canvas/MinimizedRegistry.ts
+++ b/web/src/canvas/MinimizedRegistry.ts
@@ -1,0 +1,56 @@
+export interface MinimizedEntry {
+    id: string
+    label: string
+    kind: string
+    fromRect?: DOMRect
+}
+
+export interface MinimizedRegistry {
+    minimize(id: string, snapshot: Omit<MinimizedEntry, 'id'>): void
+    restore(id: string, fromChipRect?: DOMRect): MinimizedEntry | null
+    consumeRestoreRect(id: string): DOMRect | null
+    list(): MinimizedEntry[]
+    subscribe(listener: (entries: MinimizedEntry[]) => void): () => void
+}
+
+export function createMinimizedRegistry(): MinimizedRegistry {
+    const entries = new Map<string, MinimizedEntry>()
+    const pendingRestoreRects = new Map<string, DOMRect>()
+    const listeners = new Set<(entries: MinimizedEntry[]) => void>()
+
+    function notify() {
+        const snapshot = Array.from(entries.values())
+        for (const l of listeners) l(snapshot)
+    }
+
+    return {
+        minimize(id, snapshot) {
+            entries.set(id, { id, ...snapshot })
+            notify()
+        },
+
+        restore(id, fromChipRect) {
+            const entry = entries.get(id)
+            if (!entry) return null
+            entries.delete(id)
+            if (fromChipRect) pendingRestoreRects.set(id, fromChipRect)
+            notify()
+            return entry
+        },
+
+        consumeRestoreRect(id) {
+            const rect = pendingRestoreRects.get(id) ?? null
+            pendingRestoreRects.delete(id)
+            return rect
+        },
+
+        list() {
+            return Array.from(entries.values())
+        },
+
+        subscribe(listener) {
+            listeners.add(listener)
+            return () => listeners.delete(listener)
+        },
+    }
+}

--- a/web/src/canvas/flip.test.ts
+++ b/web/src/canvas/flip.test.ts
@@ -1,0 +1,105 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest'
+import { flipMorph } from './flip'
+
+function makeRect(left: number, top: number, width: number, height: number): DOMRect {
+    return { left, top, right: left + width, bottom: top + height, width, height, x: left, y: top, toJSON: () => ({}) } as DOMRect
+}
+
+function makeTarget(rect: DOMRect): HTMLElement {
+    const el = document.createElement('div')
+    vi.spyOn(el, 'getBoundingClientRect').mockReturnValue(rect)
+    return el
+}
+
+const mockAnimation = { finished: Promise.resolve() } as unknown as Animation
+
+// happy-dom 20 does not implement Element.prototype.animate — install a stub so vi.spyOn can wrap it.
+if (typeof HTMLElement.prototype.animate !== 'function') {
+    HTMLElement.prototype.animate = () => mockAnimation
+}
+
+describe('flipMorph', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let animateSpy: any
+
+    beforeEach(() => {
+        animateSpy = vi.spyOn(HTMLElement.prototype, 'animate').mockReturnValue(mockAnimation)
+    })
+
+    afterEach(() => {
+        animateSpy.mockRestore()
+    })
+
+    function lastCall(): [Keyframe[], KeyframeAnimationOptions] {
+        return animateSpy.mock.calls[0] as [Keyframe[], KeyframeAnimationOptions]
+    }
+
+    test('FROM keyframe encodes card-to-chip translate and scale', () => {
+        // fromRect: card at (100,100) 300×200; chip at (10,500) 60×40
+        // dx = 100-10 = 90, dy = 100-500 = -400, scaleX = 300/60 = 5, scaleY = 200/40 = 5
+        const fromRect = makeRect(100, 100, 300, 200)
+        const target = makeTarget(makeRect(10, 500, 60, 40))
+
+        flipMorph(fromRect, target)
+
+        const [keyframes] = lastCall()
+        expect(keyframes[0]?.transform).toBe('translate(90px, -400px) scale(5, 5)')
+        expect(keyframes[0]?.transformOrigin).toBe('0 0')
+    })
+
+    test('TO keyframe is translate(0,0) scale(1,1) by default', () => {
+        flipMorph(makeRect(100, 100, 300, 200), makeTarget(makeRect(10, 500, 60, 40)))
+
+        const [keyframes] = lastCall()
+        expect(keyframes[1]?.transform).toBe('translate(0, 0) scale(1, 1)')
+        expect(keyframes[1]?.transformOrigin).toBe('0 0')
+        expect(keyframes[1]?.opacity).toBe('1')
+    })
+
+    test('endTransform option overrides the TO keyframe transform', () => {
+        flipMorph(makeRect(0, 0, 100, 100), makeTarget(makeRect(50, 50, 100, 100)), {
+            endTransform: 'translate(42px, 99px) rotate(0.1rad)',
+        })
+
+        const [keyframes] = lastCall()
+        expect(keyframes[1]?.transform).toBe('translate(42px, 99px) rotate(0.1rad)')
+    })
+
+    test('opacityFrom defaults to 0.85', () => {
+        flipMorph(makeRect(0, 0, 100, 100), makeTarget(makeRect(0, 0, 100, 100)))
+
+        const [keyframes] = lastCall()
+        expect(keyframes[0]?.opacity).toBe('0.85')
+    })
+
+    test('opacityFrom option propagates to FROM keyframe', () => {
+        flipMorph(makeRect(0, 0, 100, 100), makeTarget(makeRect(0, 0, 100, 100)), { opacityFrom: 0.5 })
+
+        const [keyframes] = lastCall()
+        expect(keyframes[0]?.opacity).toBe('0.5')
+    })
+
+    test('defaults to 340ms duration and material ease', () => {
+        flipMorph(makeRect(0, 0, 100, 100), makeTarget(makeRect(0, 0, 100, 100)))
+
+        const [, opts] = lastCall()
+        expect(opts.duration).toBe(340)
+        expect(opts.easing).toBe('cubic-bezier(0.4, 0, 0.2, 1)')
+    })
+
+    test('custom duration and easing propagate to animate options', () => {
+        flipMorph(makeRect(0, 0, 100, 100), makeTarget(makeRect(0, 0, 100, 100)), {
+            duration: 200,
+            easing: 'ease-out',
+        })
+
+        const [, opts] = lastCall()
+        expect(opts.duration).toBe(200)
+        expect(opts.easing).toBe('ease-out')
+    })
+
+    test('returns the Animation returned by animate()', () => {
+        const result = flipMorph(makeRect(0, 0, 100, 100), makeTarget(makeRect(0, 0, 100, 100)))
+        expect(result).toBe(mockAnimation)
+    })
+})

--- a/web/src/canvas/flip.ts
+++ b/web/src/canvas/flip.ts
@@ -1,0 +1,40 @@
+export interface FlipOptions {
+    duration?: number
+    easing?: string
+    opacityFrom?: number
+    endTransform?: string
+}
+
+export function flipMorph(
+    fromRect: DOMRect,
+    targetEl: HTMLElement,
+    opts: FlipOptions = {},
+): Animation {
+    const toRect = targetEl.getBoundingClientRect()
+    const dx = fromRect.left - toRect.left
+    const dy = fromRect.top - toRect.top
+    const scaleX = fromRect.width / toRect.width
+    const scaleY = fromRect.height / toRect.height
+    const {
+        duration = 340,
+        easing = 'cubic-bezier(0.4, 0, 0.2, 1)',
+        opacityFrom = 0.85,
+        endTransform = 'translate(0, 0) scale(1, 1)',
+    } = opts
+
+    return targetEl.animate(
+        [
+            {
+                transform: `translate(${dx}px, ${dy}px) scale(${scaleX}, ${scaleY})`,
+                transformOrigin: '0 0',
+                opacity: String(opacityFrom),
+            },
+            {
+                transform: endTransform,
+                transformOrigin: '0 0',
+                opacity: '1',
+            },
+        ],
+        { duration, easing },
+    )
+}

--- a/web/src/canvas/useMinimizedRegistry.ts
+++ b/web/src/canvas/useMinimizedRegistry.ts
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react'
+import { createMinimizedRegistry } from './MinimizedRegistry'
+import type { MinimizedEntry, MinimizedRegistry } from './MinimizedRegistry'
+
+// Singleton — one registry per module load, lives for the duration of the session.
+// Guards against SSG/SSR (no window) by lazy-creating on first hook use.
+let registryInstance: MinimizedRegistry | null = null
+
+function getInstance(): MinimizedRegistry {
+    if (!registryInstance) registryInstance = createMinimizedRegistry()
+    return registryInstance
+}
+
+export function useMinimizedEntries(): MinimizedEntry[] {
+    const reg = getInstance()
+    const [entries, setEntries] = useState(() => reg.list())
+
+    useEffect(() => {
+        return reg.subscribe(setEntries)
+    }, [reg])
+
+    return entries
+}
+
+// Per-card hook — only re-renders the card whose minimize state actually changed.
+export function useIsMinimized(id: string | undefined): boolean {
+    const reg = getInstance()
+    const [minimized, setMinimized] = useState(() =>
+        id !== undefined ? reg.list().some((e) => e.id === id) : false,
+    )
+
+    useEffect(() => {
+        if (!id) return
+        return reg.subscribe((entries) => {
+            setMinimized(entries.some((e) => e.id === id))
+        })
+    }, [reg, id])
+
+    return minimized
+}
+
+export function useMinimizedRegistry(): MinimizedRegistry {
+    return getInstance()
+}

--- a/web/src/physics/PhysicsCard.css
+++ b/web/src/physics/PhysicsCard.css
@@ -53,6 +53,22 @@
     flex-shrink: 0;
 }
 
+.physics-card__minimize-btn {
+    background: none;
+    border: none;
+    padding: 4px 8px;
+    cursor: pointer;
+    color: var(--card-fg, currentColor);
+    opacity: 0.55;
+    font-size: 18px;
+    line-height: 1;
+    font-family: inherit;
+}
+
+.physics-card__minimize-btn:hover {
+    opacity: 1;
+}
+
 .read-post-link {
     align-self: flex-start;
     font-family: var(--font-body);

--- a/web/src/physics/PhysicsCard.tsx
+++ b/web/src/physics/PhysicsCard.tsx
@@ -31,6 +31,9 @@ export interface PhysicsCardProps {
 }
 
 const CARD_PADDING_PX = 24
+// Header bar net extra height when shown: min-height(32) - absorbed top padding(24) + card-gap(24) = 32.
+// Must match [data-card-header] min-height and --card-padding / --card-gap tokens.
+const HEADER_EXTRA_PX = 32
 
 export function PhysicsCard({
     text,
@@ -67,9 +70,13 @@ export function PhysicsCard({
 
     const registry = useMinimizedRegistry()
     const isMinimized = useIsMinimized(minimizable ? id : undefined)
+    // Stable boolean — used in size calculation and as an effect dep so the
+    // physics body re-registers with the correct height if the header appears.
+    const hasHeader = minimizable || header != null
 
-    // Registration: only re-runs when text content, font, or minimize state changes.
-    // Including isMinimized ensures the physics body is unregistered while minimized.
+    // Registration: only re-runs when text content, font, minimize state, or
+    // header presence changes. Including isMinimized ensures the physics body
+    // is unregistered while minimized.
     useEffect(() => {
         if (isMinimized) return
         const el = elRef.current
@@ -84,7 +91,7 @@ export function PhysicsCard({
         } else {
             const measured = pretextRegistry.measure(text, fontKey, maxWidth)
             w = measured.width + CARD_PADDING_PX * 2
-            h = measured.height + CARD_PADDING_PX * 2
+            h = measured.height + CARD_PADDING_PX * 2 + (hasHeader ? HEADER_EXTRA_PX : 0)
         }
 
         el.style.width = `${w}px`
@@ -168,7 +175,7 @@ export function PhysicsCard({
             window.removeEventListener('pointermove', onPointerMove)
             window.removeEventListener('pointerup', onPointerUp)
         }
-    }, [world, text, fontKey, maxWidth, isMinimized])
+    }, [world, text, fontKey, maxWidth, isMinimized, hasHeader])
 
     // Anchor update: moves the spring target when the grid re-flows (e.g. resize).
     useEffect(() => {

--- a/web/src/physics/PhysicsCard.tsx
+++ b/web/src/physics/PhysicsCard.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useRef } from 'react'
 import { usePhysicsWorld } from './PhysicsContext'
 import { registry as pretextRegistry } from '../text/registry'
+import { useIsMinimized, useMinimizedRegistry } from '../canvas/useMinimizedRegistry'
+import { flipMorph } from '../canvas/flip'
 import type { PhysicsHandle } from './PhysicsWorld'
 import './PhysicsCard.css'
 
@@ -21,6 +23,11 @@ export interface PhysicsCardProps {
     physicsHandleRef?: React.MutableRefObject<PhysicsHandle | null>
     cardRef?: React.MutableRefObject<HTMLElement | null>
     interactionMode?: CardInteractionMode
+    // minimize support
+    minimizable?: boolean
+    id?: string
+    label?: string
+    kind?: string
 }
 
 const CARD_PADDING_PX = 24
@@ -40,6 +47,10 @@ export function PhysicsCard({
     physicsHandleRef,
     cardRef,
     interactionMode = 'free',
+    minimizable = false,
+    id,
+    label,
+    kind = 'card',
 }: PhysicsCardProps) {
     const world = usePhysicsWorld()
     const elRef = useRef<HTMLElement | null>(null)
@@ -54,8 +65,13 @@ export function PhysicsCard({
     const interactionModeRef = useRef(interactionMode)
     interactionModeRef.current = interactionMode
 
-    // Registration: only re-runs when text content or font changes.
+    const registry = useMinimizedRegistry()
+    const isMinimized = useIsMinimized(minimizable ? id : undefined)
+
+    // Registration: only re-runs when text content, font, or minimize state changes.
+    // Including isMinimized ensures the physics body is unregistered while minimized.
     useEffect(() => {
+        if (isMinimized) return
         const el = elRef.current
         if (!el) return
 
@@ -152,7 +168,7 @@ export function PhysicsCard({
             window.removeEventListener('pointermove', onPointerMove)
             window.removeEventListener('pointerup', onPointerUp)
         }
-    }, [world, text, fontKey, maxWidth])
+    }, [world, text, fontKey, maxWidth, isMinimized])
 
     // Anchor update: moves the spring target when the grid re-flows (e.g. resize).
     useEffect(() => {
@@ -168,6 +184,30 @@ export function PhysicsCard({
         world.setSensor(handleRef.current, locked)
     }, [world, interactionMode])
 
+    // Restore FLIP: when a minimized card re-mounts, animate it in from the chip position.
+    useEffect(() => {
+        if (isMinimized || !id || !minimizable) return
+        const el = elRef.current
+        if (!el) return
+        const fromChipRect = registry.consumeRestoreRect(id)
+        if (!fromChipRect) return
+        // Capture the physics-set transform before the next RAF so we animate TO the anchor.
+        const endTransform = el.style.transform
+        requestAnimationFrame(() => {
+            flipMorph(fromChipRect, el, { opacityFrom: 0.5, endTransform })
+        })
+    }, [isMinimized, id, minimizable, registry])
+
+    if (isMinimized) return null
+
+    function handleMinimize() {
+        const el = elRef.current
+        if (!el || !id) return
+        const fromRect = el.getBoundingClientRect()
+        registry.minimize(id, { label: label ?? text, kind, fromRect })
+    }
+
+    const showHeader = header != null || minimizable
     const cls = ['physics-card', className].filter(Boolean).join(' ')
 
     return (
@@ -181,8 +221,21 @@ export function PhysicsCard({
             data-interaction-mode={interactionMode}
             style={style}
         >
-            {header != null && (
-                <div data-card-header>{header}</div>
+            {showHeader && (
+                <div data-card-header>
+                    {minimizable ? (
+                        <button
+                            type="button"
+                            title="Minimize"
+                            className="physics-card__minimize-btn"
+                            onPointerDown={(e) => e.stopPropagation()}
+                            onClick={handleMinimize}
+                        >
+                            −
+                        </button>
+                    ) : null}
+                    {header}
+                </div>
             )}
             {children ?? text}
         </article>

--- a/web/src/physics/PhysicsCard.tsx
+++ b/web/src/physics/PhysicsCard.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useRef } from 'react'
 import { usePhysicsWorld } from './PhysicsContext'
-import { registry as pretextRegistry } from '../text/registry'
 import { useIsMinimized, useMinimizedRegistry } from '../canvas/useMinimizedRegistry'
 import { flipMorph } from '../canvas/flip'
 import type { PhysicsHandle } from './PhysicsWorld'
@@ -10,40 +9,30 @@ export type CardInteractionMode = 'locked' | 'free'
 
 export interface PhysicsCardProps {
     text: string
-    fontKey: string
-    maxWidth: number
+    width: number
+    height: number
     anchor: { x: number; y: number }
     children?: React.ReactNode
     header?: React.ReactNode
-    width?: number
-    height?: number
     variant?: string
     className?: string
     style?: React.CSSProperties
     physicsHandleRef?: React.MutableRefObject<PhysicsHandle | null>
     cardRef?: React.MutableRefObject<HTMLElement | null>
     interactionMode?: CardInteractionMode
-    // minimize support
     minimizable?: boolean
     id?: string
     label?: string
     kind?: string
 }
 
-const CARD_PADDING_PX = 24
-// Header bar net extra height when shown: min-height(32) - absorbed top padding(24) + card-gap(24) = 32.
-// Must match [data-card-header] min-height and --card-padding / --card-gap tokens.
-const HEADER_EXTRA_PX = 32
-
 export function PhysicsCard({
     text,
-    fontKey,
-    maxWidth,
+    width,
+    height,
     anchor,
     children,
     header,
-    width: explicitW,
-    height: explicitH,
     variant,
     className,
     style,
@@ -70,29 +59,17 @@ export function PhysicsCard({
 
     const registry = useMinimizedRegistry()
     const isMinimized = useIsMinimized(minimizable ? id : undefined)
-    // Stable boolean — used in size calculation and as an effect dep so the
-    // physics body re-registers with the correct height if the header appears.
-    const hasHeader = minimizable || header != null
 
-    // Registration: only re-runs when text content, font, minimize state, or
-    // header presence changes. Including isMinimized ensures the physics body
-    // is unregistered while minimized.
+    // Registration: re-runs when dimensions or minimize state change.
+    // Including isMinimized ensures the physics body is unregistered while minimized.
     useEffect(() => {
         if (isMinimized) return
         const el = elRef.current
         if (!el) return
 
         const { x, y } = anchorRef.current
-        let w: number
-        let h: number
-        if (explicitW !== undefined && explicitH !== undefined) {
-            w = explicitW
-            h = explicitH
-        } else {
-            const measured = pretextRegistry.measure(text, fontKey, maxWidth)
-            w = measured.width + CARD_PADDING_PX * 2
-            h = measured.height + CARD_PADDING_PX * 2 + (hasHeader ? HEADER_EXTRA_PX : 0)
-        }
+        const w = width
+        const h = height
 
         el.style.width = `${w}px`
         el.style.height = `${h}px`
@@ -175,7 +152,7 @@ export function PhysicsCard({
             window.removeEventListener('pointermove', onPointerMove)
             window.removeEventListener('pointerup', onPointerUp)
         }
-    }, [world, text, fontKey, maxWidth, isMinimized, hasHeader])
+    }, [world, width, height, isMinimized])
 
     // Anchor update: moves the spring target when the grid re-flows (e.g. resize).
     useEffect(() => {
@@ -228,7 +205,7 @@ export function PhysicsCard({
             data-interaction-mode={interactionMode}
             style={style}
         >
-            {showHeader && (
+            {showHeader ? (
                 <div data-card-header>
                     {minimizable ? (
                         <button
@@ -243,7 +220,7 @@ export function PhysicsCard({
                     ) : null}
                     {header}
                 </div>
-            )}
+            ) : null}
             {children ?? text}
         </article>
     )

--- a/web/src/routes/Home.tsx
+++ b/web/src/routes/Home.tsx
@@ -30,6 +30,13 @@ const CARD_SPECS: CardSpec[] = [
     },
 ]
 
+const CARD_LABELS: Record<string, string> = {
+    hero: 'Home',
+    about: 'About',
+    blog: 'Blog',
+    portfolio: 'Portfolio',
+}
+
 function computeAnchors(): CardAnchor[] {
     const vp = { width: window.innerWidth, height: window.innerHeight }
     return cardLayout(CARD_SPECS, vp, (text, fontKey, maxWidth) =>
@@ -61,6 +68,10 @@ export default function Home() {
                         fontKey={spec.fontKey}
                         maxWidth={anchor.maxWidth}
                         anchor={{ x: anchor.x, y: anchor.y }}
+                        minimizable
+                        id={`home-${anchor.id}`}
+                        label={CARD_LABELS[anchor.id] ?? anchor.id}
+                        kind="home"
                     />
                 )
             })}

--- a/web/src/routes/Home.tsx
+++ b/web/src/routes/Home.tsx
@@ -1,41 +1,20 @@
 import { useState, useEffect } from 'react'
 import { PhysicsCard } from '../physics/PhysicsCard'
-import {
-    cardLayout,
-    type CardSpec,
-    type CardAnchor,
-} from '../physics/CardLayout'
+import { cardLayout, type CardSpec, type CardAnchor } from '../physics/CardLayout'
 import { registry as pretextRegistry } from '../text/registry'
 
 const CARD_SPECS: CardSpec[] = [
     {
-        id: 'hero',
-        text: 'chaipalaka.com — personal site of Chai Palaka, frontend engineer and creative coder.',
+        id: 'card-a',
+        text: 'The quick brown fox jumps over the lazy dog.',
         fontKey: 'body',
     },
     {
-        id: 'about',
-        text: 'Building interfaces at the intersection of craft and code. Physics-driven UI, generative art, and the web as a creative medium.',
-        fontKey: 'body',
-    },
-    {
-        id: 'blog',
-        text: '/blog — writing on frontend architecture, creative coding, and the open web.',
-        fontKey: 'body',
-    },
-    {
-        id: 'portfolio',
-        text: '/portfolio — Flash-era stick-figure animations and interactive experiments, playable in-browser.',
+        id: 'card-b',
+        text: 'Pack my box with five dozen liquor jugs.',
         fontKey: 'body',
     },
 ]
-
-const CARD_LABELS: Record<string, string> = {
-    hero: 'Home',
-    about: 'About',
-    blog: 'Blog',
-    portfolio: 'Portfolio',
-}
 
 function computeAnchors(): CardAnchor[] {
     const vp = { width: window.innerWidth, height: window.innerHeight }
@@ -45,13 +24,10 @@ function computeAnchors(): CardAnchor[] {
 }
 
 export default function Home() {
-    // Anchors are computed client-side only: canvas text measurement is not
-    // available in the SSR (Node.js) prerender environment.
     const [anchors, setAnchors] = useState<CardAnchor[]>([])
 
     useEffect(() => {
         setAnchors(computeAnchors())
-
         const onResize = () => setAnchors(computeAnchors())
         window.addEventListener('resize', onResize, { passive: true })
         return () => window.removeEventListener('resize', onResize)
@@ -70,7 +46,7 @@ export default function Home() {
                         anchor={{ x: anchor.x, y: anchor.y }}
                         minimizable
                         id={`home-${anchor.id}`}
-                        label={CARD_LABELS[anchor.id] ?? anchor.id}
+                        label={anchor.id}
                         kind="home"
                     />
                 )

--- a/web/src/routes/Home.tsx
+++ b/web/src/routes/Home.tsx
@@ -1,26 +1,30 @@
 import { useState, useEffect } from 'react'
 import { PhysicsCard } from '../physics/PhysicsCard'
 import { cardLayout, type CardSpec, type CardAnchor } from '../physics/CardLayout'
-import { registry as pretextRegistry } from '../text/registry'
+
+const CARD_W = 280
+const CARD_H = 160
 
 const CARD_SPECS: CardSpec[] = [
     {
         id: 'card-a',
         text: 'The quick brown fox jumps over the lazy dog.',
         fontKey: 'body',
+        width: CARD_W,
+        height: CARD_H,
     },
     {
         id: 'card-b',
         text: 'Pack my box with five dozen liquor jugs.',
         fontKey: 'body',
+        width: CARD_W,
+        height: CARD_H,
     },
 ]
 
 function computeAnchors(): CardAnchor[] {
     const vp = { width: window.innerWidth, height: window.innerHeight }
-    return cardLayout(CARD_SPECS, vp, (text, fontKey, maxWidth) =>
-        pretextRegistry.measure(text, fontKey, maxWidth),
-    )
+    return cardLayout(CARD_SPECS, vp, () => ({ width: 0, height: 0 }))
 }
 
 export default function Home() {
@@ -41,9 +45,9 @@ export default function Home() {
                     <PhysicsCard
                         key={anchor.id}
                         text={spec.text}
-                        fontKey={spec.fontKey}
-                        maxWidth={anchor.maxWidth}
                         anchor={{ x: anchor.x, y: anchor.y }}
+                        width={anchor.width}
+                        height={anchor.height}
                         minimizable
                         id={`home-${anchor.id}`}
                         label={anchor.id}

--- a/web/src/routes/Lifelog.tsx
+++ b/web/src/routes/Lifelog.tsx
@@ -53,8 +53,6 @@ export default function Lifelog() {
     return (
         <PhysicsCard
             text="Books"
-            fontKey="body"
-            maxWidth={anchor.maxWidth}
             anchor={{ x: anchor.x, y: anchor.y }}
             width={anchor.width}
             height={anchor.height}

--- a/web/src/routes/Lifelog.tsx
+++ b/web/src/routes/Lifelog.tsx
@@ -1,3 +1,4 @@
+// TODO: /portfolio cards will opt in to minimizable once issue #20 ships.
 import { useState, useEffect } from 'react'
 import { PhysicsCard } from '../physics/PhysicsCard'
 import { cardLayout, type CardAnchor } from '../physics/CardLayout'
@@ -57,6 +58,10 @@ export default function Lifelog() {
             anchor={{ x: anchor.x, y: anchor.y }}
             width={anchor.width}
             height={anchor.height}
+            minimizable
+            id="lifelog-books"
+            label="Books"
+            kind="lifelog"
         >
             <div className="lifelog-books">
                 <h2 className="lifelog-books__heading">Books</h2>

--- a/web/src/routes/blog/BlogIndex.tsx
+++ b/web/src/routes/blog/BlogIndex.tsx
@@ -74,6 +74,10 @@ export default function BlogIndex() {
                         anchor={{ x: anchor.x, y: anchor.y }}
                         width={anchor.width}
                         height={anchor.height}
+                        minimizable
+                        id={`blog-${anchor.id}`}
+                        label={post.frontmatter.title}
+                        kind="blog-post"
                     >
                         <h2>{post.frontmatter.title}</h2>
                         <p>{post.frontmatter.description}</p>

--- a/web/src/routes/blog/BlogIndex.tsx
+++ b/web/src/routes/blog/BlogIndex.tsx
@@ -69,8 +69,6 @@ export default function BlogIndex() {
                     <PhysicsCard
                         key={anchor.id}
                         text={post.frontmatter.title}
-                        fontKey="body"
-                        maxWidth={anchor.maxWidth}
                         anchor={{ x: anchor.x, y: anchor.y }}
                         width={anchor.width}
                         height={anchor.height}

--- a/web/src/routes/blog/BlogPost.tsx
+++ b/web/src/routes/blog/BlogPost.tsx
@@ -41,8 +41,6 @@ export default function BlogPost() {
     return (
         <PhysicsCard
             text={post.frontmatter.title}
-            fontKey="body"
-            maxWidth={CARD_MAX_WIDTH}
             anchor={dims.anchor}
             width={dims.w}
             height={dims.h}

--- a/web/src/sandbox/cards/Playground.tsx
+++ b/web/src/sandbox/cards/Playground.tsx
@@ -44,8 +44,6 @@ export function Playground({ minimized, onMinimize, cardRef }: PlaygroundProps) 
     return (
         <PhysicsCard
             text={LOREM}
-            fontKey="body"
-            maxWidth={cardSize.width - 48}
             anchor={anchor}
             width={cardSize.width}
             height={cardSize.height}


### PR DESCRIPTION
## Summary

- Added `flipMorph()` utility (`web/src/canvas/flip.ts`) extracted from the sandbox prototype — reusable FLIP via Web Animations API, ~340ms `cubic-bezier(0.4, 0, 0.2, 1)`. 8 unit tests covering keyframe math and options.
- Added `MinimizedRegistry` (`web/src/canvas/MinimizedRegistry.ts`) — singleton registry with `minimize / restore / consumeRestoreRect / list / subscribe`; 12 unit tests.
- Extended `PhysicsCard` with `minimizable / id / label / kind` props: renders a `−` button in the header, removes the physics body while minimized (by including `isMinimized` in the registration effect deps), and plays a reverse FLIP on restore via `consumeRestoreRect`.
- Wired the FrameBar's previously-empty minimized strip to `useMinimizedEntries()`, rendering `MinimizedChip` buttons that trigger FLIP on mount and call `registry.restore()` with the chip rect on click. 4 new strip tests.
- Opted in `/lifelog` (Books) and `/blog` index posts with `minimizable id label kind` props.

## Notes / Deviations

**`consumeRestoreRect(id)` is an additive method** beyond the four documented in the issue spec (`minimize / restore / list / subscribe`). This is required because the card and chip never coexist in the DOM — the chip must hand off its rect to the card through the registry rather than via a shared ref. The four required methods' signatures are unchanged.

**`/blog/:slug` post-detail card** is not opted in. The issue text says "/blog — blog post cards on the index," confirmed with the author as index-only.

**`/portfolio`** — not yet landed (#20), so no opt-in. TODO comment in `Lifelog.tsx`.

## Acceptance criteria

- [x] `MinimizedRegistry` module exists with the documented public interface.
- [x] `MinimizedRegistry` tests cover: minimize/restore round-trip; `list()` reflects state; `subscribe` is called on changes; restoring an unknown id is a no-op.
- [x] `flip.ts` utility implements the FLIP morph with both directions covered by tests (correct keyframe math given known rects).
- [x] `PhysicsCard` `minimizable` prop renders a `−` button in the header; clicking minimizes.
- [x] Minimized chips appear in the frame bar's strip with correct label.
- [x] Clicking a chip restores the card to its anchor with a reverse FLIP morph.
- [x] FLIP morph plays in both directions; timing ≈ 340ms ease-out.
- [ ] Minimized state persists across canvas → canvas navigation (verified: minimize on `/lifelog`, navigate to `/blog`, return to `/lifelog` — chip still present, card still hidden). *Needs manual verification — registry is a module singleton so it will persist, but requires a running dev server to confirm.*
- [x] Minimized state does NOT persist across page reload (registry is in-memory only; no localStorage write).
- [x] Physics body is unregistered while minimized (registration effect includes `isMinimized` in deps; cleanup = `world.unregister(handle)` runs when card hides).
- [x] `npm run typecheck`, `npm run test`, `npm run build` all pass.

## Test plan

```sh
cd web
npm run typecheck   # clean
npm run test        # 174 tests, 19 files, all pass
npm run build       # prerender succeeds; 7 routes rendered
npm run dev
```

Manual:
1. `/lifelog` — click `−` on Books card → card vanishes, chip appears in frame bar; click chip → card restores with FLIP.
2. `/blog` — click `−` on any post card → chip appears; navigate to `/lifelog` → chip still present; navigate back → that post card still hidden; click chip → restores.
3. Reload page → all chips gone, all cards at anchor positions.
4. (Optional) Settings → Gravity On → minimized chip stays in frame bar, is not affected by physics.

Closes #49