### PR TITLE
Slice: gravity-always-on + strings primitive (#56)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -117,6 +117,13 @@ export const routes: RouteRecord[] = [
         },
     },
     {
+        path: '/sandbox/strings',
+        lazy: async () => {
+            const { default: Strings } = await import('./routes/sandbox/Strings')
+            return { Component: Strings }
+        },
+    },
+    {
         path: '/blog/:slug/read',
         lazy: async () => {
             const { default: PlainLayout } =

--- a/web/src/canvas/FrameBar.css
+++ b/web/src/canvas/FrameBar.css
@@ -119,6 +119,13 @@
     color: var(--color-bg);
 }
 
+.frame-bar__mini-card-badge {
+    margin-left: 4px;
+    font-size: var(--font-size-xs);
+    opacity: 0.65;
+    flex-shrink: 0;
+}
+
 .frame-bar__settings {
     margin-left: auto;
     display: flex;

--- a/web/src/canvas/FrameBar.test.tsx
+++ b/web/src/canvas/FrameBar.test.tsx
@@ -94,13 +94,12 @@ describe('FrameBar', () => {
         expect(screen.getByRole('navigation', { name: 'Section nav' })).toBeInTheDocument()
     })
 
-    test('settings menu shows all four control groups when open', async () => {
+    test('settings menu shows three control groups when open', async () => {
         renderInRouter()
         await userEvent.click(screen.getByRole('button', { name: 'Site settings' }))
         expect(screen.getByText('Background')).toBeInTheDocument()
         expect(screen.getByText('Color mode')).toBeInTheDocument()
         expect(screen.getByText('Frame edge')).toBeInTheDocument()
-        expect(screen.getByText('Gravity')).toBeInTheDocument()
     })
 
     test('background select has all four scene options', async () => {
@@ -154,11 +153,10 @@ describe('FrameBar', () => {
         await userEvent.selectOptions(select, original)
     })
 
-    test('gravity button renders as placeholder with aria-pressed="false"', async () => {
+    test('gravity toggle is absent (gravity is always on per ADR 0001)', async () => {
         renderInRouter()
         await userEvent.click(screen.getByRole('button', { name: 'Site settings' }))
-        const gravBtn = screen.getByRole('button', { name: /off/i })
-        expect(gravBtn).toHaveAttribute('aria-pressed', 'false')
+        expect(screen.queryByText('Gravity')).not.toBeInTheDocument()
     })
 
     describe('minimized strip', () => {

--- a/web/src/canvas/FrameBar.tsx
+++ b/web/src/canvas/FrameBar.tsx
@@ -44,16 +44,22 @@ function MinimizedChip({ entry, onRestore }: MinimizedChipProps) {
         onRestore(entry.id, chipRect)
     }
 
+    const badge = entry.subtreeSize > 1 ? `+${entry.subtreeSize - 1}` : null
+    const ariaLabel = badge
+        ? `Restore: ${entry.label} (${badge} more)`
+        : `Restore: ${entry.label}`
+
     return (
         <button
             ref={chipRef}
             type="button"
             className="frame-bar__mini-card"
-            aria-label={`Restore: ${entry.label}`}
-            title={`Restore: ${entry.label}`}
+            aria-label={ariaLabel}
+            title={ariaLabel}
             onClick={handleClick}
         >
             {entry.label}
+            {badge ? <span className="frame-bar__mini-card-badge">{badge}</span> : null}
         </button>
     )
 }
@@ -64,7 +70,6 @@ export function FrameBar() {
     const { active, setActive } = useGallery()
     const { theme, cycleTheme } = useTheme()
     const { edge, setEdge } = useFrameEdge()
-    const [gravityOn] = useState(false)
     const minimizedEntries = useMinimizedEntries()
     const registry = useMinimizedRegistry()
 
@@ -218,22 +223,6 @@ export function FrameBar() {
                             </select>
                         </div>
 
-                        <div
-                            role="group"
-                            aria-labelledby="fb-grav-label"
-                            className="frame-bar__menu-group"
-                        >
-                            <span id="fb-grav-label" className="frame-bar__menu-label">
-                                Gravity
-                            </span>
-                            <button
-                                type="button"
-                                className="frame-bar__menu-toggle"
-                                aria-pressed={gravityOn}
-                            >
-                                {gravityOn ? 'On' : 'Off'}
-                            </button>
-                        </div>
                     </div>
                 ) : null}
             </div>

--- a/web/src/canvas/MinimizedRegistry.test.ts
+++ b/web/src/canvas/MinimizedRegistry.test.ts
@@ -95,4 +95,69 @@ describe('MinimizedRegistry', () => {
         const reg = createMinimizedRegistry()
         expect(reg.consumeRestoreRect('anything')).toBeNull()
     })
+
+    test('minimize sets members=[id] and subtreeSize=1 for standalone card', () => {
+        const reg = createMinimizedRegistry()
+        reg.minimize('solo', { label: 'Solo', kind: 'card', fromRect: makeRect(0, 0, 100, 50) })
+        const e = reg.list()[0]!
+        expect(e.members).toEqual(['solo'])
+        expect(e.subtreeSize).toBe(1)
+    })
+})
+
+describe('MinimizedRegistry string topology', () => {
+    test('registerString: minimizing a leaf produces members=[id], subtreeSize=1', () => {
+        const reg = createMinimizedRegistry()
+        reg.registerString('child', 'parent')
+        reg.minimize('child', { label: 'Child', kind: 'card', fromRect: makeRect(0, 0, 100, 50) })
+        const e = reg.list()[0]!
+        expect(e.members).toEqual(['child'])
+        expect(e.subtreeSize).toBe(1)
+    })
+
+    test('minimize a parent cascades to children; one entry; members includes all; subtreeSize correct', () => {
+        const reg = createMinimizedRegistry()
+        reg.registerString('child-a', 'parent')
+        reg.registerString('child-b', 'parent')
+        reg.minimize('parent', { label: 'Parent', kind: 'card', fromRect: makeRect(0, 0, 100, 50) })
+        const entries = reg.list()
+        expect(entries).toHaveLength(1)
+        expect(entries[0]!.id).toBe('parent')
+        expect(entries[0]!.members).toContain('parent')
+        expect(entries[0]!.members).toContain('child-a')
+        expect(entries[0]!.members).toContain('child-b')
+        expect(entries[0]!.subtreeSize).toBe(3)
+    })
+
+    test('restore a cascaded group removes the entry and stashes chip rect for each member', () => {
+        const reg = createMinimizedRegistry()
+        reg.registerString('child-a', 'parent')
+        reg.minimize('parent', { label: 'Parent', kind: 'card', fromRect: makeRect(0, 0, 100, 50) })
+        const chip = makeRect(5, 36, 80, 28)
+        reg.restore('parent', chip)
+        expect(reg.list()).toHaveLength(0)
+        expect(reg.consumeRestoreRect('parent')).toBe(chip)
+        expect(reg.consumeRestoreRect('child-a')).toBe(chip)
+    })
+
+    test('unregisterString removes child from future cascade', () => {
+        const reg = createMinimizedRegistry()
+        reg.registerString('child-a', 'parent')
+        reg.registerString('child-b', 'parent')
+        reg.unregisterString('child-b')
+        reg.minimize('parent', { label: 'Parent', kind: 'card', fromRect: makeRect(0, 0, 100, 50) })
+        const e = reg.list()[0]!
+        expect(e.members).not.toContain('child-b')
+        expect(e.subtreeSize).toBe(2)
+    })
+
+    test('cascade is recursive: grandchildren are included', () => {
+        const reg = createMinimizedRegistry()
+        reg.registerString('child', 'parent')
+        reg.registerString('grandchild', 'child')
+        reg.minimize('parent', { label: 'Parent', kind: 'card', fromRect: makeRect(0, 0, 100, 50) })
+        const e = reg.list()[0]!
+        expect(e.members).toContain('grandchild')
+        expect(e.subtreeSize).toBe(3)
+    })
 })

--- a/web/src/canvas/MinimizedRegistry.ts
+++ b/web/src/canvas/MinimizedRegistry.ts
@@ -3,29 +3,63 @@ export interface MinimizedEntry {
     label: string
     kind: string
     fromRect?: DOMRect
+    members: string[]
+    subtreeSize: number
 }
 
 export interface MinimizedRegistry {
-    minimize(id: string, snapshot: Omit<MinimizedEntry, 'id'>): void
+    minimize(id: string, snapshot: Omit<MinimizedEntry, 'id' | 'members' | 'subtreeSize'>): void
     restore(id: string, fromChipRect?: DOMRect): MinimizedEntry | null
     consumeRestoreRect(id: string): DOMRect | null
     list(): MinimizedEntry[]
     subscribe(listener: (entries: MinimizedEntry[]) => void): () => void
+    registerString(cardId: string, parentId: string): void
+    unregisterString(cardId: string): void
 }
 
 export function createMinimizedRegistry(): MinimizedRegistry {
     const entries = new Map<string, MinimizedEntry>()
     const pendingRestoreRects = new Map<string, DOMRect>()
     const listeners = new Set<(entries: MinimizedEntry[]) => void>()
+    const parents = new Map<string, string>()
+    const children = new Map<string, Set<string>>()
 
     function notify() {
         const snapshot = Array.from(entries.values())
         for (const l of listeners) l(snapshot)
     }
 
+    function subtree(rootId: string): string[] {
+        const result: string[] = []
+        const queue = [rootId]
+        while (queue.length > 0) {
+            const id = queue.shift()!
+            result.push(id)
+            const kids = children.get(id)
+            if (kids) for (const c of kids) queue.push(c)
+        }
+        return result
+    }
+
     return {
+        registerString(cardId, parentId) {
+            parents.set(cardId, parentId)
+            if (!children.has(parentId)) children.set(parentId, new Set())
+            children.get(parentId)!.add(cardId)
+        },
+
+        unregisterString(cardId) {
+            const parentId = parents.get(cardId)
+            if (parentId !== undefined) {
+                children.get(parentId)?.delete(cardId)
+                parents.delete(cardId)
+            }
+            children.delete(cardId)
+        },
+
         minimize(id, snapshot) {
-            entries.set(id, { id, ...snapshot })
+            const members = subtree(id)
+            entries.set(id, { id, ...snapshot, members, subtreeSize: members.length })
             notify()
         },
 
@@ -33,7 +67,11 @@ export function createMinimizedRegistry(): MinimizedRegistry {
             const entry = entries.get(id)
             if (!entry) return null
             entries.delete(id)
-            if (fromChipRect) pendingRestoreRects.set(id, fromChipRect)
+            if (fromChipRect) {
+                for (const memberId of entry.members) {
+                    pendingRestoreRects.set(memberId, fromChipRect)
+                }
+            }
             notify()
             return entry
         },

--- a/web/src/canvas/StringLayer.css
+++ b/web/src/canvas/StringLayer.css
@@ -1,0 +1,16 @@
+.string-layer {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    z-index: 2;
+    overflow: visible;
+}
+
+.string-layer__string {
+    fill: none;
+    stroke: var(--color-fg);
+    stroke-width: 1;
+    opacity: 0.4;
+}

--- a/web/src/canvas/StringLayer.test.tsx
+++ b/web/src/canvas/StringLayer.test.tsx
@@ -1,0 +1,38 @@
+import { describe, test, expect } from 'vitest'
+import { render, cleanup } from '@testing-library/react'
+import { PhysicsProvider } from '../physics/PhysicsContext'
+import { PhysicsCard } from '../physics/PhysicsCard'
+import { StringLayer } from './StringLayer'
+
+describe('StringLayer', () => {
+    // Regression for: opening /sandbox/strings crashed with "Maximum update depth exceeded"
+    // because getSnapshot returned a fresh array each call. The fix uses getTetherList(),
+    // which returns a stable reference until the tether set changes.
+    test('mounts under PhysicsProvider without triggering an infinite render loop', () => {
+        expect(() =>
+            render(
+                <PhysicsProvider>
+                    <StringLayer />
+                    <PhysicsCard
+                        id="parent"
+                        text="P"
+                        width={80}
+                        height={40}
+                        anchor={{ x: 100, y: 100 }}
+                        parent="ceiling"
+                        buoyancy="heavy"
+                    />
+                    <PhysicsCard
+                        text="C"
+                        width={80}
+                        height={40}
+                        anchor={{ x: 100, y: 200 }}
+                        parent="parent"
+                        buoyancy="heavy"
+                    />
+                </PhysicsProvider>,
+            ),
+        ).not.toThrow()
+        cleanup()
+    })
+})

--- a/web/src/canvas/StringLayer.tsx
+++ b/web/src/canvas/StringLayer.tsx
@@ -7,24 +7,28 @@ export function StringLayer() {
     const svgRef = useRef<SVGSVGElement | null>(null)
     const pathRefs = useRef<Map<string, SVGPathElement>>(new Map())
 
-    // Re-render only when the SET of tethers changes (mount/unmount of strung cards)
-    const tethers = useSyncExternalStore(
+    // Re-render only when the SET of tethers changes (mount/unmount of strung cards).
+    // Use getTetherList() (cached, stable reference) — getTethers() builds a fresh array
+    // each call and would cause an infinite useSyncExternalStore re-render loop.
+    const tetherList = useSyncExternalStore(
         (cb) => world.subscribeTetherSetChange(cb),
-        () => world.getTethers(),
-        () => world.getTethers(),
+        () => world.getTetherList(),
+        () => world.getTetherList(),
     )
 
     // Per-frame mutation of path `d` attributes — no React re-renders
     useEffect(() => {
         const svg = svgRef.current
         if (!svg) return
-        const g = world.getGravityVector()
-        const gLen = Math.hypot(g.x, g.y)
-        const gx = gLen > 0 ? g.x / gLen : 0
-        const gy = gLen > 0 ? g.y / gLen : 1
 
         let raf = 0
         const frame = () => {
+            // Re-read gravity every frame so direction changes are reflected immediately
+            const g = world.getGravityVector()
+            const gLen = Math.hypot(g.x, g.y)
+            const gx = gLen > 0 ? g.x / gLen : 0
+            const gy = gLen > 0 ? g.y / gLen : 1
+
             const views = world.getTethers()
             for (let i = 0; i < views.length; i++) {
                 const v = views[i]!
@@ -51,13 +55,13 @@ export function StringLayer() {
         }
         raf = requestAnimationFrame(frame)
         return () => cancelAnimationFrame(raf)
-    }, [world, tethers])
+    }, [world, tetherList])
 
     return (
         <svg ref={svgRef} className="string-layer" aria-hidden="true">
-            {tethers.map((_, i) => (
+            {tetherList.map((handle, i) => (
                 <path
-                    key={i}
+                    key={handle}
                     ref={(el) => {
                         if (el) pathRefs.current.set(String(i), el)
                         else pathRefs.current.delete(String(i))

--- a/web/src/canvas/StringLayer.tsx
+++ b/web/src/canvas/StringLayer.tsx
@@ -1,0 +1,70 @@
+import { useEffect, useRef, useSyncExternalStore } from 'react'
+import { usePhysicsWorld } from '../physics/PhysicsContext'
+import './StringLayer.css'
+
+export function StringLayer() {
+    const world = usePhysicsWorld()
+    const svgRef = useRef<SVGSVGElement | null>(null)
+    const pathRefs = useRef<Map<string, SVGPathElement>>(new Map())
+
+    // Re-render only when the SET of tethers changes (mount/unmount of strung cards)
+    const tethers = useSyncExternalStore(
+        (cb) => world.subscribeTetherSetChange(cb),
+        () => world.getTethers(),
+        () => world.getTethers(),
+    )
+
+    // Per-frame mutation of path `d` attributes — no React re-renders
+    useEffect(() => {
+        const svg = svgRef.current
+        if (!svg) return
+        const g = world.getGravityVector()
+        const gLen = Math.hypot(g.x, g.y)
+        const gx = gLen > 0 ? g.x / gLen : 0
+        const gy = gLen > 0 ? g.y / gLen : 1
+
+        let raf = 0
+        const frame = () => {
+            const views = world.getTethers()
+            for (let i = 0; i < views.length; i++) {
+                const v = views[i]!
+                const key = String(i)
+                const pathEl = pathRefs.current.get(key)
+                if (!pathEl) continue
+                const { parentPos: A, childPos: B, length: L, slack } = v
+                let d: string
+                if (!slack) {
+                    d = `M ${A.x},${A.y} L ${B.x},${B.y}`
+                } else {
+                    // Cubic bezier with gravity-direction sag
+                    const dist = Math.hypot(B.x - A.x, B.y - A.y)
+                    const sag = Math.max((L - dist) * 0.5, 0)
+                    const c1x = A.x + (B.x - A.x) / 3 + gx * sag
+                    const c1y = A.y + (B.y - A.y) / 3 + gy * sag
+                    const c2x = A.x + (2 * (B.x - A.x)) / 3 + gx * sag
+                    const c2y = A.y + (2 * (B.y - A.y)) / 3 + gy * sag
+                    d = `M ${A.x},${A.y} C ${c1x},${c1y} ${c2x},${c2y} ${B.x},${B.y}`
+                }
+                pathEl.setAttribute('d', d)
+            }
+            raf = requestAnimationFrame(frame)
+        }
+        raf = requestAnimationFrame(frame)
+        return () => cancelAnimationFrame(raf)
+    }, [world, tethers])
+
+    return (
+        <svg ref={svgRef} className="string-layer" aria-hidden="true">
+            {tethers.map((_, i) => (
+                <path
+                    key={i}
+                    ref={(el) => {
+                        if (el) pathRefs.current.set(String(i), el)
+                        else pathRefs.current.delete(String(i))
+                    }}
+                    className="string-layer__string"
+                />
+            ))}
+        </svg>
+    )
+}

--- a/web/src/canvas/useMinimizedRegistry.ts
+++ b/web/src/canvas/useMinimizedRegistry.ts
@@ -26,13 +26,13 @@ export function useMinimizedEntries(): MinimizedEntry[] {
 export function useIsMinimized(id: string | undefined): boolean {
     const reg = getInstance()
     const [minimized, setMinimized] = useState(() =>
-        id !== undefined ? reg.list().some((e) => e.id === id) : false,
+        id !== undefined ? reg.list().some((e) => e.members.includes(id)) : false,
     )
 
     useEffect(() => {
         if (!id) return
         return reg.subscribe((entries) => {
-            setMinimized(entries.some((e) => e.id === id))
+            setMinimized(entries.some((e) => e.members.includes(id)))
         })
     }, [reg, id])
 

--- a/web/src/physics/PageDef.ts
+++ b/web/src/physics/PageDef.ts
@@ -1,0 +1,17 @@
+export type Cardinal = 'down' | 'up' | 'left' | 'right'
+export type Buoyancy = 'heavy' | 'balloon'
+export type ParentRef = 'ceiling' | 'floor' | string
+
+export interface CardSpec {
+    id: string
+    width: number
+    height: number
+    parent?: ParentRef
+    buoyancy?: Buoyancy
+    minimizable?: boolean
+}
+
+export interface PageDef {
+    gravity: Cardinal
+    cards: CardSpec[]
+}

--- a/web/src/physics/PhysicsCard.tsx
+++ b/web/src/physics/PhysicsCard.tsx
@@ -2,10 +2,9 @@ import { useEffect, useRef } from 'react'
 import { usePhysicsWorld } from './PhysicsContext'
 import { useIsMinimized, useMinimizedRegistry } from '../canvas/useMinimizedRegistry'
 import { flipMorph } from '../canvas/flip'
-import type { PhysicsHandle } from './PhysicsWorld'
+import type { PhysicsHandle, TetherHandle } from './PhysicsWorld'
+import type { Buoyancy, ParentRef } from './PageDef'
 import './PhysicsCard.css'
-
-export type CardInteractionMode = 'locked' | 'free'
 
 export interface PhysicsCardProps {
     text: string
@@ -19,11 +18,12 @@ export interface PhysicsCardProps {
     style?: React.CSSProperties
     physicsHandleRef?: React.MutableRefObject<PhysicsHandle | null>
     cardRef?: React.MutableRefObject<HTMLElement | null>
-    interactionMode?: CardInteractionMode
     minimizable?: boolean
     id?: string
     label?: string
     kind?: string
+    parent?: ParentRef
+    buoyancy?: Buoyancy
 }
 
 export function PhysicsCard({
@@ -38,30 +38,23 @@ export function PhysicsCard({
     style,
     physicsHandleRef,
     cardRef,
-    interactionMode = 'free',
     minimizable = false,
     id,
     label,
     kind = 'card',
+    parent,
+    buoyancy,
 }: PhysicsCardProps) {
     const world = usePhysicsWorld()
     const elRef = useRef<HTMLElement | null>(null)
     const handleRef = useRef<PhysicsHandle | null>(null)
-    // Keep a ref to the current anchor so the registration effect can read the
-    // latest value without taking it as a dependency (avoids re-registering on
-    // every resize tick while the spring update is handled separately).
     const anchorRef = useRef(anchor)
     anchorRef.current = anchor
-    // Ref so pointer handlers always read the current interactionMode without
-    // being re-registered on every toggle (rerender-use-ref-transient-values).
-    const interactionModeRef = useRef(interactionMode)
-    interactionModeRef.current = interactionMode
+    const tetherHandleRef = useRef<TetherHandle | null>(null)
 
     const registry = useMinimizedRegistry()
     const isMinimized = useIsMinimized(minimizable ? id : undefined)
 
-    // Registration: re-runs when dimensions or minimize state change.
-    // Including isMinimized ensures the physics body is unregistered while minimized.
     useEffect(() => {
         if (isMinimized) return
         const el = elRef.current
@@ -75,17 +68,52 @@ export function PhysicsCard({
         el.style.height = `${h}px`
         el.style.transform = `translate(${x - w / 2}px, ${y - h / 2}px)`
 
-        const handle = world.register(
-            { x, y },
-            { width: w, height: h },
-            {
+        const handle = id
+            ? world.registerById(id, { x, y }, { width: w, height: h }, {
                 onTransform: ({ x: px, y: py, rotation }) => {
                     el.style.transform = `translate(${px - w / 2}px, ${py - h / 2}px) rotate(${rotation}rad)`
                 },
-            },
-        )
+            })
+            : world.register(
+                { x, y },
+                { width: w, height: h },
+                {
+                    onTransform: ({ x: px, y: py, rotation }) => {
+                        el.style.transform = `translate(${px - w / 2}px, ${py - h / 2}px) rotate(${rotation}rad)`
+                    },
+                },
+            )
         handleRef.current = handle
         if (physicsHandleRef) physicsHandleRef.current = handle
+
+        if (buoyancy) world.setBuoyancy(handle, buoyancy)
+
+        // Wire tether if parent declared
+        let rafId = 0
+        const wireTether = (parentHandle: number) => {
+            const parentPos = world.getPosition(parentHandle)
+            const ca = anchorRef.current
+            const length = Math.hypot(ca.x - parentPos.x, ca.y - parentPos.y)
+            tetherHandleRef.current = world.tether(parentHandle, handle, length)
+        }
+        if (parent) {
+            const parentHandle =
+                parent === 'ceiling' ? world.ceilingHandle
+                : parent === 'floor' ? world.floorHandle
+                : world.getHandleById(parent)
+            if (parentHandle != null) {
+                wireTether(parentHandle)
+            } else {
+                rafId = requestAnimationFrame(() => {
+                    const ph = world.getHandleById(parent)
+                    if (ph == null) {
+                        console.warn(`PhysicsCard: parent "${parent}" not found after one frame; tether skipped`)
+                        return
+                    }
+                    wireTether(ph)
+                })
+            }
+        }
 
         let dragging = false
         let lastX = 0
@@ -97,7 +125,6 @@ export function PhysicsCard({
         const FLING_PAUSE_MS = 50
 
         const onPointerDown = (e: PointerEvent) => {
-            if (interactionModeRef.current !== 'free') return
             if ((e.target as Element | null)?.closest('[data-card-header], a, button')) return
             e.preventDefault()
             dragging = true
@@ -145,6 +172,11 @@ export function PhysicsCard({
         window.addEventListener('pointerup', onPointerUp)
 
         return () => {
+            cancelAnimationFrame(rafId)
+            if (tetherHandleRef.current !== null) {
+                world.untether(tetherHandleRef.current)
+                tetherHandleRef.current = null
+            }
             world.unregister(handle)
             handleRef.current = null
             if (physicsHandleRef) physicsHandleRef.current = null
@@ -154,28 +186,17 @@ export function PhysicsCard({
         }
     }, [world, width, height, isMinimized])
 
-    // Anchor update: moves the spring target when the grid re-flows (e.g. resize).
     useEffect(() => {
         if (handleRef.current === null) return
         world.setAnchor(handleRef.current, anchor)
     }, [world, anchor.x, anchor.y])
 
-    // Interaction mode change: pin/unpin and sensor-toggle when lock state changes.
-    useEffect(() => {
-        if (handleRef.current === null) return
-        const locked = interactionMode === 'locked'
-        world.setStatic(handleRef.current, locked)
-        world.setSensor(handleRef.current, locked)
-    }, [world, interactionMode])
-
-    // Restore FLIP: when a minimized card re-mounts, animate it in from the chip position.
     useEffect(() => {
         if (isMinimized || !id || !minimizable) return
         const el = elRef.current
         if (!el) return
         const fromChipRect = registry.consumeRestoreRect(id)
         if (!fromChipRect) return
-        // Capture the physics-set transform before the next RAF so we animate TO the anchor.
         const endTransform = el.style.transform
         requestAnimationFrame(() => {
             flipMorph(fromChipRect, el, { opacityFrom: 0.5, endTransform })
@@ -202,7 +223,6 @@ export function PhysicsCard({
             }}
             className={cls}
             data-variant={variant}
-            data-interaction-mode={interactionMode}
             style={style}
         >
             {showHeader ? (

--- a/web/src/physics/PhysicsContext.tsx
+++ b/web/src/physics/PhysicsContext.tsx
@@ -47,7 +47,15 @@ export function PhysicsProvider({ children }: PhysicsProviderProps) {
             raf = requestAnimationFrame(frame)
         }
         raf = requestAnimationFrame(frame)
-        return () => cancelAnimationFrame(raf)
+
+        const onResize = () =>
+            world.setViewport({ width: window.innerWidth, height: window.innerHeight })
+        window.addEventListener('resize', onResize)
+
+        return () => {
+            cancelAnimationFrame(raf)
+            window.removeEventListener('resize', onResize)
+        }
     }, [world])
 
     return (

--- a/web/src/physics/PhysicsWorld.test.ts
+++ b/web/src/physics/PhysicsWorld.test.ts
@@ -454,6 +454,33 @@ describe('PhysicsWorld tether', () => {
         world.untether(th)
         expect(world.getTethers()).toHaveLength(0)
     })
+
+    test('getTetherList returns a stable reference until the tether set changes', () => {
+        // Required by useSyncExternalStore in StringLayer — a new reference on
+        // every call causes an infinite re-render loop ("Maximum update depth exceeded").
+        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
+        const parent = world.registerStatic({ x: 400, y: 0 }, { width: 40, height: 40 })
+        const child = world.register({ x: 400, y: 200 }, { width: 80, height: 40 })
+
+        const empty1 = world.getTetherList()
+        const empty2 = world.getTetherList()
+        expect(empty2).toBe(empty1)
+
+        const th = world.tether(parent, child, 200)
+        const withTether1 = world.getTetherList()
+        expect(withTether1).not.toBe(empty1)
+        expect(withTether1).toHaveLength(1)
+
+        // Stable across calls when the set hasn't changed — even after world.tick advances positions
+        for (let i = 0; i < 10; i++) world.tick(FIXED_DT_MS)
+        const withTether2 = world.getTetherList()
+        expect(withTether2).toBe(withTether1)
+
+        world.untether(th)
+        const afterUntether = world.getTetherList()
+        expect(afterUntether).not.toBe(withTether1)
+        expect(afterUntether).toHaveLength(0)
+    })
 })
 
 describe('PhysicsWorld linkBodies / unlinkBodies', () => {

--- a/web/src/physics/PhysicsWorld.test.ts
+++ b/web/src/physics/PhysicsWorld.test.ts
@@ -47,11 +47,10 @@ describe('PhysicsWorld dynamics', () => {
         expect(pos.x).toBeGreaterThan(100)
         expect(Math.abs(pos.y - 100)).toBeLessThan(1)
     })
-
 })
 
 describe('PhysicsWorld gravity', () => {
-    test('setGravity(true) makes a card fall', () => {
+    test('gravity is on by default — a registered body falls downward', () => {
         const world = new PhysicsWorld({
             viewport: { width: 800, height: 600 },
         })
@@ -59,25 +58,90 @@ describe('PhysicsWorld gravity', () => {
             { x: 100, y: 100 },
             { width: 100, height: 50 },
         )
-        world.setGravity(true)
         for (let i = 0; i < 30; i++) world.tick(FIXED_DT_MS)
         const fellTo = world.getPosition(handle)
         expect(fellTo.y).toBeGreaterThan(100)
     })
 
-    test('with gravity on, the floor body catches a falling card (no escape)', () => {
+    test('floor catches a falling body', () => {
         const viewport = { width: 800, height: 400 }
         const world = new PhysicsWorld({ viewport })
         const handle = world.register(
             { x: 100, y: 50 },
             { width: 100, height: 50 },
         )
-
-        world.setGravity(true)
         for (let i = 0; i < 600; i++) world.tick(FIXED_DT_MS)
-
         const pos = world.getPosition(handle)
         expect(pos.y).toBeLessThanOrEqual(viewport.height)
+    })
+})
+
+describe('PhysicsWorld gravity direction', () => {
+    test('setGravityDirection("down") makes a body fall in positive y', () => {
+        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
+        const handle = world.register({ x: 400, y: 200 }, { width: 80, height: 40 })
+        world.setGravityDirection('down')
+        for (let i = 0; i < 30; i++) world.tick(FIXED_DT_MS)
+        expect(world.getPosition(handle).y).toBeGreaterThan(200)
+    })
+
+    test('setGravityDirection("up") makes a body rise in negative y', () => {
+        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
+        const handle = world.register({ x: 400, y: 400 }, { width: 80, height: 40 })
+        world.setGravityDirection('up')
+        for (let i = 0; i < 30; i++) world.tick(FIXED_DT_MS)
+        expect(world.getPosition(handle).y).toBeLessThan(400)
+    })
+
+    test('setGravityDirection("left") makes a body drift in negative x', () => {
+        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
+        const handle = world.register({ x: 400, y: 300 }, { width: 80, height: 40 })
+        world.setGravityDirection('left')
+        for (let i = 0; i < 30; i++) world.tick(FIXED_DT_MS)
+        expect(world.getPosition(handle).x).toBeLessThan(400)
+    })
+
+    test('setGravityDirection("right") makes a body drift in positive x', () => {
+        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
+        const handle = world.register({ x: 400, y: 300 }, { width: 80, height: 40 })
+        world.setGravityDirection('right')
+        for (let i = 0; i < 30; i++) world.tick(FIXED_DT_MS)
+        expect(world.getPosition(handle).x).toBeGreaterThan(400)
+    })
+
+    test('getGravityVector returns direction and non-zero magnitude', () => {
+        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
+        const down = world.getGravityVector()
+        expect(down.x).toBeCloseTo(0)
+        expect(down.y).toBeGreaterThan(0)
+        world.setGravityDirection('up')
+        const up = world.getGravityVector()
+        expect(up.y).toBeLessThan(0)
+        world.setGravityDirection('left')
+        const left = world.getGravityVector()
+        expect(left.x).toBeLessThan(0)
+    })
+
+    test('ceiling catches a body rising under upward gravity', () => {
+        const viewport = { width: 800, height: 600 }
+        const world = new PhysicsWorld({ viewport })
+        const handle = world.register({ x: 400, y: 400 }, { width: 80, height: 40 })
+        world.setGravityDirection('up')
+        for (let i = 0; i < 600; i++) world.tick(FIXED_DT_MS)
+        const pos = world.getPosition(handle)
+        // ceiling is near y=0; body should be stopped by it, not escaping to negative y
+        expect(pos.y).toBeGreaterThanOrEqual(0)
+    })
+})
+
+describe('PhysicsWorld setViewport', () => {
+    test('setViewport repositions floor so new floor catches a falling body', () => {
+        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
+        const handle = world.register({ x: 400, y: 50 }, { width: 80, height: 40 })
+        world.setViewport({ width: 800, height: 200 })
+        for (let i = 0; i < 600; i++) world.tick(FIXED_DT_MS)
+        const pos = world.getPosition(handle)
+        expect(pos.y).toBeLessThanOrEqual(200)
     })
 })
 
@@ -168,6 +232,52 @@ describe('PhysicsWorld dragging', () => {
     })
 })
 
+describe('PhysicsWorld registerById', () => {
+    test('registerById makes card retrievable by id', () => {
+        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
+        const handle = world.registerById('hero', { x: 100, y: 100 }, { width: 80, height: 40 })
+        expect(world.getHandleById('hero')).toBe(handle)
+    })
+
+    test('registerById with duplicate id throws', () => {
+        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
+        world.registerById('card-1', { x: 100, y: 100 }, { width: 80, height: 40 })
+        expect(() =>
+            world.registerById('card-1', { x: 200, y: 200 }, { width: 80, height: 40 })
+        ).toThrow()
+    })
+
+    test('unregister removes the id from the id map', () => {
+        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
+        const handle = world.registerById('card-1', { x: 100, y: 100 }, { width: 80, height: 40 })
+        world.unregister(handle)
+        expect(world.getHandleById('card-1')).toBeUndefined()
+    })
+
+    test('getHandleById returns undefined for unknown id', () => {
+        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
+        expect(world.getHandleById('missing')).toBeUndefined()
+    })
+})
+
+describe('PhysicsWorld setBuoyancy', () => {
+    test('balloon card is lifted against default downward gravity relative to heavy card', () => {
+        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
+        const heavy = world.register({ x: 400, y: 300 }, { width: 80, height: 40 })
+        const balloon = world.register({ x: 400, y: 300 }, { width: 80, height: 40 })
+        world.setBuoyancy(balloon, 'balloon')
+        for (let i = 0; i < 60; i++) world.tick(FIXED_DT_MS)
+        const heavyPos = world.getPosition(heavy)
+        const balloonPos = world.getPosition(balloon)
+        expect(balloonPos.y).toBeLessThan(heavyPos.y)
+    })
+
+    test('setBuoyancy throws for unknown handle', () => {
+        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
+        expect(() => world.setBuoyancy(999, 'balloon')).toThrow()
+    })
+})
+
 describe('PhysicsWorld setSize', () => {
     test('setSize throws for unknown handle', () => {
         const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
@@ -255,13 +365,12 @@ describe('PhysicsWorld static registration (gravity-exempt)', () => {
         expect(pos.y).toBeCloseTo(500, 5)
     })
 
-    test('a static body does not fall when gravity is on', () => {
+    test('a static body does not fall under downward gravity', () => {
         const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
         const handle = world.registerStatic(
             { x: 200, y: 200 },
             { width: 120, height: 60 },
         )
-        world.setGravity(true)
         for (let i = 0; i < 60; i++) world.tick(FIXED_DT_MS)
         const pos = world.getPosition(handle)
         expect(pos.y).toBeCloseTo(200, 1)
@@ -279,18 +388,71 @@ describe('PhysicsWorld static registration (gravity-exempt)', () => {
         expect(pos.y).toBeCloseTo(300, 5)
     })
 
-    test('a static body stays put after setPosition across many ticks with gravity', () => {
+    test('a static body stays put after setPosition with gravity active', () => {
         const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
         const handle = world.registerStatic(
             { x: 200, y: 500 },
             { width: 120, height: 60 },
         )
-        world.setGravity(true)
         world.setPosition(handle, { x: 400, y: 300 })
         for (let i = 0; i < 120; i++) world.tick(FIXED_DT_MS)
         const pos = world.getPosition(handle)
         expect(pos.x).toBeCloseTo(400, 1)
         expect(pos.y).toBeCloseTo(300, 1)
+    })
+})
+
+describe('PhysicsWorld tether', () => {
+    test('tether returns a numeric handle', () => {
+        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
+        const parent = world.registerStatic({ x: 400, y: 0 }, { width: 40, height: 40 })
+        const child = world.register({ x: 400, y: 200 }, { width: 80, height: 40 })
+        const th = world.tether(parent, child, 200)
+        expect(th).toBeTypeOf('number')
+    })
+
+    test('body within tether length falls freely under gravity (not held)', () => {
+        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
+        const parent = world.registerStatic({ x: 400, y: 0 }, { width: 40, height: 40 })
+        const child = world.register({ x: 400, y: 50 }, { width: 80, height: 40 })
+        world.tether(parent, child, 300)  // child at distance 50, tether length 300 → slack
+        for (let i = 0; i < 30; i++) world.tick(FIXED_DT_MS)
+        expect(world.getPosition(child).y).toBeGreaterThan(50)  // fell under gravity
+    })
+
+    test('body stretched past tether length is pulled back and settles near tether length', () => {
+        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
+        const parent = world.registerStatic({ x: 400, y: 100 }, { width: 40, height: 40 })
+        const child = world.register({ x: 400, y: 300 }, { width: 80, height: 40 })
+        world.tether(parent, child, 50)  // child at distance 200, tether length 50 → stretched
+        for (let i = 0; i < 300; i++) world.tick(FIXED_DT_MS)
+        const pos = world.getPosition(child)
+        const dist = Math.hypot(pos.x - 400, pos.y - 100)
+        expect(dist).toBeLessThan(100)  // settled near tether length of 50
+    })
+
+    test('untether removes the pull-only force so body falls freely', () => {
+        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
+        const parent = world.registerStatic({ x: 400, y: 50 }, { width: 40, height: 40 })
+        const child = world.register({ x: 400, y: 200 }, { width: 80, height: 40 })
+        const th = world.tether(parent, child, 50)
+        world.untether(th)
+        for (let i = 0; i < 600; i++) world.tick(FIXED_DT_MS)
+        const pos = world.getPosition(child)
+        const dist = Math.hypot(pos.x - 400, pos.y - 50)
+        expect(dist).toBeGreaterThan(200)  // fell away to floor
+    })
+
+    test('getTethers returns views with parent/child positions and length', () => {
+        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
+        const parent = world.registerStatic({ x: 400, y: 0 }, { width: 40, height: 40 })
+        const child = world.register({ x: 400, y: 200 }, { width: 80, height: 40 })
+        const th = world.tether(parent, child, 200)
+        const views = world.getTethers()
+        expect(views).toHaveLength(1)
+        expect(views[0]!.length).toBe(200)
+        world.untether(th)
+        expect(world.getTethers()).toHaveLength(0)
     })
 })
 

--- a/web/src/physics/PhysicsWorld.ts
+++ b/web/src/physics/PhysicsWorld.ts
@@ -68,7 +68,7 @@ interface Registration {
 }
 
 const GRAVITY_Y = 0.7
-const BODY_FRICTION_AIR = 0.05
+const BODY_FRICTION_AIR = 0.005
 const FLOOR_THICKNESS = 60
 const TETHER_STIFFNESS = 1.75e-5
 const BUOYANCY_GAIN = 1.5

--- a/web/src/physics/PhysicsWorld.ts
+++ b/web/src/physics/PhysicsWorld.ts
@@ -86,6 +86,7 @@ export class PhysicsWorld {
     private links = new Map<LinkHandle, Matter.Constraint>()
     private tethers = new Map<TetherHandle, TetherRecord>()
     private tetherChangeListeners = new Set<() => void>()
+    private cachedTetherList: ReadonlyArray<TetherHandle> | null = null
 
     readonly floorHandle: PhysicsHandle
     readonly ceilingHandle: PhysicsHandle
@@ -391,6 +392,7 @@ export class PhysicsWorld {
         const lh = this.linkBodies(parent, child, { length, stiffness: 1e-9, damping: 0 })
         const th = this.nextId++
         this.tethers.set(th, { parent, child, length, linkHandle: lh })
+        this.cachedTetherList = null
         for (const cb of this.tetherChangeListeners) cb()
         return th
     }
@@ -400,6 +402,7 @@ export class PhysicsWorld {
         if (!rec) return
         this.unlinkBodies(rec.linkHandle)
         this.tethers.delete(th)
+        this.cachedTetherList = null
         for (const cb of this.tetherChangeListeners) cb()
     }
 
@@ -415,6 +418,15 @@ export class PhysicsWorld {
             views.push({ parentPos, childPos, length: rec.length, slack: d < rec.length * 0.98 })
         }
         return views
+    }
+
+    // Stable-identity snapshot for useSyncExternalStore consumers. Reference only changes
+    // when the tether set changes (mount/unmount), not on every call.
+    getTetherList(): ReadonlyArray<TetherHandle> {
+        if (!this.cachedTetherList) {
+            this.cachedTetherList = Object.freeze(Array.from(this.tethers.keys()))
+        }
+        return this.cachedTetherList
     }
 
     subscribeTetherSetChange(cb: () => void): () => void {

--- a/web/src/physics/PhysicsWorld.ts
+++ b/web/src/physics/PhysicsWorld.ts
@@ -1,5 +1,7 @@
 import Matter from 'matter-js'
 
+export type Cardinal = 'down' | 'up' | 'left' | 'right'
+
 export interface Vec2 {
     x: number
     y: number
@@ -17,10 +19,12 @@ export interface Viewport {
 
 export interface PhysicsWorldOptions {
     viewport: Viewport
+    frameBarHeight?: number
 }
 
 export type PhysicsHandle = number
 export type LinkHandle = number
+export type TetherHandle = number
 
 export interface BodyState {
     x: number
@@ -38,44 +42,119 @@ export interface LinkOptions {
     damping?: number
 }
 
+export interface TetherView {
+    parentPos: Vec2
+    childPos: Vec2
+    length: number
+    slack: boolean
+}
+
+interface TetherRecord {
+    parent: PhysicsHandle
+    child: PhysicsHandle
+    length: number
+    linkHandle: LinkHandle
+}
+
 interface Registration {
     body: Matter.Body
-    spring?: Matter.Constraint
     anchor: Vec2
     isStatic: boolean
     onTransform?: (state: BodyState) => void
     width: number
     height: number
+    buoyancy: 'heavy' | 'balloon'
+    id?: string
 }
 
-const SPRING_STIFFNESS = 1e-9
-const SPRING_DAMPING = 0
 const GRAVITY_Y = 0.7
 const BODY_FRICTION_AIR = 0.05
 const FLOOR_THICKNESS = 60
+const TETHER_STIFFNESS = 1.75e-5
+const BUOYANCY_GAIN = 1.5
 
 export class PhysicsWorld {
     private engine: Matter.Engine
     private world: Matter.World
-    private floor: Matter.Body
+    private _floor: Matter.Body
+    private _ceiling: Matter.Body
+    private _leftWall: Matter.Body
+    private _rightWall: Matter.Body
     private nextId: PhysicsHandle = 1
     private registrations = new Map<PhysicsHandle, Registration>()
+    private byId = new Map<string, PhysicsHandle>()
     private links = new Map<LinkHandle, Matter.Constraint>()
+    private tethers = new Map<TetherHandle, TetherRecord>()
+    private tetherChangeListeners = new Set<() => void>()
+
+    readonly floorHandle: PhysicsHandle
+    readonly ceilingHandle: PhysicsHandle
 
     constructor(opts: PhysicsWorldOptions) {
         this.engine = Matter.Engine.create()
         this.world = this.engine.world
         this.engine.gravity.x = 0
-        this.engine.gravity.y = 0
+        this.engine.gravity.y = GRAVITY_Y  // always on, default down
 
-        this.floor = Matter.Bodies.rectangle(
-            opts.viewport.width / 2,
-            opts.viewport.height + FLOOR_THICKNESS / 2,
-            opts.viewport.width,
+        const { width, height } = opts.viewport
+        const frameBarHeight = opts.frameBarHeight ?? 0
+
+        // Floor — dynamic cards fall onto it; balloon cards tether to it
+        this._floor = Matter.Bodies.rectangle(
+            width / 2,
+            height + FLOOR_THICKNESS / 2,
+            width,
             FLOOR_THICKNESS,
             { isStatic: true },
         )
-        Matter.Composite.add(this.world, this.floor)
+        Matter.Composite.add(this.world, this._floor)
+        const floorId = this.nextId++
+        this.registrations.set(floorId, {
+            body: this._floor,
+            anchor: { x: width / 2, y: height },
+            isStatic: true,
+            width,
+            height: FLOOR_THICKNESS,
+            buoyancy: 'heavy',
+        })
+        this.floorHandle = floorId
+
+        // Ceiling — heavy cards hang from it; upward-gravity balloon cards fall to it
+        this._ceiling = Matter.Bodies.rectangle(
+            width / 2,
+            frameBarHeight - FLOOR_THICKNESS / 2,
+            width,
+            FLOOR_THICKNESS,
+            { isStatic: true },
+        )
+        Matter.Composite.add(this.world, this._ceiling)
+        const ceilingId = this.nextId++
+        this.registrations.set(ceilingId, {
+            body: this._ceiling,
+            anchor: { x: width / 2, y: frameBarHeight },
+            isStatic: true,
+            width,
+            height: FLOOR_THICKNESS,
+            buoyancy: 'heavy',
+        })
+        this.ceilingHandle = ceilingId
+
+        // Side walls — invisible collision boundaries
+        this._leftWall = Matter.Bodies.rectangle(
+            -FLOOR_THICKNESS / 2,
+            height / 2,
+            FLOOR_THICKNESS,
+            height + 2 * FLOOR_THICKNESS,
+            { isStatic: true },
+        )
+        this._rightWall = Matter.Bodies.rectangle(
+            width + FLOOR_THICKNESS / 2,
+            height / 2,
+            FLOOR_THICKNESS,
+            height + 2 * FLOOR_THICKNESS,
+            { isStatic: true },
+        )
+        Matter.Composite.add(this.world, [this._leftWall, this._rightWall])
     }
 
     register(
@@ -88,30 +167,39 @@ export class PhysicsWorld {
             anchor.y,
             size.width,
             size.height,
-            {
-                frictionAir: BODY_FRICTION_AIR,
-            },
+            { frictionAir: BODY_FRICTION_AIR },
         )
-        const spring = Matter.Constraint.create({
-            pointA: { x: anchor.x, y: anchor.y },
-            bodyB: body,
-            pointB: { x: 0, y: 0 },
-            stiffness: SPRING_STIFFNESS,
-            damping: SPRING_DAMPING,
-            length: 0,
-        })
-        Matter.Composite.add(this.world, [body, spring])
+        Matter.Composite.add(this.world, body)
         const id = this.nextId++
         this.registrations.set(id, {
             body,
-            spring,
             anchor: { ...anchor },
             isStatic: false,
             onTransform: opts.onTransform,
             width: size.width,
             height: size.height,
+            buoyancy: 'heavy',
         })
         return id
+    }
+
+    registerById(
+        cardId: string,
+        anchor: Vec2,
+        size: CardSize,
+        opts: RegisterOptions = {},
+    ): PhysicsHandle {
+        if (this.byId.has(cardId)) {
+            throw new Error(`PhysicsWorld: duplicate id "${cardId}"`)
+        }
+        const handle = this.register(anchor, size, opts)
+        this.byId.set(cardId, handle)
+        this.registrations.get(handle)!.id = cardId
+        return handle
+    }
+
+    getHandleById(cardId: string): PhysicsHandle | undefined {
+        return this.byId.get(cardId)
     }
 
     registerStatic(
@@ -130,12 +218,12 @@ export class PhysicsWorld {
         const id = this.nextId++
         this.registrations.set(id, {
             body,
-            spring: undefined,
             anchor: { ...position },
             isStatic: true,
             onTransform: opts.onTransform,
             width: size.width,
             height: size.height,
+            buoyancy: 'heavy',
         })
         return id
     }
@@ -144,7 +232,7 @@ export class PhysicsWorld {
         const reg = this.registrations.get(handle)
         if (!reg) return
         Matter.Composite.remove(this.world, reg.body)
-        if (reg.spring) Matter.Composite.remove(this.world, reg.spring)
+        if (reg.id) this.byId.delete(reg.id)
         this.registrations.delete(handle)
     }
 
@@ -178,12 +266,43 @@ export class PhysicsWorld {
         Matter.Body.setVelocity(reg.body, { x: 0, y: 0 })
     }
 
-    setGravity(on: boolean): void {
-        this.engine.gravity.y = on ? GRAVITY_Y : 0
-        for (const reg of this.registrations.values()) {
-            if (reg.isStatic || !reg.spring) continue
-            reg.spring.stiffness = SPRING_STIFFNESS
+    setGravityDirection(dir: Cardinal): void {
+        switch (dir) {
+            case 'down':
+                this.engine.gravity.x = 0
+                this.engine.gravity.y = GRAVITY_Y
+                break
+            case 'up':
+                this.engine.gravity.x = 0
+                this.engine.gravity.y = -GRAVITY_Y
+                break
+            case 'left':
+                this.engine.gravity.x = -GRAVITY_Y
+                this.engine.gravity.y = 0
+                break
+            case 'right':
+                this.engine.gravity.x = GRAVITY_Y
+                this.engine.gravity.y = 0
+                break
         }
+    }
+
+    getGravityVector(): Vec2 {
+        return { x: this.engine.gravity.x, y: this.engine.gravity.y }
+    }
+
+    setViewport(vp: Viewport): void {
+        const hw = FLOOR_THICKNESS / 2
+        Matter.Body.setPosition(this._floor, { x: vp.width / 2, y: vp.height + hw })
+        Matter.Body.setPosition(this._ceiling, { x: vp.width / 2, y: -hw })
+        Matter.Body.setPosition(this._leftWall, { x: -hw, y: vp.height / 2 })
+        Matter.Body.setPosition(this._rightWall, { x: vp.width + hw, y: vp.height / 2 })
+    }
+
+    setBuoyancy(handle: PhysicsHandle, b: 'heavy' | 'balloon'): void {
+        const reg = this.registrations.get(handle)
+        if (!reg) throw new Error(`PhysicsWorld: unknown handle ${handle}`)
+        reg.buoyancy = b
     }
 
     setVelocity(handle: PhysicsHandle, velocity: Vec2): void {
@@ -202,14 +321,10 @@ export class PhysicsWorld {
     setAnchor(handle: PhysicsHandle, anchor: Vec2): void {
         const reg = this.registrations.get(handle)
         if (!reg) throw new Error(`PhysicsWorld: unknown handle ${handle}`)
-        if (reg.isStatic || !reg.spring) {
-            Matter.Body.setPosition(reg.body, anchor)
-            reg.anchor = { ...anchor }
-            return
-        }
         reg.anchor = { ...anchor }
-        reg.spring.pointA!.x = anchor.x
-        reg.spring.pointA!.y = anchor.y
+        // Always teleport — static bodies snap immediately; dynamic bodies reposition on resize
+        Matter.Body.setPosition(reg.body, anchor)
+        if (!reg.isStatic) Matter.Body.setVelocity(reg.body, { x: 0, y: 0 })
     }
 
     getSize(handle: PhysicsHandle): CardSize {
@@ -267,6 +382,46 @@ export class PhysicsWorld {
         this.links.delete(link)
     }
 
+    tether(parent: PhysicsHandle, child: PhysicsHandle, length: number): TetherHandle {
+        const regP = this.registrations.get(parent)
+        if (!regP) throw new Error(`PhysicsWorld: unknown handle ${parent}`)
+        const regC = this.registrations.get(child)
+        if (!regC) throw new Error(`PhysicsWorld: unknown handle ${child}`)
+        // linkBodies creates a matter.js Constraint record for cleanup; stiffness ~0 so no spring force
+        const lh = this.linkBodies(parent, child, { length, stiffness: 1e-9, damping: 0 })
+        const th = this.nextId++
+        this.tethers.set(th, { parent, child, length, linkHandle: lh })
+        for (const cb of this.tetherChangeListeners) cb()
+        return th
+    }
+
+    untether(th: TetherHandle): void {
+        const rec = this.tethers.get(th)
+        if (!rec) return
+        this.unlinkBodies(rec.linkHandle)
+        this.tethers.delete(th)
+        for (const cb of this.tetherChangeListeners) cb()
+    }
+
+    getTethers(): TetherView[] {
+        const views: TetherView[] = []
+        for (const rec of this.tethers.values()) {
+            const regP = this.registrations.get(rec.parent)
+            const regC = this.registrations.get(rec.child)
+            if (!regP || !regC) continue
+            const parentPos = { x: regP.body.position.x, y: regP.body.position.y }
+            const childPos = { x: regC.body.position.x, y: regC.body.position.y }
+            const d = Math.hypot(childPos.x - parentPos.x, childPos.y - parentPos.y)
+            views.push({ parentPos, childPos, length: rec.length, slack: d < rec.length * 0.98 })
+        }
+        return views
+    }
+
+    subscribeTetherSetChange(cb: () => void): () => void {
+        this.tetherChangeListeners.add(cb)
+        return () => this.tetherChangeListeners.delete(cb)
+    }
+
     setSensor(handle: PhysicsHandle, isSensor: boolean): void {
         const reg = this.registrations.get(handle)
         if (!reg) throw new Error(`PhysicsWorld: unknown handle ${handle}`)
@@ -281,7 +436,42 @@ export class PhysicsWorld {
     }
 
     tick(dtMs: number): void {
+        // 1. Apply balloon buoyancy — per-tick force opposing gravity, scaled to match gravity force units
+        const g = this.getGravityVector()
+        const gravScale: number = (this.engine.gravity as { scale?: number }).scale ?? 0.001
+        for (const reg of this.registrations.values()) {
+            if (reg.isStatic || reg.buoyancy !== 'balloon') continue
+            Matter.Body.applyForce(reg.body, reg.body.position, {
+                x: -g.x * reg.body.mass * gravScale * BUOYANCY_GAIN,
+                y: -g.y * reg.body.mass * gravScale * BUOYANCY_GAIN,
+            })
+        }
+
+        // 2. Apply pull-only tether forces (rope semantics)
+        for (const rec of this.tethers.values()) {
+            const regP = this.registrations.get(rec.parent)
+            const regC = this.registrations.get(rec.child)
+            if (!regP || !regC) continue
+            const dx = regP.body.position.x - regC.body.position.x
+            const dy = regP.body.position.y - regC.body.position.y
+            const d = Math.hypot(dx, dy)
+            if (d <= rec.length || d === 0) continue
+            const overshoot = d - rec.length
+            const nx = dx / d
+            const ny = dy / d
+            const a = overshoot * TETHER_STIFFNESS  // acceleration-scale; multiply by mass → force
+            if (!regC.body.isStatic) {
+                Matter.Body.applyForce(regC.body, regC.body.position, { x: nx * a * regC.body.mass, y: ny * a * regC.body.mass })
+            }
+            if (!regP.body.isStatic) {
+                Matter.Body.applyForce(regP.body, regP.body.position, { x: -nx * a * regP.body.mass, y: -ny * a * regP.body.mass })
+            }
+        }
+
+        // 3. Advance the physics engine
         Matter.Engine.update(this.engine, dtMs)
+
+        // 4. Notify transform listeners
         for (const reg of this.registrations.values()) {
             if (!reg.onTransform) continue
             reg.onTransform({

--- a/web/src/routes/sandbox/Strings.tsx
+++ b/web/src/routes/sandbox/Strings.tsx
@@ -1,0 +1,127 @@
+import { useState, useEffect } from 'react'
+import { PhysicsProvider } from '../../physics/PhysicsContext'
+import { PhysicsCard } from '../../physics/PhysicsCard'
+import { StringLayer } from '../../canvas/StringLayer'
+
+function computeLayout(w: number, h: number) {
+    return {
+        heavyCeiling:    { x: Math.round(w * 0.15), y: Math.round(h * 0.35) },
+        balloonFloor1:   { x: Math.round(w * 0.35), y: Math.round(h * 0.60) },
+        balloonFloor2:   { x: Math.round(w * 0.50), y: Math.round(h * 0.60) },
+        parentMixed:     { x: Math.round(w * 0.75), y: Math.round(h * 0.30) },
+        childHeavy:      { x: Math.round(w * 0.75), y: Math.round(h * 0.55) },
+        childBalloon:    { x: Math.round(w * 0.75), y: Math.round(h * 0.15) },
+        childHeavy2:     { x: Math.round(w * 0.75), y: Math.round(h * 0.70) },
+        detached:        { x: Math.round(w * 0.35), y: Math.round(h * 0.20) },
+    }
+}
+
+const CARD_W = 120
+const CARD_H = 50
+
+export default function Strings() {
+    const [layout, setLayout] = useState(() =>
+        typeof window !== 'undefined'
+            ? computeLayout(window.innerWidth, window.innerHeight)
+            : computeLayout(1280, 800),
+    )
+
+    useEffect(() => {
+        const onResize = () =>
+            setLayout(computeLayout(window.innerWidth, window.innerHeight))
+        window.addEventListener('resize', onResize, { passive: true })
+        return () => window.removeEventListener('resize', onResize)
+    }, [])
+
+    return (
+        <div style={{ position: 'relative', width: '100vw', height: '100vh', overflow: 'hidden' }}>
+            <PhysicsProvider>
+                <StringLayer />
+
+                {/* Scenario 1: heavy card hanging from ceiling */}
+                <PhysicsCard
+                    id="heavy-ceiling"
+                    text="Ceiling hang"
+                    width={CARD_W}
+                    height={CARD_H}
+                    anchor={layout.heavyCeiling}
+                    parent="ceiling"
+                    buoyancy="heavy"
+                    minimizable
+                    label="Ceiling hang"
+                />
+
+                {/* Scenario 2a: balloon tethered to floor */}
+                <PhysicsCard
+                    id="balloon-floor-1"
+                    text="Balloon 1"
+                    width={CARD_W}
+                    height={CARD_H}
+                    anchor={layout.balloonFloor1}
+                    parent="floor"
+                    buoyancy="balloon"
+                />
+
+                {/* Scenario 2b: balloon tethered to floor */}
+                <PhysicsCard
+                    id="balloon-floor-2"
+                    text="Balloon 2"
+                    width={CARD_W}
+                    height={CARD_H}
+                    anchor={layout.balloonFloor2}
+                    parent="floor"
+                    buoyancy="balloon"
+                />
+
+                {/* Scenario 3: parent with 3 mixed children */}
+                <PhysicsCard
+                    id="parent-mixed"
+                    text="Parent"
+                    width={CARD_W}
+                    height={CARD_H}
+                    anchor={layout.parentMixed}
+                    parent="ceiling"
+                    buoyancy="heavy"
+                    minimizable
+                    label="Parent (mixed)"
+                />
+                <PhysicsCard
+                    id="child-heavy"
+                    text="Child heavy"
+                    width={CARD_W}
+                    height={CARD_H}
+                    anchor={layout.childHeavy}
+                    parent="parent-mixed"
+                    buoyancy="heavy"
+                />
+                <PhysicsCard
+                    id="child-balloon"
+                    text="Child balloon"
+                    width={CARD_W}
+                    height={CARD_H}
+                    anchor={layout.childBalloon}
+                    parent="parent-mixed"
+                    buoyancy="balloon"
+                />
+                <PhysicsCard
+                    id="child-heavy-2"
+                    text="Child heavy 2"
+                    width={CARD_W}
+                    height={CARD_H}
+                    anchor={layout.childHeavy2}
+                    parent="parent-mixed"
+                    buoyancy="heavy"
+                />
+
+                {/* Scenario 4: detached heavy — falls to floor */}
+                <PhysicsCard
+                    id="detached"
+                    text="Detached"
+                    width={CARD_W}
+                    height={CARD_H}
+                    anchor={layout.detached}
+                />
+            </PhysicsProvider>
+        </div>
+    )
+}

--- a/web/src/sandbox/cards/CardHeader.tsx
+++ b/web/src/sandbox/cards/CardHeader.tsx
@@ -1,92 +1,28 @@
 interface CardHeaderProps {
-    locked: boolean
-    onChange: (locked: boolean) => void
     onMinimize?: () => void
 }
 
-export function CardHeader({ locked, onChange, onMinimize }: CardHeaderProps) {
+export function CardHeader({ onMinimize }: CardHeaderProps) {
+    if (!onMinimize) return null
     return (
-        <>
-            {onMinimize != null && (
-                <button
-                    type="button"
-                    title="Minimize"
-                    onPointerDown={(e) => e.stopPropagation()}
-                    onClick={onMinimize}
-                    style={{
-                        background: 'none',
-                        border: 'none',
-                        padding: '4px 8px',
-                        cursor: 'pointer',
-                        color: 'var(--card-fg, currentColor)',
-                        opacity: 0.55,
-                        fontSize: 18,
-                        lineHeight: 1,
-                        fontFamily: 'inherit',
-                    }}
-                >
-                    −
-                </button>
-            )}
-            <button
-                type="button"
-                title={locked ? 'Locked — click to free' : 'Free — click to lock'}
-                onPointerDown={(e) => e.stopPropagation()}
-                onClick={() => onChange(!locked)}
-                style={{
-                    marginLeft: 'auto',
+        <button
+            type="button"
+            title="Minimize"
+            onPointerDown={(e) => e.stopPropagation()}
+            onClick={onMinimize}
+            style={{
                 background: 'none',
                 border: 'none',
-                padding: '4px 6px',
+                padding: '4px 8px',
                 cursor: 'pointer',
                 color: 'var(--card-fg, currentColor)',
-                opacity: locked ? 1 : 0.45,
-                display: 'flex',
-                alignItems: 'center',
+                opacity: 0.55,
+                fontSize: 18,
                 lineHeight: 1,
+                fontFamily: 'inherit',
             }}
         >
-            {locked ? (
-                <svg width="17" height="18" viewBox="0 0 13 14" fill="none" aria-hidden="true">
-                    {/* Closed shackle */}
-                    <path
-                        d="M3 6V4.5a3.5 3.5 0 0 1 7 0V6"
-                        stroke="currentColor"
-                        strokeWidth="1.5"
-                        strokeLinecap="round"
-                        fill="none"
-                    />
-                    {/* Body */}
-                    <rect x="1" y="6" width="11" height="7.5" rx="1.5" fill="currentColor" />
-                    {/* Keyhole */}
-                    <circle cx="6.5" cy="9.5" r="1.2" fill="var(--card-bg, canvas)" />
-                </svg>
-            ) : (
-                <svg width="17" height="18" viewBox="0 0 13 14" fill="none" aria-hidden="true">
-                    {/* Open shackle (swung to the right) */}
-                    <path
-                        d="M3 6V4.5a3.5 3.5 0 0 1 7 0"
-                        stroke="currentColor"
-                        strokeWidth="1.5"
-                        strokeLinecap="round"
-                        fill="none"
-                    />
-                    {/* Body */}
-                    <rect
-                        x="1"
-                        y="6"
-                        width="11"
-                        height="7.5"
-                        rx="1.5"
-                        stroke="currentColor"
-                        strokeWidth="1.25"
-                        fill="none"
-                    />
-                    {/* Keyhole */}
-                    <circle cx="6.5" cy="9.5" r="1.2" fill="currentColor" />
-                </svg>
-            )}
+            −
         </button>
-        </>
     )
 }

--- a/web/src/sandbox/cards/Playground.tsx
+++ b/web/src/sandbox/cards/Playground.tsx
@@ -31,7 +31,6 @@ export function Playground({ minimized, onMinimize, cardRef }: PlaygroundProps) 
         typeof window !== 'undefined' ? computeAnchor() : { x: 400, y: 350 },
     )
     const [cardSize] = useState({ width: DEFAULT_W, height: DEFAULT_H })
-    const [locked, setLocked] = useState(false)
 
     useEffect(() => {
         const onResize = () => setAnchor(computeAnchor())
@@ -50,8 +49,7 @@ export function Playground({ minimized, onMinimize, cardRef }: PlaygroundProps) 
             variant="playground"
             physicsHandleRef={handleRef}
             cardRef={cardRef}
-            interactionMode={locked ? 'locked' : 'free'}
-            header={<CardHeader locked={locked} onChange={setLocked} onMinimize={onMinimize} />}
+            header={<CardHeader onMinimize={onMinimize} />}
         >
             <div
                 style={{


### PR DESCRIPTION
## Summary

- **PhysicsWorld:** gravity always on; `setGravityDirection(Cardinal)` replaces the old toggle; ceiling + floor + side walls as resize-aware static bodies; `registerById` id→handle map; `setBuoyancy('balloon'|'heavy')`; per-tick pull-only tether forces with mass-proportional stiffness; `getTethers()` + `subscribeTetherSetChange()` for `StringLayer`
- **PhysicsCard:** `CardInteractionMode`/padlock removed entirely; `parent` and `buoyancy` props added; wires `world.tether()` on mount (frame-deferred for parent-by-id); untethers on unmount
- **MinimizedRegistry:** `registerString`/`unregisterString` for parent→child topology; `minimize()` BFS-cascades subtree into one chip entry with `members[]` and `subtreeSize`; `restore()` stashes chip rect for all members; `useIsMinimized` updated to check `e.members.includes(id)`
- **FrameBar:** `+N` badge on cascaded chip; dead gravity-toggle control removed (gravity always on per ADR)
- **StringLayer:** full-viewport SVG RAF loop mutating path `d` attributes directly (no React re-renders at 60fps); straight taut / cubic bezier slack
- **`/sandbox/strings`:** 4 demo scenarios — ceiling-hung heavy, two floor-tethered balloons, parent + 3 mixed-buoyancy children, detached heavy

## Notes / deviations

- **Tether stiffness calibration:** `TETHER_STIFFNESS = 1.75e-5` (mass × acceleration-scale units). matter.js applies `applyForce` as `velocity += (F/mass) × dt²`, so naïve spring constants 1000× too large cause instant NaN from ceiling collision. The mass-proportional formula keeps equilibrium offset (~40 px past tether length) mass-independent.
- **`setAnchor` on dynamic bodies teleports** (no spring return). This is the intended behavior for the "anchor IS the layout" principle; strung cards settle via tether, detached cards fall freely.
- **StringLayer sandbox-only** this slice. CanvasLayout wiring deferred to #57.
- **Production routes untouched** — no parent declared → DETACHED → falls under gravity, same drag-and-stay feel as before.

## Acceptance criteria

- [x] `setGravityDirection('down'|'up'|'left'|'right')` works; body falls in the declared direction
- [x] Ceiling, floor, side walls present and resize-aware (`setViewport`)
- [x] `registerById` / `getHandleById` round-trip; duplicate id throws
- [x] Balloon buoyancy rises against downward gravity
- [x] `tether()` pull-only: slack within length, pulls back past length, settles near tether length
- [x] `untether()` releases pull-only force; body falls freely
- [x] `getTethers()` + `subscribeTetherSetChange()` for StringLayer integration
- [x] PhysicsCard: no padlock, no interactionMode; `parent` and `buoyancy` props wired
- [x] MinimizedRegistry cascade: one chip for subtree, `members`, `subtreeSize`, `+N` badge
- [x] StringLayer renders straight (taut) and bezier (slack) strings at 60fps via ref mutation
- [x] `/sandbox/strings` route loads with 4 scenarios
- [x] All 198 tests pass; typecheck clean; production build succeeds

## Test plan

1. `cd web && npm run test` — 198 tests pass
2. `npm run typecheck` — clean
3. `npm run build` — builds, all 7 SSG pages render
4. `npm run dev` → open `/sandbox/strings`:
   - Card 1 (ceiling hang) hangs below ceiling with visible string
   - Cards 2-3 (balloons) float above floor with strings to floor
   - Card 4 (parent-mixed) hangs from ceiling; 3 children attached below/above with strings
   - Card 5 (detached) falls to floor on load
   - Drag any strung card and release: pendulums back, string shows bezier sag when slack
   - Minimize "Parent (mixed)": all 4 cards (parent + 3 children) collapse to one chip with `+3` badge
   - Restore: all 4 cards reappear with FLIP animation
   - Resize window: floor/ceiling/walls reposition; nothing escapes bounds
5. Open `/`, `/blog`, `/lifelog` — cards drift/drag as before, no padlock visible anywhere

Closes #56