### PR TITLE
Chore: align PRD/issues/memory with gravity+strings redesign (#58)

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -59,7 +59,7 @@ Daily notes and lifelog annotations appear as first-class cards strung to their 
 28. As a portfolio visitor, I want each animation to play in-browser via Ruffle without me installing anything, so that I can actually watch the work.
 29. As a portfolio visitor, I want each piece to have a dedicated route with description, year, and any retrospective notes, so that I get context, not just the artifact.
 30. As a portfolio visitor, I want clicking a portfolio thumbnail to morph it into the hero of the detail page (shared-element transition), so that the navigation feels deliberate and elegant.
-31. As a portfolio visitor, I want the portfolio index cards to be free (draggable, throwable, no spring-back), so that the index itself reflects the playful subject matter.
+31. As a portfolio visitor, I want the portfolio index cards to be detached from any string (gravity acts, they fling and fall when dragged), so that the index itself reflects the playful subject matter.
 32. As a portfolio visitor, I want Ruffle's WASM payload only to load when I'm on a portfolio route, so that visitors never browsing portfolio pages don't pay its bundle cost.
 
 ### Lifelog visitor
@@ -67,9 +67,9 @@ Daily notes and lifelog annotations appear as first-class cards strung to their 
 33. As a lifelog visitor, I want to find a `/lifelog` page that surfaces five sources at once: now-playing music, currently-reading books, recently-watched films, recent GitHub activity, and a stream of free-form daily notes, so that I get a sense of what the site owner is up to.
 34. As a lifelog visitor, I want a dashboard-of-cards default view, so that each source has its own visual presence.
 35. As a lifelog visitor, I want a "feed view" toggle that merges everything chronologically, so that I can read the site like a journal when I want to.
-36. As a lifelog visitor, I want notes to appear as small floating cards spring-attached to their parent card via a visible curved bezier connector, so that I can see "this commentary belongs to that book."
-37. As a lifelog visitor, I want a soft cap of 5 visible notes per parent with the rest expandable inline, so that long-running threads don't blow up the layout.
-38. As a lifelog visitor, I want notes ordered with the newest closest to the parent, so that I read the most recent commentary first.
+36. As a lifelog visitor, I want notes to appear as small balloon cards strung to their parent lifelog card via a visible string (straight when taut, sagging when slack), so that I can see "this commentary belongs to that book."
+37. *(removed — superseded by the strings model; notes are first-class balloon cards in the standard physics world; no soft cap or inline-expand affordance. See ADR 0001.)*
+38. *(removed — note ordering is now determined by `CardLayout` for the route; no per-position recency rule. See ADR 0001.)*
 39. As a lifelog visitor, I want lifelog cards to keep showing their last-known value when an upstream source is broken or slow, so that the page never has gaping holes.
 40. As a lifelog visitor, I want to see a small "stale" hint when data is being served from cache after an upstream failure, so that I know the timing isn't necessarily live.
 
@@ -88,10 +88,10 @@ Daily notes and lifelog annotations appear as first-class cards strung to their 
 48. As a reduced-motion visitor, I want route transitions to become instant cross-fades rather than physics motions, so that I'm never thrown by an animation I didn't ask for.
 49. As a screen-reader user, I want the WebGL canvas marked `aria-hidden="true"`, so that decorative content doesn't pollute my reading.
 50. As a screen-reader user, I want every card's content to live in semantic DOM (`<article>`, `<a>`, `<h1>`, etc.) regardless of physics-driven visual position, so that reading order is determined by structure, not pixels.
-51. As a screen-reader user, I want notes-chain notes nested as an `<aside aria-label="notes">` inside their parent's `<article>`, so that the relationship is announced as a group.
+51. As a screen-reader user, I want note cards nested as an `<aside aria-label="notes">` inside their parent's `<article>`, so that the relationship is announced as a group.
 52. As a keyboard user, I want Tab order to follow the DOM order of cards, so that I navigate predictably regardless of physics positions.
 53. As a keyboard user, I want a high-contrast custom focus ring (the default browser ring is invisible against R3F backgrounds), so that I always know where focus is.
-54. As a keyboard user, I want `Esc` to collapse any expanded notes-chain, so that I can dismiss without mousing.
+54. *(removed — there is no expanded notes-chain to collapse; notes are regular balloon cards. `Esc` still closes the settings menu, declared in the Frame bar section.)*
 55. As a visitor on a browser without WebGL, I want the foreground physics to keep working and the background to swap to a static gradient, so that most of the experience survives.
 56. As a visitor whose WebGL context is lost mid-session, I want the background to fall back gracefully to a static gradient without a page reload, so that the site keeps working.
 


### PR DESCRIPTION
## Summary

- Rewrote 6 stale user stories that still referenced notes-chain / locked-free terminology (stories 31, 36, 37, 38, 51, 54).
- Fixed one stale line in the local May 2026 redesign memory file (`binary locked/free` → `STRUNG or DETACHED`).
- Confirmed all other acceptance criteria were already satisfied by #56 / #57 work: PRD §5 sections, ADR, and remaining memory files were already aligned.

## Notes / deviations

- ADR is at `docs/adr/0001-gravity-and-strings.md` (not `gravity-and-strings.md` as spelled in the issue) — kept the numbered filename since it's already the committed path and referenced in the ADR header.
- Issues #19 and #13 were already closed with appropriate superseded comments. Issue #24 already uses `gravity: 'up'` / `PageDef` language and has no `#13`/`#19` blockers — no edits needed.

## Acceptance criteria

- [x] **Solution paragraph**: floating note-chain sentence removed; gravity always-on wording in place.
- [x] **User stories**: stories 8/9/10 (gravity toggle/nav/persist) removed; story 6 updated (pendulum swing); story 14 (404 gravity:'up'); new gravity identity story added.
- [x] **§5.1 Card interaction**: STRUNG/DETACHED model; padlock removed; no spring-back language.
- [x] **§5.2 Strings** (was NotesChain): rewritten — design-time tree topology, inextensible rope, layout-determines-length, StringLayer SVG.
- [x] **§5.3 PhysicsWorld — gravity**: always-on + per-page direction; `setGravityDirection` in public interface; ceiling + floor + walls; cascade-minimize.
- [x] **§5.3 Settings menu**: gravity toggle removed.
- [x] **§5.X Buoyancy**: new subsection — `kind: 'note'` → balloon, others → heavy.
- [x] **Domain extras — 404**: `gravity: 'up'` in PageDef language.
- [x] **Testing: PhysicsWorld bullets**: updated for new interface.
- [x] **Testing: NotesChain bullets**: replaced with Tether/StringLayer bullets.
- [x] **PRD:368 load-bearing principle**: reworded to reference tether length derivation.
- [x] Close #19 — already closed with superseded comment.
- [x] Close #13 — already closed with superseded comment.
- [x] Edit #24 — body already uses PageDef/gravity:'up' language; no stale blockers.
- [x] Memory `feedback_card_lock_two_state_only.md` — STRUNG/DETACHED already in place.
- [x] Memory `feedback_card_no_spring_back.md` — pendulum-settle wording already in place.
- [x] Memory `feedback_card_chain_string_length.md` — auto-derive language already in place.
- [x] Memory `project_visual_redesign_2026_05.md` — gravity+strings appendix already present; fixed one stale "binary locked/free" line in the "Final design decisions" section.
- [x] `MEMORY.md` index — entries already current.
- [x] `docs/adr/0001-gravity-and-strings.md` — exists, 10 decisions + consequences, complete.

## Test plan

1. Read `PRD.md` user stories end-to-end — confirm no orphaned `notes-chain`, `spring-attached`, `free (draggable`, `locked/free` references outside `*(removed — ...)` placeholders.
2. `grep -nE 'notes-chain|NotesChain|spring-attached|setGravity\(' PRD.md` — only match should be the story-54 removed-placeholder.
3. `gh issue view 19 --repo cpalaka/chaipalaka.com` — CLOSED, superseded comment visible.
4. `gh issue view 13 --repo cpalaka/chaipalaka.com` — CLOSED, superseded comment visible.
5. `gh issue view 24 --repo cpalaka/chaipalaka.com` — body uses `gravity: 'up'` / `PageDef`; no `#13`/`#19` in blockers.
6. `docs/adr/0001-gravity-and-strings.md` — present in repo, 10 decision entries.

Closes #58