### PR TITLE
Slice: per-route PageDef — gravity + string topology + buoyancy (#57)

### DIFF
--- a/content/notes/2026-05-05-standalone.mdx
+++ b/content/notes/2026-05-05-standalone.mdx
@@ -1,0 +1,6 @@
+---
+date: "2026-05-05"
+parent: null
+---
+
+Ships are safe in the harbor, but that is not what ships are for.

--- a/content/notes/2026-05-08-physics-rabbit-hole.mdx
+++ b/content/notes/2026-05-08-physics-rabbit-hole.mdx
@@ -1,0 +1,6 @@
+---
+date: "2026-05-08"
+parent: "lifelog:books"
+---
+
+Spent the evening debugging constraint stiffness in matter.js. Zero stiffness means hard pin, not free joint — counterintuitive.

--- a/content/notes/2026-05-10-on-strings.mdx
+++ b/content/notes/2026-05-10-on-strings.mdx
@@ -1,0 +1,6 @@
+---
+date: "2026-05-10"
+parent: "lifelog:books"
+---
+
+Reading _The Information_ by James Gleick. The history of the drum telegraph reads like a pre-digital API spec — constraints shape creativity.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -18,6 +18,14 @@ export const routes: RouteRecord[] = [
                 },
                 entry: 'src/routes/Home.tsx',
             },
+            {
+                path: '*',
+                lazy: async () => {
+                    const { default: NotFound } =
+                        await import('./routes/NotFound')
+                    return { Component: NotFound }
+                },
+            },
         ],
     },
     {
@@ -77,6 +85,26 @@ export const routes: RouteRecord[] = [
                     return { Component: Lifelog }
                 },
                 entry: 'src/routes/Lifelog.tsx',
+            },
+        ],
+    },
+    {
+        path: '/portfolio',
+        lazy: async () => {
+            const { default: CanvasLayout } =
+                await import('./layouts/CanvasLayout')
+            return { Component: CanvasLayout }
+        },
+        entry: 'src/layouts/CanvasLayout.tsx',
+        children: [
+            {
+                index: true,
+                lazy: async () => {
+                    const { default: Portfolio } =
+                        await import('./routes/Portfolio')
+                    return { Component: Portfolio }
+                },
+                entry: 'src/routes/Portfolio.tsx',
             },
         ],
     },

--- a/web/src/layouts/CanvasLayout.tsx
+++ b/web/src/layouts/CanvasLayout.tsx
@@ -4,6 +4,7 @@ import { BackgroundCanvas } from '../canvas/BackgroundCanvas'
 import { CANVAS_ONLY_BUNDLE_MARKER } from '../lib/canvas-only-marker'
 import { PhysicsProvider } from '../physics/PhysicsContext'
 import { FrameBar } from '../canvas/FrameBar'
+import { StringLayer } from '../canvas/StringLayer'
 import { useFrameEdge } from '../canvas/useFrameEdge'
 import './CanvasLayout.css'
 
@@ -24,6 +25,7 @@ export default function CanvasLayout() {
                 data-frame-edge={edge}
             >
                 <BackgroundCanvas />
+                <StringLayer />
                 <FrameBar />
                 <Outlet />
             </div>

--- a/web/src/lib/NotesReader.test.ts
+++ b/web/src/lib/NotesReader.test.ts
@@ -1,10 +1,13 @@
 import { describe, test, expect } from 'vitest'
+import type { ComponentType } from 'react'
 import {
     deriveNoteSlug,
     validateNoteFrontmatter,
     filterAndSortNotes,
 } from './NotesReader'
 import type { Note } from './NotesReader'
+
+const Stub: ComponentType = () => null
 
 describe('deriveNoteSlug', () => {
     test('strips date prefix and returns slug from path', () => {
@@ -47,17 +50,17 @@ describe('filterAndSortNotes', () => {
         {
             slug: 'b',
             frontmatter: { date: '2026-03-01', parent: 'lifelog:books' },
-            body: 'b',
+            Component: Stub,
         },
         {
             slug: 'a',
             frontmatter: { date: '2026-05-08', parent: 'lifelog:books' },
-            body: 'a',
+            Component: Stub,
         },
         {
             slug: 'c',
             frontmatter: { date: '2026-04-10', parent: null },
-            body: 'c',
+            Component: Stub,
         },
     ]
 

--- a/web/src/lib/NotesReader.test.ts
+++ b/web/src/lib/NotesReader.test.ts
@@ -1,0 +1,80 @@
+import { describe, test, expect } from 'vitest'
+import {
+    deriveNoteSlug,
+    validateNoteFrontmatter,
+    filterAndSortNotes,
+} from './NotesReader'
+import type { Note } from './NotesReader'
+
+describe('deriveNoteSlug', () => {
+    test('strips date prefix and returns slug from path', () => {
+        expect(
+            deriveNoteSlug('../../../content/notes/2026-05-08-on-strings.mdx'),
+        ).toBe('on-strings')
+    })
+
+    test('handles multi-word slug', () => {
+        expect(
+            deriveNoteSlug(
+                '../../../content/notes/2026-01-15-reading-and-thinking.mdx',
+            ),
+        ).toBe('reading-and-thinking')
+    })
+})
+
+describe('validateNoteFrontmatter', () => {
+    test('accepts valid frontmatter with parent', () => {
+        const fm = validateNoteFrontmatter({
+            date: '2026-05-08',
+            parent: 'lifelog:books',
+        })
+        expect(fm.date).toBe('2026-05-08')
+        expect(fm.parent).toBe('lifelog:books')
+    })
+
+    test('accepts valid frontmatter with null parent', () => {
+        const fm = validateNoteFrontmatter({ date: '2026-05-08', parent: null })
+        expect(fm.parent).toBeNull()
+    })
+
+    test('throws on missing date', () => {
+        expect(() => validateNoteFrontmatter({ parent: null })).toThrow()
+    })
+})
+
+describe('filterAndSortNotes', () => {
+    const notes: Note[] = [
+        {
+            slug: 'b',
+            frontmatter: { date: '2026-03-01', parent: 'lifelog:books' },
+            body: 'b',
+        },
+        {
+            slug: 'a',
+            frontmatter: { date: '2026-05-08', parent: 'lifelog:books' },
+            body: 'a',
+        },
+        {
+            slug: 'c',
+            frontmatter: { date: '2026-04-10', parent: null },
+            body: 'c',
+        },
+    ]
+
+    test('sorts newest-first by default', () => {
+        const sorted = filterAndSortNotes(notes)
+        expect(sorted.map((n) => n.slug)).toEqual(['a', 'c', 'b'])
+    })
+
+    test('filters by parent when provided', () => {
+        const filtered = filterAndSortNotes(notes, {
+            parent: 'lifelog:books',
+        })
+        expect(filtered.map((n) => n.slug)).toEqual(['a', 'b'])
+    })
+
+    test('returns only standalone notes when parent is null', () => {
+        const filtered = filterAndSortNotes(notes, { parent: null })
+        expect(filtered.map((n) => n.slug)).toEqual(['c'])
+    })
+})

--- a/web/src/lib/NotesReader.ts
+++ b/web/src/lib/NotesReader.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import type { ComponentType } from 'react'
 
 const NoteSchema = z.object({
     date: z.string().date(),
@@ -13,7 +14,7 @@ export interface NoteFrontmatter {
 export interface Note {
     slug: string
     frontmatter: NoteFrontmatter
-    body: string
+    Component: ComponentType
 }
 
 export function deriveNoteSlug(globKey: string): string {
@@ -42,7 +43,7 @@ export function filterAndSortNotes(
 
 type NoteModule = {
     frontmatter: unknown
-    default?: unknown
+    default: ComponentType
 }
 
 export function listNotes(filter?: { parent?: string | null }): Note[] {
@@ -53,7 +54,7 @@ export function listNotes(filter?: { parent?: string | null }): Note[] {
     const all: Note[] = Object.entries(modules).map(([path, mod]) => ({
         slug: deriveNoteSlug(path),
         frontmatter: validateNoteFrontmatter(mod.frontmatter),
-        body: '',
+        Component: mod.default,
     }))
     return filterAndSortNotes(all, filter)
 }

--- a/web/src/lib/NotesReader.ts
+++ b/web/src/lib/NotesReader.ts
@@ -1,0 +1,59 @@
+import { z } from 'zod'
+
+const NoteSchema = z.object({
+    date: z.string().date(),
+    parent: z.string().nullable().default(null),
+})
+
+export interface NoteFrontmatter {
+    date: string
+    parent: string | null
+}
+
+export interface Note {
+    slug: string
+    frontmatter: NoteFrontmatter
+    body: string
+}
+
+export function deriveNoteSlug(globKey: string): string {
+    const filename = globKey.split('/').at(-1) ?? ''
+    return filename.replace(/^\d{4}-\d{2}-\d{2}-/, '').replace(/\.mdx?$/, '')
+}
+
+export function validateNoteFrontmatter(raw: unknown): NoteFrontmatter {
+    return NoteSchema.parse(raw)
+}
+
+export function filterAndSortNotes(
+    notes: Note[],
+    filter?: { parent?: string | null },
+): Note[] {
+    let result = notes
+    if (filter !== undefined && 'parent' in filter) {
+        result = notes.filter((n) => n.frontmatter.parent === filter.parent)
+    }
+    return result
+        .slice()
+        .sort((a, b) =>
+            b.frontmatter.date.localeCompare(a.frontmatter.date),
+        )
+}
+
+type NoteModule = {
+    frontmatter: unknown
+    default?: unknown
+}
+
+export function listNotes(filter?: { parent?: string | null }): Note[] {
+    const modules = import.meta.glob<NoteModule>(
+        '../../../content/notes/*.mdx',
+        { eager: true },
+    )
+    const all: Note[] = Object.entries(modules).map(([path, mod]) => ({
+        slug: deriveNoteSlug(path),
+        frontmatter: validateNoteFrontmatter(mod.frontmatter),
+        body: '',
+    }))
+    return filterAndSortNotes(all, filter)
+}

--- a/web/src/physics/CardLayout.test.ts
+++ b/web/src/physics/CardLayout.test.ts
@@ -1,15 +1,15 @@
 import { describe, test, expect } from 'vitest'
-import { cardLayout, type CardSpec, type MeasureFn } from './CardLayout'
+import { cardLayout, type LayoutInput, type MeasureFn } from './CardLayout'
 
 const fixedMeasure: MeasureFn = (_text, _fontKey, maxWidth) => ({
     width: Math.min(200, maxWidth),
     height: 60,
 })
 
-const SPEC_A: CardSpec = { id: 'a', text: 'Card A', fontKey: 'body' }
-const SPEC_B: CardSpec = { id: 'b', text: 'Card B', fontKey: 'body' }
-const SPEC_C: CardSpec = { id: 'c', text: 'Card C', fontKey: 'body' }
-const SPEC_D: CardSpec = { id: 'd', text: 'Card D', fontKey: 'body' }
+const SPEC_A: LayoutInput = { id: 'a', text: 'Card A', fontKey: 'body' }
+const SPEC_B: LayoutInput = { id: 'b', text: 'Card B', fontKey: 'body' }
+const SPEC_C: LayoutInput = { id: 'c', text: 'Card C', fontKey: 'body' }
+const SPEC_D: LayoutInput = { id: 'd', text: 'Card D', fontKey: 'body' }
 
 describe('cardLayout — basic', () => {
     test('returns one anchor per spec with matching id', () => {
@@ -82,7 +82,7 @@ describe('cardLayout — pre-computed dims', () => {
         const spy: MeasureFn = () => {
             throw new Error('should not measure')
         }
-        const spec: CardSpec = {
+        const spec: LayoutInput = {
             id: 'x',
             text: 'X',
             fontKey: 'body',
@@ -100,7 +100,7 @@ describe('cardLayout — pre-computed dims', () => {
             called = true
             return { width: Math.min(200, mw), height: 60 }
         }
-        const spec: CardSpec = { id: 'x', text: 'X', fontKey: 'body' }
+        const spec: LayoutInput = { id: 'x', text: 'X', fontKey: 'body' }
         cardLayout([spec], { width: 1200, height: 800 }, spy)
         expect(called).toBe(true)
     })

--- a/web/src/physics/CardLayout.ts
+++ b/web/src/physics/CardLayout.ts
@@ -1,4 +1,4 @@
-export interface CardSpec {
+export interface LayoutInput {
     id: string
     text: string
     fontKey: string
@@ -33,7 +33,7 @@ function colsForWidth(viewportWidth: number): number {
 }
 
 export function cardLayout(
-    specs: CardSpec[],
+    specs: LayoutInput[],
     viewport: { width: number; height: number },
     measure: MeasureFn,
 ): CardAnchor[] {

--- a/web/src/physics/PageDef.test.ts
+++ b/web/src/physics/PageDef.test.ts
@@ -1,0 +1,28 @@
+import { describe, test, expect } from 'vitest'
+import { buoyancyForKind } from './PageDef'
+
+describe('buoyancyForKind', () => {
+    test('note kind returns balloon', () => {
+        expect(buoyancyForKind('note')).toBe('balloon')
+    })
+
+    test('blog kind returns heavy', () => {
+        expect(buoyancyForKind('blog')).toBe('heavy')
+    })
+
+    test('headline kind returns heavy', () => {
+        expect(buoyancyForKind('headline')).toBe('heavy')
+    })
+
+    test('lifelog kind returns heavy', () => {
+        expect(buoyancyForKind('lifelog')).toBe('heavy')
+    })
+
+    test('portfolio kind returns heavy', () => {
+        expect(buoyancyForKind('portfolio')).toBe('heavy')
+    })
+
+    test('link kind returns heavy', () => {
+        expect(buoyancyForKind('link')).toBe('heavy')
+    })
+})

--- a/web/src/physics/PageDef.ts
+++ b/web/src/physics/PageDef.ts
@@ -1,17 +1,19 @@
 export type Cardinal = 'down' | 'up' | 'left' | 'right'
 export type Buoyancy = 'heavy' | 'balloon'
 export type ParentRef = 'ceiling' | 'floor' | string
+export type CardKind = 'lifelog' | 'blog' | 'portfolio' | 'note' | 'link' | 'headline'
 
 export interface CardSpec {
     id: string
-    width: number
-    height: number
-    parent?: ParentRef
-    buoyancy?: Buoyancy
-    minimizable?: boolean
+    kind: CardKind
+    parent: ParentRef
 }
 
 export interface PageDef {
     gravity: Cardinal
     cards: CardSpec[]
+}
+
+export function buoyancyForKind(kind: CardKind): Buoyancy {
+    return kind === 'note' ? 'balloon' : 'heavy'
 }

--- a/web/src/physics/PhysicsCard.css
+++ b/web/src/physics/PhysicsCard.css
@@ -7,6 +7,7 @@
     gap: var(--card-gap);
     padding: var(--card-padding);
     margin: 0;
+    overflow: hidden;
     background: var(--color-bg-raised);
     color: var(--color-fg);
     border: var(--card-border-width) solid var(--color-fg);

--- a/web/src/physics/PhysicsCard.tsx
+++ b/web/src/physics/PhysicsCard.tsx
@@ -64,18 +64,27 @@ export function PhysicsCard({
         const w = width
         const h = height
 
+        // Spawn 20px in gravity direction so the card visibly settles to anchor on load.
+        const SPAWN_OFFSET = 20
+        const g = world.getGravityVector()
+        const gLen = Math.hypot(g.x, g.y)
+        const gx = gLen > 0 ? g.x / gLen : 0
+        const gy = gLen > 0 ? g.y / gLen : 1
+        const sx = x + gx * SPAWN_OFFSET
+        const sy = y + gy * SPAWN_OFFSET
+
         el.style.width = `${w}px`
         el.style.height = `${h}px`
-        el.style.transform = `translate(${x - w / 2}px, ${y - h / 2}px)`
+        el.style.transform = `translate(${sx - w / 2}px, ${sy - h / 2}px)`
 
         const handle = id
-            ? world.registerById(id, { x, y }, { width: w, height: h }, {
+            ? world.registerById(id, { x: sx, y: sy }, { width: w, height: h }, {
                 onTransform: ({ x: px, y: py, rotation }) => {
                     el.style.transform = `translate(${px - w / 2}px, ${py - h / 2}px) rotate(${rotation}rad)`
                 },
             })
             : world.register(
-                { x, y },
+                { x: sx, y: sy },
                 { width: w, height: h },
                 {
                     onTransform: ({ x: px, y: py, rotation }) => {

--- a/web/src/physics/PhysicsContext.tsx
+++ b/web/src/physics/PhysicsContext.tsx
@@ -6,6 +6,16 @@ import {
     type ReactNode,
 } from 'react'
 import { PhysicsWorld } from './PhysicsWorld'
+import { useFrameEdge, getFrameEdgeController } from '../canvas/useFrameEdge'
+import type { FrameEdge } from '../canvas/useFrameEdge'
+
+const FRAME_BAR_HEIGHT = 40
+
+function edgeToInsets(edge: FrameEdge) {
+    return edge === 'top'
+        ? { top: FRAME_BAR_HEIGHT, bottom: 0 }
+        : { top: 0, bottom: FRAME_BAR_HEIGHT }
+}
 
 const PhysicsContext = createContext<PhysicsWorld | null>(null)
 
@@ -23,19 +33,20 @@ interface PhysicsProviderProps {
 }
 
 export function PhysicsProvider({ children }: PhysicsProviderProps) {
-    const [world] = useState(
-        () =>
-            new PhysicsWorld({
-                viewport:
-                    typeof window !== 'undefined'
-                        ? {
-                              width: window.innerWidth,
-                              height: window.innerHeight,
-                          }
-                        : { width: 1024, height: 768 },
-            }),
-    )
+    const { edge } = useFrameEdge()
 
+    const [world] = useState(() => {
+        const initialEdge = getFrameEdgeController().getEdge()
+        return new PhysicsWorld({
+            viewport:
+                typeof window !== 'undefined'
+                    ? { width: window.innerWidth, height: window.innerHeight }
+                    : { width: 1024, height: 768 },
+            insets: edgeToInsets(initialEdge),
+        })
+    })
+
+    // RAF tick loop — stable across edge changes
     useEffect(() => {
         if (typeof window === 'undefined') return
         let raf = 0
@@ -47,16 +58,22 @@ export function PhysicsProvider({ children }: PhysicsProviderProps) {
             raf = requestAnimationFrame(frame)
         }
         raf = requestAnimationFrame(frame)
-
-        const onResize = () =>
-            world.setViewport({ width: window.innerWidth, height: window.innerHeight })
-        window.addEventListener('resize', onResize)
-
-        return () => {
-            cancelAnimationFrame(raf)
-            window.removeEventListener('resize', onResize)
-        }
+        return () => cancelAnimationFrame(raf)
     }, [world])
+
+    // Viewport + insets — re-applies when edge changes or window resizes
+    useEffect(() => {
+        if (typeof window === 'undefined') return
+        const insets = edgeToInsets(edge)
+        const apply = () =>
+            world.setViewport(
+                { width: window.innerWidth, height: window.innerHeight },
+                insets,
+            )
+        apply()
+        window.addEventListener('resize', apply, { passive: true })
+        return () => window.removeEventListener('resize', apply)
+    }, [world, edge])
 
     return (
         <PhysicsContext.Provider value={world}>

--- a/web/src/physics/PhysicsPage.test.tsx
+++ b/web/src/physics/PhysicsPage.test.tsx
@@ -1,0 +1,42 @@
+import { describe, test, expect } from 'vitest'
+import { render, cleanup, screen } from '@testing-library/react'
+import { PhysicsProvider } from './PhysicsContext'
+import { PhysicsPage } from './PhysicsPage'
+import type { PageDef } from './PageDef'
+
+const pageDef: PageDef = {
+    gravity: 'down',
+    cards: [
+        { id: 'parent-card', kind: 'headline', parent: 'ceiling' },
+        { id: 'child-card', kind: 'note', parent: 'parent-card' },
+    ],
+}
+
+const cardContent = {
+    'parent-card': { text: 'Headline', width: 240, height: 120 },
+    'child-card': { text: 'A note', width: 200, height: 100 },
+}
+
+describe('PhysicsPage', () => {
+    test('renders one DOM card per spec', () => {
+        render(
+            <PhysicsProvider>
+                <PhysicsPage pageDef={pageDef} cardContent={cardContent} />
+            </PhysicsProvider>,
+        )
+        expect(screen.getByText('Headline')).toBeTruthy()
+        expect(screen.getByText('A note')).toBeTruthy()
+        cleanup()
+    })
+
+    test('note kind gets balloon buoyancy — mounts without throwing', () => {
+        expect(() =>
+            render(
+                <PhysicsProvider>
+                    <PhysicsPage pageDef={pageDef} cardContent={cardContent} />
+                </PhysicsProvider>,
+            ),
+        ).not.toThrow()
+        cleanup()
+    })
+})

--- a/web/src/physics/PhysicsPage.tsx
+++ b/web/src/physics/PhysicsPage.tsx
@@ -1,0 +1,97 @@
+import { useState, useEffect, type ReactNode } from 'react'
+import { PhysicsCard } from './PhysicsCard'
+import { cardLayout, type CardAnchor } from './CardLayout'
+import { buoyancyForKind } from './PageDef'
+import { usePageDef } from './usePageDef'
+import type { PageDef } from './PageDef'
+
+export interface CardContent {
+    text: string
+    width: number
+    height: number
+    children?: ReactNode
+    minimizable?: boolean
+    label?: string
+}
+
+function getViewport() {
+    return typeof window !== 'undefined'
+        ? { width: window.innerWidth, height: window.innerHeight }
+        : { width: 1024, height: 768 }
+}
+
+function noopMeasure() {
+    return { width: 0, height: 0 }
+}
+
+export function PhysicsPage({
+    pageDef,
+    cardContent,
+}: {
+    pageDef: PageDef
+    cardContent: Record<string, CardContent>
+}) {
+    usePageDef(pageDef)
+
+    const [anchors, setAnchors] = useState<CardAnchor[]>(() => {
+        const inputs = pageDef.cards.map((spec) => {
+            const c = cardContent[spec.id]
+            return {
+                id: spec.id,
+                text: c?.text ?? '',
+                fontKey: 'body',
+                width: c?.width,
+                height: c?.height,
+            }
+        })
+        return cardLayout(inputs, getViewport(), noopMeasure)
+    })
+
+    useEffect(() => {
+        function recompute() {
+            const inputs = pageDef.cards.map((spec) => {
+                const c = cardContent[spec.id]
+                return {
+                    id: spec.id,
+                    text: c?.text ?? '',
+                    fontKey: 'body',
+                    width: c?.width,
+                    height: c?.height,
+                }
+            })
+            setAnchors(cardLayout(inputs, getViewport(), noopMeasure))
+        }
+        recompute()
+        window.addEventListener('resize', recompute, { passive: true })
+        return () => window.removeEventListener('resize', recompute)
+    }, [pageDef, cardContent])
+
+    // Build anchor lookup once per render
+    const anchorById = new Map(anchors.map((a) => [a.id, a]))
+
+    return (
+        <>
+            {pageDef.cards.map((spec) => {
+                const anchor = anchorById.get(spec.id)
+                if (!anchor) return null
+                const c = cardContent[spec.id]
+                return (
+                    <PhysicsCard
+                        key={spec.id}
+                        id={spec.id}
+                        text={c?.text ?? ''}
+                        width={anchor.width}
+                        height={anchor.height}
+                        anchor={{ x: anchor.x, y: anchor.y }}
+                        parent={spec.parent}
+                        buoyancy={buoyancyForKind(spec.kind)}
+                        minimizable={c?.minimizable ?? false}
+                        label={c?.label}
+                    >
+                        {c?.children}
+                    </PhysicsCard>
+                )
+            })}
+        </>
+    )
+}

--- a/web/src/physics/PhysicsWorld.test.ts
+++ b/web/src/physics/PhysicsWorld.test.ts
@@ -143,6 +143,33 @@ describe('PhysicsWorld setViewport', () => {
         const pos = world.getPosition(handle)
         expect(pos.y).toBeLessThanOrEqual(200)
     })
+
+    test('top inset at construction: ceiling stops upward-rising body at or below inset y', () => {
+        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 }, insets: { top: 40, bottom: 0 } })
+        const handle = world.register({ x: 400, y: 400 }, { width: 80, height: 40 })
+        world.setGravityDirection('up')
+        for (let i = 0; i < 600; i++) world.tick(FIXED_DT_MS)
+        const pos = world.getPosition(handle)
+        expect(pos.y).toBeGreaterThanOrEqual(40)
+    })
+
+    test('bottom inset at construction: floor catches a falling body above viewport bottom', () => {
+        const world = new PhysicsWorld({ viewport: { width: 800, height: 400 }, insets: { top: 0, bottom: 40 } })
+        const handle = world.register({ x: 400, y: 50 }, { width: 80, height: 40 })
+        for (let i = 0; i < 600; i++) world.tick(FIXED_DT_MS)
+        const pos = world.getPosition(handle)
+        expect(pos.y).toBeLessThanOrEqual(360)
+    })
+
+    test('setViewport with top inset repositions ceiling so rising body stops at inset y', () => {
+        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
+        const handle = world.register({ x: 400, y: 400 }, { width: 80, height: 40 })
+        world.setGravityDirection('up')
+        world.setViewport({ width: 800, height: 600 }, { top: 40, bottom: 0 })
+        for (let i = 0; i < 600; i++) world.tick(FIXED_DT_MS)
+        const pos = world.getPosition(handle)
+        expect(pos.y).toBeGreaterThanOrEqual(40)
+    })
 })
 
 describe('PhysicsWorld drag handles', () => {

--- a/web/src/physics/PhysicsWorld.ts
+++ b/web/src/physics/PhysicsWorld.ts
@@ -19,7 +19,7 @@ export interface Viewport {
 
 export interface PhysicsWorldOptions {
     viewport: Viewport
-    frameBarHeight?: number
+    insets?: { top: number; bottom: number }
 }
 
 export type PhysicsHandle = number
@@ -98,12 +98,14 @@ export class PhysicsWorld {
         this.engine.gravity.y = GRAVITY_Y  // always on, default down
 
         const { width, height } = opts.viewport
-        const frameBarHeight = opts.frameBarHeight ?? 0
+        const top = opts.insets?.top ?? 0
+        const bottom = opts.insets?.bottom ?? 0
+        const hw = FLOOR_THICKNESS / 2
 
         // Floor — dynamic cards fall onto it; balloon cards tether to it
         this._floor = Matter.Bodies.rectangle(
             width / 2,
-            height + FLOOR_THICKNESS / 2,
+            height - bottom + hw,
             width,
             FLOOR_THICKNESS,
             { isStatic: true },
@@ -112,7 +114,7 @@ export class PhysicsWorld {
         const floorId = this.nextId++
         this.registrations.set(floorId, {
             body: this._floor,
-            anchor: { x: width / 2, y: height },
+            anchor: { x: width / 2, y: height - bottom },
             isStatic: true,
             width,
             height: FLOOR_THICKNESS,
@@ -123,7 +125,7 @@ export class PhysicsWorld {
         // Ceiling — heavy cards hang from it; upward-gravity balloon cards fall to it
         this._ceiling = Matter.Bodies.rectangle(
             width / 2,
-            frameBarHeight - FLOOR_THICKNESS / 2,
+            top - hw,
             width,
             FLOOR_THICKNESS,
             { isStatic: true },
@@ -132,7 +134,7 @@ export class PhysicsWorld {
         const ceilingId = this.nextId++
         this.registrations.set(ceilingId, {
             body: this._ceiling,
-            anchor: { x: width / 2, y: frameBarHeight },
+            anchor: { x: width / 2, y: top },
             isStatic: true,
             width,
             height: FLOOR_THICKNESS,
@@ -292,10 +294,12 @@ export class PhysicsWorld {
         return { x: this.engine.gravity.x, y: this.engine.gravity.y }
     }
 
-    setViewport(vp: Viewport): void {
+    setViewport(vp: Viewport, insets?: { top: number; bottom: number }): void {
         const hw = FLOOR_THICKNESS / 2
-        Matter.Body.setPosition(this._floor, { x: vp.width / 2, y: vp.height + hw })
-        Matter.Body.setPosition(this._ceiling, { x: vp.width / 2, y: -hw })
+        const top = insets?.top ?? 0
+        const bottom = insets?.bottom ?? 0
+        Matter.Body.setPosition(this._floor, { x: vp.width / 2, y: vp.height - bottom + hw })
+        Matter.Body.setPosition(this._ceiling, { x: vp.width / 2, y: top - hw })
         Matter.Body.setPosition(this._leftWall, { x: -hw, y: vp.height / 2 })
         Matter.Body.setPosition(this._rightWall, { x: vp.width + hw, y: vp.height / 2 })
     }

--- a/web/src/physics/usePageDef.ts
+++ b/web/src/physics/usePageDef.ts
@@ -1,0 +1,15 @@
+import { useEffect } from 'react'
+import { usePhysicsWorld } from './PhysicsContext'
+import type { PageDef } from './PageDef'
+
+export function usePageDef(pageDef: PageDef): void {
+    const world = usePhysicsWorld()
+    const { gravity } = pageDef
+
+    useEffect(() => {
+        world.setGravityDirection(gravity)
+        return () => {
+            world.setGravityDirection('down')
+        }
+    }, [world, gravity])
+}

--- a/web/src/routes/Home.tsx
+++ b/web/src/routes/Home.tsx
@@ -1,60 +1,35 @@
-import { useState, useEffect } from 'react'
-import { PhysicsCard } from '../physics/PhysicsCard'
-import { cardLayout, type CardSpec, type CardAnchor } from '../physics/CardLayout'
+import { PhysicsPage } from '../physics/PhysicsPage'
+import type { PageDef } from '../physics/PageDef'
+import type { CardContent } from '../physics/PhysicsPage'
 
 const CARD_W = 280
 const CARD_H = 160
 
-const CARD_SPECS: CardSpec[] = [
-    {
-        id: 'card-a',
-        text: 'The quick brown fox jumps over the lazy dog.',
-        fontKey: 'body',
-        width: CARD_W,
-        height: CARD_H,
-    },
-    {
-        id: 'card-b',
-        text: 'Pack my box with five dozen liquor jugs.',
-        fontKey: 'body',
-        width: CARD_W,
-        height: CARD_H,
-    },
-]
+const pageDef: PageDef = {
+    gravity: 'down',
+    cards: [
+        { id: 'card-a', kind: 'headline', parent: 'ceiling' },
+        { id: 'card-b', kind: 'headline', parent: 'ceiling' },
+    ],
+}
 
-function computeAnchors(): CardAnchor[] {
-    const vp = { width: window.innerWidth, height: window.innerHeight }
-    return cardLayout(CARD_SPECS, vp, () => ({ width: 0, height: 0 }))
+const cardContent: Record<string, CardContent> = {
+    'card-a': {
+        text: 'The quick brown fox jumps over the lazy dog.',
+        width: CARD_W,
+        height: CARD_H,
+        minimizable: true,
+        label: 'card-a',
+    },
+    'card-b': {
+        text: 'Pack my box with five dozen liquor jugs.',
+        width: CARD_W,
+        height: CARD_H,
+        minimizable: true,
+        label: 'card-b',
+    },
 }
 
 export default function Home() {
-    const [anchors, setAnchors] = useState<CardAnchor[]>([])
-
-    useEffect(() => {
-        setAnchors(computeAnchors())
-        const onResize = () => setAnchors(computeAnchors())
-        window.addEventListener('resize', onResize, { passive: true })
-        return () => window.removeEventListener('resize', onResize)
-    }, [])
-
-    return (
-        <>
-            {anchors.map((anchor) => {
-                const spec = CARD_SPECS.find((s) => s.id === anchor.id)!
-                return (
-                    <PhysicsCard
-                        key={anchor.id}
-                        text={spec.text}
-                        anchor={{ x: anchor.x, y: anchor.y }}
-                        width={anchor.width}
-                        height={anchor.height}
-                        minimizable
-                        id={`home-${anchor.id}`}
-                        label={anchor.id}
-                        kind="home"
-                    />
-                )
-            })}
-        </>
-    )
+    return <PhysicsPage pageDef={pageDef} cardContent={cardContent} />
 }

--- a/web/src/routes/Lifelog.tsx
+++ b/web/src/routes/Lifelog.tsx
@@ -6,7 +6,7 @@ import './Lifelog.css'
 const BOOKS_W = 240
 const BOOKS_H = 160
 const NOTE_W = 200
-const NOTE_H = 100
+const NOTE_H = 240
 
 const booksChildren = (
     <div className="lifelog-books">

--- a/web/src/routes/Lifelog.tsx
+++ b/web/src/routes/Lifelog.tsx
@@ -45,7 +45,14 @@ const cardContent: Record<string, CardContent> = {
                 text: n.frontmatter.date,
                 width: NOTE_W,
                 height: NOTE_H,
-                children: <p style={{ margin: 0, fontSize: '0.875rem' }}>{n.frontmatter.date}</p>,
+                children: (
+                    <>
+                        <time style={{ display: 'block', fontSize: '0.75rem', opacity: 0.6, marginBottom: '0.5rem' }}>
+                            {n.frontmatter.date}
+                        </time>
+                        <n.Component />
+                    </>
+                ),
             } satisfies CardContent,
         ]),
     ),

--- a/web/src/routes/Lifelog.tsx
+++ b/web/src/routes/Lifelog.tsx
@@ -1,70 +1,56 @@
-// TODO: /portfolio cards will opt in to minimizable once issue #20 ships.
-import { useState, useEffect } from 'react'
-import { PhysicsCard } from '../physics/PhysicsCard'
-import { cardLayout, type CardAnchor } from '../physics/CardLayout'
+import { PhysicsPage, type CardContent } from '../physics/PhysicsPage'
+import { listNotes } from '../lib/NotesReader'
+import type { PageDef } from '../physics/PageDef'
 import './Lifelog.css'
 
-const BOOKS_CARD_HEIGHT = 200
-const BOOKS_CARD_MAX_WIDTH = 360
-const GUTTER = 16
+const BOOKS_W = 240
+const BOOKS_H = 160
+const NOTE_W = 200
+const NOTE_H = 100
 
-function computeBookAnchor(): CardAnchor {
-    const vp = { width: window.innerWidth, height: window.innerHeight }
-    const numCols = vp.width >= 1024 ? 3 : vp.width >= 480 ? 2 : 1
-    const colWidth = vp.width / numCols
-    const w = Math.min(BOOKS_CARD_MAX_WIDTH, colWidth - GUTTER * 2)
-    const anchors = cardLayout(
-        [
+const booksChildren = (
+    <div className="lifelog-books">
+        <h2 className="lifelog-books__heading">Books</h2>
+        <p className="lifelog-books__empty">—</p>
+    </div>
+)
+
+const bookNotes = listNotes({ parent: 'lifelog:books' })
+
+const pageDef: PageDef = {
+    gravity: 'down',
+    cards: [
+        { id: 'lifelog-books', kind: 'lifelog', parent: 'ceiling' },
+        ...bookNotes.map((n) => ({
+            id: `note-${n.slug}`,
+            kind: 'note' as const,
+            parent: 'lifelog-books',
+        })),
+    ],
+}
+
+const cardContent: Record<string, CardContent> = {
+    'lifelog-books': {
+        text: 'Books',
+        width: BOOKS_W,
+        height: BOOKS_H,
+        minimizable: true,
+        label: 'Books',
+        children: booksChildren,
+    },
+    ...Object.fromEntries(
+        bookNotes.map((n) => [
+            `note-${n.slug}`,
             {
-                id: 'books',
-                text: 'Books',
-                fontKey: 'body',
-                width: w,
-                height: BOOKS_CARD_HEIGHT,
-            },
-        ],
-        vp,
-        () => ({ width: 0, height: 0 }),
-    )
-    return (
-        anchors[0] ?? {
-            id: 'books',
-            x: vp.width / 2,
-            y: BOOKS_CARD_HEIGHT / 2 + 80,
-            width: w,
-            height: BOOKS_CARD_HEIGHT,
-            maxWidth: w,
-        }
-    )
+                text: n.frontmatter.date,
+                width: NOTE_W,
+                height: NOTE_H,
+                children: <p style={{ margin: 0, fontSize: '0.875rem' }}>{n.frontmatter.date}</p>,
+            } satisfies CardContent,
+        ]),
+    ),
 }
 
 export default function Lifelog() {
-    const [anchor, setAnchor] = useState<CardAnchor | null>(null)
-
-    useEffect(() => {
-        setAnchor(computeBookAnchor())
-        const onResize = () => setAnchor(computeBookAnchor())
-        window.addEventListener('resize', onResize, { passive: true })
-        return () => window.removeEventListener('resize', onResize)
-    }, [])
-
-    if (!anchor) return null
-
-    return (
-        <PhysicsCard
-            text="Books"
-            anchor={{ x: anchor.x, y: anchor.y }}
-            width={anchor.width}
-            height={anchor.height}
-            minimizable
-            id="lifelog-books"
-            label="Books"
-            kind="lifelog"
-        >
-            <div className="lifelog-books">
-                <h2 className="lifelog-books__heading">Books</h2>
-                <p className="lifelog-books__empty">—</p>
-            </div>
-        </PhysicsCard>
-    )
+    return <PhysicsPage pageDef={pageDef} cardContent={cardContent} />
 }

--- a/web/src/routes/NotFound.tsx
+++ b/web/src/routes/NotFound.tsx
@@ -1,0 +1,87 @@
+import { PhysicsPage } from '../physics/PhysicsPage'
+import { Link } from 'react-router-dom'
+import { getPosts } from '../blog/posts'
+import type { PageDef } from '../physics/PageDef'
+import type { CardContent } from '../physics/PhysicsPage'
+
+const recentPosts = getPosts().slice(0, 3)
+
+const pageDef: PageDef = {
+    gravity: 'up',
+    cards: [
+        { id: 'notfound-headline', kind: 'headline', parent: 'floor' },
+        ...recentPosts.map((p) => ({
+            id: `notfound-blog-${p.slug}`,
+            kind: 'blog' as const,
+            parent: 'floor' as const,
+        })),
+        { id: 'notfound-portfolio', kind: 'portfolio', parent: 'floor' },
+        { id: 'notfound-link', kind: 'link', parent: 'floor' },
+    ],
+}
+
+const cardContent: Record<string, CardContent> = {
+    'notfound-headline': {
+        text: '404 — Page not found',
+        width: 320,
+        height: 160,
+        children: (
+            <>
+                <h1 style={{ margin: 0, fontSize: '1.5rem' }}>404</h1>
+                <p style={{ margin: '0.5rem 0 0' }}>
+                    This page doesn't exist. Everything is floating away.
+                </p>
+            </>
+        ),
+    },
+    ...Object.fromEntries(
+        recentPosts.map((p) => [
+            `notfound-blog-${p.slug}`,
+            {
+                text: p.frontmatter.title,
+                width: 240,
+                height: 140,
+                children: (
+                    <>
+                        <h2 style={{ margin: 0, fontSize: '1rem' }}>
+                            {p.frontmatter.title}
+                        </h2>
+                        <Link to={`/blog/${p.slug}`} style={{ fontSize: '0.875rem' }}>
+                            Read post →
+                        </Link>
+                    </>
+                ),
+            } satisfies CardContent,
+        ]),
+    ),
+    'notfound-portfolio': {
+        text: 'Portfolio',
+        width: 200,
+        height: 120,
+        children: (
+            <>
+                <h2 style={{ margin: 0, fontSize: '1rem' }}>Portfolio</h2>
+                <Link to="/portfolio" style={{ fontSize: '0.875rem' }}>
+                    Browse work →
+                </Link>
+            </>
+        ),
+    },
+    'notfound-link': {
+        text: 'Did you mean / ?',
+        width: 200,
+        height: 100,
+        children: (
+            <>
+                <p style={{ margin: 0, fontSize: '0.875rem' }}>Did you mean</p>
+                <Link to="/" style={{ fontSize: '0.875rem' }}>
+                    Home →
+                </Link>
+            </>
+        ),
+    },
+}
+
+export default function NotFound() {
+    return <PhysicsPage pageDef={pageDef} cardContent={cardContent} />
+}

--- a/web/src/routes/Portfolio.tsx
+++ b/web/src/routes/Portfolio.tsx
@@ -1,0 +1,66 @@
+import { PhysicsPage } from '../physics/PhysicsPage'
+import type { PageDef } from '../physics/PageDef'
+import type { CardContent } from '../physics/PhysicsPage'
+
+const pageDef: PageDef = {
+    gravity: 'down',
+    cards: [
+        { id: 'portfolio-stick', kind: 'portfolio', parent: 'ceiling' },
+        { id: 'portfolio-flash', kind: 'portfolio', parent: 'ceiling' },
+        { id: 'portfolio-anim', kind: 'portfolio', parent: 'ceiling' },
+        { id: 'portfolio-site', kind: 'portfolio', parent: 'ceiling' },
+    ],
+}
+
+const cardContent: Record<string, CardContent> = {
+    'portfolio-stick': {
+        text: 'Stick Figures',
+        width: 240,
+        height: 160,
+        children: (
+            <>
+                <h2>Stick Figures</h2>
+                <p>Flash-era animations — coming soon.</p>
+            </>
+        ),
+    },
+    'portfolio-flash': {
+        text: 'Flash Shorts',
+        width: 240,
+        height: 160,
+        children: (
+            <>
+                <h2>Flash Shorts</h2>
+                <p>Micro-animations from 2004–2008 — coming soon.</p>
+            </>
+        ),
+    },
+    'portfolio-anim': {
+        text: 'Motion Studies',
+        width: 240,
+        height: 160,
+        children: (
+            <>
+                <h2>Motion Studies</h2>
+                <p>Easing and physics explorations — coming soon.</p>
+            </>
+        ),
+    },
+    'portfolio-site': {
+        text: 'This Site',
+        width: 240,
+        height: 160,
+        children: (
+            <>
+                <h2>This Site</h2>
+                <p>
+                    A physics-driven personal site — the source is the artifact.
+                </p>
+            </>
+        ),
+    },
+}
+
+export default function Portfolio() {
+    return <PhysicsPage pageDef={pageDef} cardContent={cardContent} />
+}

--- a/web/src/routes/blog/BlogIndex.measure.test.ts
+++ b/web/src/routes/blog/BlogIndex.measure.test.ts
@@ -5,6 +5,7 @@ import {
     CARD_GAP,
     CARD_PADDING,
     CARD_PADDING_BOTTOM,
+    CARD_HEADER_HEIGHT,
 } from './BlogIndex.measure'
 import type { PostFrontmatter } from '../../blog/types'
 
@@ -33,20 +34,20 @@ describe('measureBlogCard', () => {
         expect(width).toBe(100 + CARD_PADDING * 2)
     })
 
-    test('height = sum of 5 parts (title+desc+date+tags+cta) + 4 gaps + top + bottom padding', () => {
+    test('height = sum of 5 parts (title+desc+date+tags+cta) + 4 gaps + top + bottom padding + header', () => {
         const { height } = measureBlogCard(baseFrontmatter, 400, fixedMeasure)
         const expectedContent = 5 * 20 + 4 * CARD_GAP
         expect(height).toBe(
-            expectedContent + CARD_PADDING + CARD_PADDING_BOTTOM,
+            expectedContent + CARD_PADDING + CARD_PADDING_BOTTOM + CARD_HEADER_HEIGHT,
         )
     })
 
-    test('tag-less post omits the tags row — 4 parts + 3 gaps', () => {
+    test('tag-less post omits the tags row — 4 parts + 3 gaps + header', () => {
         const noTags: PostFrontmatter = { ...baseFrontmatter, tags: [] }
         const { height } = measureBlogCard(noTags, 400, fixedMeasure)
         const expectedContent = 4 * 20 + 3 * CARD_GAP
         expect(height).toBe(
-            expectedContent + CARD_PADDING + CARD_PADDING_BOTTOM,
+            expectedContent + CARD_PADDING + CARD_PADDING_BOTTOM + CARD_HEADER_HEIGHT,
         )
     })
 

--- a/web/src/routes/blog/BlogIndex.measure.ts
+++ b/web/src/routes/blog/BlogIndex.measure.ts
@@ -12,6 +12,13 @@ export const CARD_GAP = 24
 export const CARD_PADDING = 24
 /** Bottom padding — larger than top to give the CTA link more visual breathing room. */
 export const CARD_PADDING_BOTTOM = 36
+/**
+ * Height of the card header bar (minimize button row).
+ * Must match [data-card-header] min-height in PhysicsCard.css.
+ * The header has margin-top: -card-padding so it sits inside the top padding, but
+ * it still consumes this many px of vertical space before the card body content.
+ */
+export const CARD_HEADER_HEIGHT = 32
 
 export function formatPostDate(dateStr: string): string {
     // Replace '-' with '/' so Date parses as local midnight, not UTC midnight.
@@ -48,6 +55,6 @@ export function measureBlogCard(
 
     return {
         width: contentW + CARD_PADDING * 2,
-        height: contentH + CARD_PADDING + CARD_PADDING_BOTTOM,
+        height: contentH + CARD_PADDING + CARD_PADDING_BOTTOM + CARD_HEADER_HEIGHT,
     }
 }

--- a/web/src/routes/blog/BlogIndex.tsx
+++ b/web/src/routes/blog/BlogIndex.tsx
@@ -1,11 +1,6 @@
 import { useState, useEffect } from 'react'
 import { Link } from 'react-router-dom'
-import { PhysicsCard } from '../../physics/PhysicsCard'
-import {
-    cardLayout,
-    type CardSpec,
-    type CardAnchor,
-} from '../../physics/CardLayout'
+import { PhysicsPage, type CardContent } from '../../physics/PhysicsPage'
 import { registry as pretextRegistry } from '../../text/registry'
 import { getPosts } from '../../blog/posts'
 import {
@@ -13,10 +8,20 @@ import {
     formatPostDate,
     CARD_PADDING,
 } from './BlogIndex.measure'
+import type { PageDef } from '../../physics/PageDef'
+
+const GUTTER = 16
 
 const posts = getPosts()
 
-const GUTTER = 16
+const pageDef: PageDef = {
+    gravity: 'down',
+    cards: posts.map((post) => ({
+        id: `blog-${post.slug}`,
+        kind: 'blog' as const,
+        parent: 'ceiling' as const,
+    })),
+}
 
 function colsForWidth(vw: number): number {
     if (vw >= 1024) return 3
@@ -24,78 +29,65 @@ function colsForWidth(vw: number): number {
     return 1
 }
 
-function computeAnchors(): CardAnchor[] {
-    const vp = { width: window.innerWidth, height: window.innerHeight }
-    const numCols = colsForWidth(vp.width)
-    const colWidth = vp.width / numCols
+function buildCardContent(): Record<string, CardContent> {
+    const vw = typeof window !== 'undefined' ? window.innerWidth : 1024
+    const numCols = colsForWidth(vw)
+    const colWidth = vw / numCols
     const textMaxWidth = Math.max(1, colWidth - GUTTER * 2 - CARD_PADDING * 2)
-
     const measure = (text: string, fontKey: string, mw: number) =>
         pretextRegistry.measure(text, fontKey, mw)
 
-    const specs: CardSpec[] = posts.map((post) => {
+    const content: Record<string, CardContent> = {}
+    for (const post of posts) {
         const { width, height } = measureBlogCard(
             post.frontmatter,
             textMaxWidth,
             measure,
         )
-        return {
-            id: post.slug,
+        content[`blog-${post.slug}`] = {
             text: post.frontmatter.title,
-            fontKey: 'body',
             width,
             height,
+            minimizable: true,
+            label: post.frontmatter.title,
+            children: (
+                <>
+                    <h2>{post.frontmatter.title}</h2>
+                    <p>{post.frontmatter.description}</p>
+                    <time dateTime={post.frontmatter.date}>
+                        {formatPostDate(post.frontmatter.date)}
+                    </time>
+                    {post.frontmatter.tags.length > 0 && (
+                        <p className="card-tags">
+                            {post.frontmatter.tags.join(' · ')}
+                        </p>
+                    )}
+                    <Link
+                        to={`/blog/${post.slug}`}
+                        className="read-post-link"
+                    >
+                        Read post →
+                    </Link>
+                </>
+            ),
         }
-    })
-
-    return cardLayout(specs, vp, measure)
+    }
+    return content
 }
 
 export default function BlogIndex() {
-    const [anchors, setAnchors] = useState<CardAnchor[]>([])
+    const [cardContent, setCardContent] = useState<Record<string, CardContent>>(
+        {},
+    )
 
     useEffect(() => {
-        setAnchors(computeAnchors())
-        const onResize = () => setAnchors(computeAnchors())
-        window.addEventListener('resize', onResize, { passive: true })
-        return () => window.removeEventListener('resize', onResize)
+        function update() {
+            setCardContent(buildCardContent())
+        }
+        update()
+        window.addEventListener('resize', update, { passive: true })
+        return () => window.removeEventListener('resize', update)
     }, [])
 
-    return (
-        <>
-            {anchors.map((anchor) => {
-                const post = posts.find((p) => p.slug === anchor.id)!
-                return (
-                    <PhysicsCard
-                        key={anchor.id}
-                        text={post.frontmatter.title}
-                        anchor={{ x: anchor.x, y: anchor.y }}
-                        width={anchor.width}
-                        height={anchor.height}
-                        minimizable
-                        id={`blog-${anchor.id}`}
-                        label={post.frontmatter.title}
-                        kind="blog-post"
-                    >
-                        <h2>{post.frontmatter.title}</h2>
-                        <p>{post.frontmatter.description}</p>
-                        <time dateTime={post.frontmatter.date}>
-                            {formatPostDate(post.frontmatter.date)}
-                        </time>
-                        {post.frontmatter.tags.length > 0 && (
-                            <p className="card-tags">
-                                {post.frontmatter.tags.join(' · ')}
-                            </p>
-                        )}
-                        <Link
-                            to={`/blog/${post.slug}`}
-                            className="read-post-link"
-                        >
-                            Read post →
-                        </Link>
-                    </PhysicsCard>
-                )
-            })}
-        </>
-    )
+    return <PhysicsPage pageDef={pageDef} cardContent={cardContent} />
 }


### PR DESCRIPTION
## Summary

- Introduces \`PageDef { gravity, cards: CardSpec[] }\` where each \`CardSpec\` is \`{id, kind, parent}\` with buoyancy derived from kind (\`note\` → balloon, all others → heavy)
- Shared \`<PhysicsPage pageDef cardContent>\` mapper renders all canvas routes; \`usePageDef\` sets gravity per-route and resets on unmount
- \`StringLayer\` now mounts in \`CanvasLayout\` (was sandbox-only); all canvas routes show visible strings
- \`PhysicsCard\` spawns 20px in gravity direction on mount for a visible settle animation
- New routes: \`/portfolio\` (stub, 4 placeholder cards) and \`*\` catch-all 404 with \`gravity: 'up'\` (cards float upward on floor-anchored strings)
- \`NotesReader\` reads \`content/notes/*.mdx\` at build time; Lifelog renders \`kind: 'note'\` balloon cards strung from the Books card; note cards now render MDX body content (\`Note.Component\`) instead of just the date
- \`CardLayout.CardSpec\` renamed to \`LayoutInput\` (frees name for \`PageDef.CardSpec\`)
- \`PhysicsWorld.setViewport\` now accepts optional \`insets: { top, bottom }\`; \`PhysicsContext\` reads \`useFrameEdge\` and applies a 40px inset on whichever edge the frame bar occupies — ceiling and floor stay aligned with the nav bar and update when the user toggles the edge setting
- \`overflow: hidden\` added to \`.physics-card\` to prevent content bleed; \`measureBlogCard\` corrected to include the 32px header bar height; note card height increased from 100 → 240px to accommodate MDX body text

## Notes / deviations

- **Portfolio**: stub only per agreed scope — real content/Ruffle/morph in a later slice
- **Notes data source**: build-time \`listNotes()\` + 3 sample note files; \`/api/notes\` runtime endpoint deferred
- **404 parent**: uses \`parent: 'floor'\` (not \`'ceiling'\`) — with \`gravity: 'up'\`, floor-anchored strings stretch cards upward giving the dramatic "floating away" visual the PRD describes. Ceiling-anchored with upward gravity would make strings invisible (cards pulled into anchor)
- **BlogIndex SSR**: \`buildCardContent\` (which calls \`pretextRegistry.measure\` requiring DOM canvas) moved to \`useEffect\`; SSR prerender starts with empty state as original did
- **Frame bar inset**: \`FRAME_BAR_HEIGHT = 40\` matches \`.frame-bar { min-height: 40px }\`. The initial edge is read from the singleton controller (defaults to \`'bottom'\`) so SSG prerender and hydration stay consistent

## Acceptance criteria

- [x] \`PageDef\` + \`CardSpec\` (with \`kind\`) exported from \`physics/PageDef.ts\`
- [x] Home declares \`PageDef\` (\`gravity: 'down'\`, both cards from \`ceiling\`, \`kind: 'headline'\`)
- [x] BlogIndex declares \`PageDef\` (\`gravity: 'down'\`, blog cards from \`ceiling\`, \`kind: 'blog'\`)
- [x] Lifelog declares \`PageDef\` (\`gravity: 'down'\`, Books from \`ceiling\`, note balloons from Books id)
- [x] Portfolio declares \`PageDef\` (\`gravity: 'down'\`, 4 placeholder cards from \`ceiling\`)
- [x] 404 declares \`PageDef\` with \`gravity: 'up'\`; no minimize button on any card
- [x] String length auto-derived (unchanged — \`PhysicsCard\` uses \`hypot(anchor − parentPos)\`)
- [x] Spawn ~20px offset in gravity direction, settle ~300ms
- [x] \`kind: 'note'\` → balloon; all others → heavy (\`buoyancyForKind()\`)
- [x] Legacy \`CARD_SPECS\` const removed from Home; BlogIndex/Lifelog inline arrays replaced
- [x] 404 cards: no minimize button (\`minimizable\` not passed, defaults \`false\`)
- [x] Ceiling/floor respect frame bar edge — 40px inset on the nav bar side, updates when edge toggled
- [x] Note cards render MDX body content, not just the date
- [x] No content bleed past card edges (\`overflow: hidden\` + corrected heights)

## Test plan

1. \`npm run typecheck && npm run test\` — 219/219 pass, typecheck clean
2. \`npm run build\` — SSG prerender of all 8 routes succeeds, \`data-server-rendered="true"\` in every HTML file
3. \`npm run dev\`:
   - \`/\` — two headline cards hang from ceiling, swing on drag, strings visible
   - \`/blog\` — blog cards hang from ceiling with strings; card heights fit all content (title, description, date, tags, CTA)
   - \`/lifelog\` — Books card from ceiling; note balloon cards strung below; note body text visible, no bleed
   - \`/portfolio\` — 4 placeholder portfolio cards from ceiling
   - \`/this-does-not-exist\` — cards float **upward**, strings trail down to floor; no minimize button
   - Toggle frame edge (Settings → Frame edge): ceiling/floor shift to match bar position on both top and bottom
   - Resize: layout and strings recompute correctly on all routes

Closes #57