### PR TITLE
Slice 9b: GoodreadsAdapter + /api/books (#40)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ web/.vitest-cache/
 
 # Planning docs — kept locally, not tracked
 # (PRD.md and grillmedoc.md are now committed — they are the design record)
+
+# Personal notes
+NOTES.md

--- a/PRD.md
+++ b/PRD.md
@@ -217,7 +217,7 @@ The frame bar is the persistent app-shell chrome. It replaces the original "cont
 - **Endpoints:**
   - `/api/now-playing` — last.fm now-playing — cache 30s
   - `/api/recent-tracks` — last.fm recent tracks — cache 5m
-  - `/api/books` — sourced from `content/books/*.mdx` — cache 1h
+  - `/api/books` — Goodreads RSS (`currently-reading` + `read` shelves, `GOODREADS_USER_ID` env var) — cache 30m
   - `/api/films` — Letterboxd RSS for the user — cache 1h, parsed server-side
   - `/api/github` — GitHub events API — cache 5m (TBD)
   - `/api/notes?parent=<id>|standalone=1` — sourced from `content/notes/*.md` — cache 1h
@@ -349,7 +349,7 @@ There is no prior art in this repo (it's empty). Tests should be set up with:
 - **Full image processing pipeline** (sharp, AVIF/WebP variants, LQIP). Author pre-compresses for v1.
 - **Side-project subdomains.** Deferred — pattern is decided (each its own repo, own Caddy block at `<project>.chaipalaka.com`) but no infrastructure built.
 - **Authentication / private content.** Public-only; if anything sensitive surfaces, keep it out via authoring (not via auth).
-- **Goodreads / Storygraph integration** for books. Manual MDX is the source of truth.
+- **Storygraph integration** as an alternative to Goodreads. Goodreads RSS is the live source in v1.
 - **Spotify integration** (in lieu of last.fm). Spotify requires user-OAuth refresh tokens which can't be browser-side; last.fm covers the use case.
 - **Audio-reactive shader's full ambition** (BPM analysis, Spotify track-feature analysis). v1 audio-reactive uses last.fm now-playing + album-art palette extraction only; deeper audio-feature analysis later.
 - **Comments / annotations from visitors** on the lifelog. Notes are owner-authored only.

--- a/api/src/adapters/GoodreadsAdapter.test.ts
+++ b/api/src/adapters/GoodreadsAdapter.test.ts
@@ -24,7 +24,7 @@ describe('GoodreadsAdapter', () => {
     it('returns a Book for each valid item in the currently-reading shelf', async () => {
       const adapter = new GoodreadsAdapter({
         userId: '12345678',
-        fetch: mockFetch({ 'currently-reading': currentlyReadingXml, read: readXml }),
+        fetch: mockFetch({ 'currently-reading': currentlyReadingXml, favorites: readXml }),
       });
 
       const books = await adapter.fetchBooks();
@@ -37,17 +37,17 @@ describe('GoodreadsAdapter', () => {
       expect(dune?.cover).toBe('https://images.gr-assets.com/books/1555447414m/44767458.jpg');
     });
 
-    it('returns Books for each valid item in the read shelf', async () => {
+    it('returns Books for each valid item in the favorites shelf', async () => {
       const adapter = new GoodreadsAdapter({
         userId: '12345678',
-        fetch: mockFetch({ 'currently-reading': currentlyReadingXml, read: readXml }),
+        fetch: mockFetch({ 'currently-reading': currentlyReadingXml, favorites: readXml }),
       });
 
       const books = await adapter.fetchBooks();
       const foundation = books.find((b) => b.slug === '29579');
 
       expect(foundation).toBeDefined();
-      expect(foundation?.status).toBe('finished');
+      expect(foundation?.status).toBe('favorites');
       expect(foundation?.title).toBe('Foundation');
       expect(foundation?.author).toBe('Isaac Asimov');
     });
@@ -55,15 +55,15 @@ describe('GoodreadsAdapter', () => {
     it('includes both shelves in the returned array', async () => {
       const adapter = new GoodreadsAdapter({
         userId: '12345678',
-        fetch: mockFetch({ 'currently-reading': currentlyReadingXml, read: readXml }),
+        fetch: mockFetch({ 'currently-reading': currentlyReadingXml, favorites: readXml }),
       });
 
       const books = await adapter.fetchBooks();
       const slugs = books.map((b) => b.slug);
 
       expect(slugs).toContain('44767458'); // currently-reading
-      expect(slugs).toContain('29579');    // read
-      expect(slugs).toContain('40961427'); // read
+      expect(slugs).toContain('29579');    // favorites
+      expect(slugs).toContain('40961427'); // favorites
     });
   });
 
@@ -71,22 +71,22 @@ describe('GoodreadsAdapter', () => {
     it('maps currently-reading shelf to status "reading"', async () => {
       const adapter = new GoodreadsAdapter({
         userId: '12345678',
-        fetch: mockFetch({ 'currently-reading': currentlyReadingXml, read: '<rss><channel></channel></rss>' }),
+        fetch: mockFetch({ 'currently-reading': currentlyReadingXml, favorites: '<rss><channel></channel></rss>' }),
       });
 
       const books = await adapter.fetchBooks();
       expect(books.every((b) => b.status === 'reading')).toBe(true);
     });
 
-    it('maps read shelf to status "finished"', async () => {
+    it('maps favorites shelf to status "favorites"', async () => {
       const adapter = new GoodreadsAdapter({
         userId: '12345678',
-        fetch: mockFetch({ 'currently-reading': '<rss><channel></channel></rss>', read: readXml }),
+        fetch: mockFetch({ 'currently-reading': '<rss><channel></channel></rss>', favorites: readXml }),
       });
 
       const books = await adapter.fetchBooks();
-      const readBooks = books.filter((b) => b.slug !== '');
-      expect(readBooks.every((b) => b.status === 'finished')).toBe(true);
+      const favBooks = books.filter((b) => b.slug !== '');
+      expect(favBooks.every((b) => b.status === 'favorites')).toBe(true);
     });
   });
 
@@ -94,7 +94,7 @@ describe('GoodreadsAdapter', () => {
     it('includes rating when user_rating is 1–5', async () => {
       const adapter = new GoodreadsAdapter({
         userId: '12345678',
-        fetch: mockFetch({ 'currently-reading': '<rss><channel></channel></rss>', read: readXml }),
+        fetch: mockFetch({ 'currently-reading': '<rss><channel></channel></rss>', favorites: readXml }),
       });
 
       const books = await adapter.fetchBooks();
@@ -106,7 +106,7 @@ describe('GoodreadsAdapter', () => {
     it('omits rating when user_rating is 0 (unrated)', async () => {
       const adapter = new GoodreadsAdapter({
         userId: '12345678',
-        fetch: mockFetch({ 'currently-reading': currentlyReadingXml, read: '<rss><channel></channel></rss>' }),
+        fetch: mockFetch({ 'currently-reading': currentlyReadingXml, favorites: '<rss><channel></channel></rss>' }),
       });
 
       const books = await adapter.fetchBooks();
@@ -118,7 +118,7 @@ describe('GoodreadsAdapter', () => {
     it('omits rating when user_rating is 0 for a finished book', async () => {
       const adapter = new GoodreadsAdapter({
         userId: '12345678',
-        fetch: mockFetch({ 'currently-reading': '<rss><channel></channel></rss>', read: readXml }),
+        fetch: mockFetch({ 'currently-reading': '<rss><channel></channel></rss>', favorites: readXml }),
       });
 
       const books = await adapter.fetchBooks();
@@ -132,7 +132,7 @@ describe('GoodreadsAdapter', () => {
     it('skips items missing a book_id without throwing', async () => {
       const adapter = new GoodreadsAdapter({
         userId: '12345678',
-        fetch: mockFetch({ 'currently-reading': '<rss><channel></channel></rss>', read: readXml }),
+        fetch: mockFetch({ 'currently-reading': '<rss><channel></channel></rss>', favorites: readXml }),
       });
 
       const books = await adapter.fetchBooks();

--- a/api/src/adapters/GoodreadsAdapter.test.ts
+++ b/api/src/adapters/GoodreadsAdapter.test.ts
@@ -6,14 +6,10 @@ import { GoodreadsAdapter } from './GoodreadsAdapter';
 
 const FIXTURES = join(dirname(fileURLToPath(import.meta.url)), '__fixtures__');
 
-function mockFetch(responses: Record<string, string>): typeof globalThis.fetch {
-  return vi.fn(async (input: string | URL | Request) => {
-    const url = input.toString();
-    const shelf = new URL(url).searchParams.get('shelf') ?? '';
-    const body = responses[shelf];
-    if (!body) throw new Error(`No mock for shelf=${shelf}`);
-    return new Response(body, { status: 200, headers: { 'content-type': 'application/rss+xml' } });
-  }) as unknown as typeof globalThis.fetch;
+function mockFetch(xml: string): typeof globalThis.fetch {
+  return vi.fn(async () =>
+    new Response(xml, { status: 200, headers: { 'content-type': 'application/rss+xml' } }),
+  ) as unknown as typeof globalThis.fetch;
 }
 
 const currentlyReadingXml = readFileSync(join(FIXTURES, 'goodreads-currently-reading.xml'), 'utf-8');
@@ -21,10 +17,10 @@ const readXml = readFileSync(join(FIXTURES, 'goodreads-read.xml'), 'utf-8');
 
 describe('GoodreadsAdapter', () => {
   describe('fetchBooks() — happy path', () => {
-    it('returns a Book for each valid item in the currently-reading shelf', async () => {
+    it('returns a Book for each valid item', async () => {
       const adapter = new GoodreadsAdapter({
         userId: '12345678',
-        fetch: mockFetch({ 'currently-reading': currentlyReadingXml, favorites: readXml }),
+        fetch: mockFetch(currentlyReadingXml),
       });
 
       const books = await adapter.fetchBooks();
@@ -36,57 +32,17 @@ describe('GoodreadsAdapter', () => {
       expect(dune?.status).toBe('currently-reading');
       expect(dune?.cover).toBe('https://images.gr-assets.com/books/1555447414m/44767458.jpg');
     });
-
-    it('returns Books for each valid item in the favorites shelf', async () => {
-      const adapter = new GoodreadsAdapter({
-        userId: '12345678',
-        fetch: mockFetch({ 'currently-reading': currentlyReadingXml, favorites: readXml }),
-      });
-
-      const books = await adapter.fetchBooks();
-      const foundation = books.find((b) => b.slug === '29579');
-
-      expect(foundation).toBeDefined();
-      expect(foundation?.status).toBe('favorites'); // GoodreadsShelf.Favorites
-      expect(foundation?.title).toBe('Foundation');
-      expect(foundation?.author).toBe('Isaac Asimov');
-    });
-
-    it('includes both shelves in the returned array', async () => {
-      const adapter = new GoodreadsAdapter({
-        userId: '12345678',
-        fetch: mockFetch({ 'currently-reading': currentlyReadingXml, favorites: readXml }),
-      });
-
-      const books = await adapter.fetchBooks();
-      const slugs = books.map((b) => b.slug);
-
-      expect(slugs).toContain('44767458'); // currently-reading
-      expect(slugs).toContain('29579');    // favorites
-      expect(slugs).toContain('40961427'); // favorites
-    });
   });
 
   describe('status mapping', () => {
-    it('maps currently-reading shelf to status "reading"', async () => {
+    it('sets status to "currently-reading" for all items', async () => {
       const adapter = new GoodreadsAdapter({
         userId: '12345678',
-        fetch: mockFetch({ 'currently-reading': currentlyReadingXml, favorites: '<rss><channel></channel></rss>' }),
+        fetch: mockFetch(currentlyReadingXml),
       });
 
       const books = await adapter.fetchBooks();
       expect(books.every((b) => b.status === 'currently-reading')).toBe(true);
-    });
-
-    it('maps favorites shelf to status "favorites"', async () => {
-      const adapter = new GoodreadsAdapter({
-        userId: '12345678',
-        fetch: mockFetch({ 'currently-reading': '<rss><channel></channel></rss>', favorites: readXml }),
-      });
-
-      const books = await adapter.fetchBooks();
-      const favBooks = books.filter((b) => b.slug !== '');
-      expect(favBooks.every((b) => b.status === 'favorites')).toBe(true); // GoodreadsShelf.Favorites
     });
   });
 
@@ -94,7 +50,7 @@ describe('GoodreadsAdapter', () => {
     it('includes rating when user_rating is 1–5', async () => {
       const adapter = new GoodreadsAdapter({
         userId: '12345678',
-        fetch: mockFetch({ 'currently-reading': '<rss><channel></channel></rss>', favorites: readXml }),
+        fetch: mockFetch(readXml),
       });
 
       const books = await adapter.fetchBooks();
@@ -106,7 +62,7 @@ describe('GoodreadsAdapter', () => {
     it('omits rating when user_rating is 0 (unrated)', async () => {
       const adapter = new GoodreadsAdapter({
         userId: '12345678',
-        fetch: mockFetch({ 'currently-reading': currentlyReadingXml, favorites: '<rss><channel></channel></rss>' }),
+        fetch: mockFetch(currentlyReadingXml),
       });
 
       const books = await adapter.fetchBooks();
@@ -115,10 +71,10 @@ describe('GoodreadsAdapter', () => {
       expect(dune?.rating).toBeUndefined();
     });
 
-    it('omits rating when user_rating is 0 for a finished book', async () => {
+    it('omits rating when user_rating is 0 even when read_at is set', async () => {
       const adapter = new GoodreadsAdapter({
         userId: '12345678',
-        fetch: mockFetch({ 'currently-reading': '<rss><channel></channel></rss>', favorites: readXml }),
+        fetch: mockFetch(readXml),
       });
 
       const books = await adapter.fetchBooks();
@@ -132,14 +88,14 @@ describe('GoodreadsAdapter', () => {
     it('skips items missing a book_id without throwing', async () => {
       const adapter = new GoodreadsAdapter({
         userId: '12345678',
-        fetch: mockFetch({ 'currently-reading': '<rss><channel></channel></rss>', favorites: readXml }),
+        fetch: mockFetch(readXml),
       });
 
       const books = await adapter.fetchBooks();
       const malformed = books.find((b) => b.title === 'Malformed No ID Book');
 
       expect(malformed).toBeUndefined();
-      expect(books.length).toBeGreaterThan(0); // others survived
+      expect(books.length).toBeGreaterThan(0);
     });
   });
 });

--- a/api/src/adapters/GoodreadsAdapter.test.ts
+++ b/api/src/adapters/GoodreadsAdapter.test.ts
@@ -1,0 +1,145 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it, vi } from 'vitest';
+import { GoodreadsAdapter } from './GoodreadsAdapter';
+
+const FIXTURES = join(dirname(fileURLToPath(import.meta.url)), '__fixtures__');
+
+function mockFetch(responses: Record<string, string>): typeof globalThis.fetch {
+  return vi.fn(async (input: string | URL | Request) => {
+    const url = input.toString();
+    const shelf = new URL(url).searchParams.get('shelf') ?? '';
+    const body = responses[shelf];
+    if (!body) throw new Error(`No mock for shelf=${shelf}`);
+    return new Response(body, { status: 200, headers: { 'content-type': 'application/rss+xml' } });
+  }) as unknown as typeof globalThis.fetch;
+}
+
+const currentlyReadingXml = readFileSync(join(FIXTURES, 'goodreads-currently-reading.xml'), 'utf-8');
+const readXml = readFileSync(join(FIXTURES, 'goodreads-read.xml'), 'utf-8');
+
+describe('GoodreadsAdapter', () => {
+  describe('fetchBooks() — happy path', () => {
+    it('returns a Book for each valid item in the currently-reading shelf', async () => {
+      const adapter = new GoodreadsAdapter({
+        userId: '12345678',
+        fetch: mockFetch({ 'currently-reading': currentlyReadingXml, read: readXml }),
+      });
+
+      const books = await adapter.fetchBooks();
+      const dune = books.find((b) => b.slug === '44767458');
+
+      expect(dune).toBeDefined();
+      expect(dune?.title).toBe('Dune (Dune Chronicles, #1)');
+      expect(dune?.author).toBe('Frank Herbert');
+      expect(dune?.status).toBe('reading');
+      expect(dune?.cover).toBe('https://images.gr-assets.com/books/1555447414m/44767458.jpg');
+    });
+
+    it('returns Books for each valid item in the read shelf', async () => {
+      const adapter = new GoodreadsAdapter({
+        userId: '12345678',
+        fetch: mockFetch({ 'currently-reading': currentlyReadingXml, read: readXml }),
+      });
+
+      const books = await adapter.fetchBooks();
+      const foundation = books.find((b) => b.slug === '29579');
+
+      expect(foundation).toBeDefined();
+      expect(foundation?.status).toBe('finished');
+      expect(foundation?.title).toBe('Foundation');
+      expect(foundation?.author).toBe('Isaac Asimov');
+    });
+
+    it('includes both shelves in the returned array', async () => {
+      const adapter = new GoodreadsAdapter({
+        userId: '12345678',
+        fetch: mockFetch({ 'currently-reading': currentlyReadingXml, read: readXml }),
+      });
+
+      const books = await adapter.fetchBooks();
+      const slugs = books.map((b) => b.slug);
+
+      expect(slugs).toContain('44767458'); // currently-reading
+      expect(slugs).toContain('29579');    // read
+      expect(slugs).toContain('40961427'); // read
+    });
+  });
+
+  describe('status mapping', () => {
+    it('maps currently-reading shelf to status "reading"', async () => {
+      const adapter = new GoodreadsAdapter({
+        userId: '12345678',
+        fetch: mockFetch({ 'currently-reading': currentlyReadingXml, read: '<rss><channel></channel></rss>' }),
+      });
+
+      const books = await adapter.fetchBooks();
+      expect(books.every((b) => b.status === 'reading')).toBe(true);
+    });
+
+    it('maps read shelf to status "finished"', async () => {
+      const adapter = new GoodreadsAdapter({
+        userId: '12345678',
+        fetch: mockFetch({ 'currently-reading': '<rss><channel></channel></rss>', read: readXml }),
+      });
+
+      const books = await adapter.fetchBooks();
+      const readBooks = books.filter((b) => b.slug !== '');
+      expect(readBooks.every((b) => b.status === 'finished')).toBe(true);
+    });
+  });
+
+  describe('rating handling', () => {
+    it('includes rating when user_rating is 1–5', async () => {
+      const adapter = new GoodreadsAdapter({
+        userId: '12345678',
+        fetch: mockFetch({ 'currently-reading': '<rss><channel></channel></rss>', read: readXml }),
+      });
+
+      const books = await adapter.fetchBooks();
+      const foundation = books.find((b) => b.slug === '29579');
+
+      expect(foundation?.rating).toBe(5);
+    });
+
+    it('omits rating when user_rating is 0 (unrated)', async () => {
+      const adapter = new GoodreadsAdapter({
+        userId: '12345678',
+        fetch: mockFetch({ 'currently-reading': currentlyReadingXml, read: '<rss><channel></channel></rss>' }),
+      });
+
+      const books = await adapter.fetchBooks();
+      const dune = books.find((b) => b.slug === '44767458');
+
+      expect(dune?.rating).toBeUndefined();
+    });
+
+    it('omits rating when user_rating is 0 for a finished book', async () => {
+      const adapter = new GoodreadsAdapter({
+        userId: '12345678',
+        fetch: mockFetch({ 'currently-reading': '<rss><channel></channel></rss>', read: readXml }),
+      });
+
+      const books = await adapter.fetchBooks();
+      const orwell = books.find((b) => b.slug === '40961427');
+
+      expect(orwell?.rating).toBeUndefined();
+    });
+  });
+
+  describe('malformed items', () => {
+    it('skips items missing a book_id without throwing', async () => {
+      const adapter = new GoodreadsAdapter({
+        userId: '12345678',
+        fetch: mockFetch({ 'currently-reading': '<rss><channel></channel></rss>', read: readXml }),
+      });
+
+      const books = await adapter.fetchBooks();
+      const malformed = books.find((b) => b.title === 'Malformed No ID Book');
+
+      expect(malformed).toBeUndefined();
+      expect(books.length).toBeGreaterThan(0); // others survived
+    });
+  });
+});

--- a/api/src/adapters/GoodreadsAdapter.test.ts
+++ b/api/src/adapters/GoodreadsAdapter.test.ts
@@ -33,7 +33,7 @@ describe('GoodreadsAdapter', () => {
       expect(dune).toBeDefined();
       expect(dune?.title).toBe('Dune (Dune Chronicles, #1)');
       expect(dune?.author).toBe('Frank Herbert');
-      expect(dune?.status).toBe('reading');
+      expect(dune?.status).toBe('currently-reading');
       expect(dune?.cover).toBe('https://images.gr-assets.com/books/1555447414m/44767458.jpg');
     });
 
@@ -47,7 +47,7 @@ describe('GoodreadsAdapter', () => {
       const foundation = books.find((b) => b.slug === '29579');
 
       expect(foundation).toBeDefined();
-      expect(foundation?.status).toBe('favorites');
+      expect(foundation?.status).toBe('favorites'); // GoodreadsShelf.Favorites
       expect(foundation?.title).toBe('Foundation');
       expect(foundation?.author).toBe('Isaac Asimov');
     });
@@ -75,7 +75,7 @@ describe('GoodreadsAdapter', () => {
       });
 
       const books = await adapter.fetchBooks();
-      expect(books.every((b) => b.status === 'reading')).toBe(true);
+      expect(books.every((b) => b.status === 'currently-reading')).toBe(true);
     });
 
     it('maps favorites shelf to status "favorites"', async () => {
@@ -86,7 +86,7 @@ describe('GoodreadsAdapter', () => {
 
       const books = await adapter.fetchBooks();
       const favBooks = books.filter((b) => b.slug !== '');
-      expect(favBooks.every((b) => b.status === 'favorites')).toBe(true);
+      expect(favBooks.every((b) => b.status === 'favorites')).toBe(true); // GoodreadsShelf.Favorites
     });
   });
 

--- a/api/src/adapters/GoodreadsAdapter.ts
+++ b/api/src/adapters/GoodreadsAdapter.ts
@@ -1,6 +1,5 @@
 export enum GoodreadsShelf {
   CurrentlyReading = 'currently-reading',
-  Favorites = 'favorites',
 }
 
 export interface Book {
@@ -76,16 +75,16 @@ export class GoodreadsAdapter {
   }
 
   async fetchBooks(): Promise<Book[]> {
-    const [reading, favorites] = await Promise.all([
-      this.fetchShelf(GoodreadsShelf.CurrentlyReading),
-      this.fetchShelf(GoodreadsShelf.Favorites),
-    ])
-    return [...reading, ...favorites]
+    return this.fetchShelf(GoodreadsShelf.CurrentlyReading)
   }
 
   private async fetchShelf(shelf: GoodreadsShelf): Promise<Book[]> {
     const url = `https://www.goodreads.com/review/list_rss/${this.userId}?shelf=${shelf}`
-    const res = await this.fetchFn(url)
+    const res = await this.fetchFn(url, {
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36',
+      },
+    })
     if (!res.ok) throw new Error(`Goodreads ${shelf} returned ${res.status}`)
     const xml = await res.text()
     return parseItems(xml, shelf)

--- a/api/src/adapters/GoodreadsAdapter.ts
+++ b/api/src/adapters/GoodreadsAdapter.ts
@@ -1,10 +1,13 @@
-export type BookStatus = 'reading' | 'finished' | 'favorites' | 'want-to-read'
+export enum GoodreadsShelf {
+  CurrentlyReading = 'currently-reading',
+  Favorites = 'favorites',
+}
 
 export interface Book {
   slug: string
   title: string
   author: string
-  status: BookStatus
+  status: GoodreadsShelf
   started?: string
   finished?: string
   cover?: string
@@ -31,7 +34,7 @@ function toIso(dateStr: string): string | undefined {
   return isNaN(d.getTime()) ? undefined : d.toISOString()
 }
 
-function parseItems(xml: string, status: BookStatus): Book[] {
+function parseItems(xml: string, shelf: GoodreadsShelf): Book[] {
   const books: Book[] = []
   const blocks = xml.split('</item>')
   for (const block of blocks) {
@@ -58,7 +61,7 @@ function parseItems(xml: string, status: BookStatus): Book[] {
     const started = toIso(field(item, 'user_date_added'))
     const finished = toIso(field(item, 'user_read_at'))
 
-    books.push({ slug, title, author, status, started, finished, cover, rating })
+    books.push({ slug, title, author, status: shelf, started, finished, cover, rating })
   }
   return books
 }
@@ -74,17 +77,17 @@ export class GoodreadsAdapter {
 
   async fetchBooks(): Promise<Book[]> {
     const [reading, favorites] = await Promise.all([
-      this.fetchShelf('currently-reading', 'reading'),
-      this.fetchShelf('favorites', 'favorites'),
+      this.fetchShelf(GoodreadsShelf.CurrentlyReading),
+      this.fetchShelf(GoodreadsShelf.Favorites),
     ])
     return [...reading, ...favorites]
   }
 
-  private async fetchShelf(shelf: string, status: BookStatus): Promise<Book[]> {
+  private async fetchShelf(shelf: GoodreadsShelf): Promise<Book[]> {
     const url = `https://www.goodreads.com/review/list_rss/${this.userId}?shelf=${shelf}`
     const res = await this.fetchFn(url)
     if (!res.ok) throw new Error(`Goodreads ${shelf} returned ${res.status}`)
     const xml = await res.text()
-    return parseItems(xml, status)
+    return parseItems(xml, shelf)
   }
 }

--- a/api/src/adapters/GoodreadsAdapter.ts
+++ b/api/src/adapters/GoodreadsAdapter.ts
@@ -1,4 +1,4 @@
-export type BookStatus = 'reading' | 'finished' | 'want-to-read'
+export type BookStatus = 'reading' | 'finished' | 'favorites' | 'want-to-read'
 
 export interface Book {
   slug: string
@@ -73,11 +73,11 @@ export class GoodreadsAdapter {
   }
 
   async fetchBooks(): Promise<Book[]> {
-    const [reading, read] = await Promise.all([
+    const [reading, favorites] = await Promise.all([
       this.fetchShelf('currently-reading', 'reading'),
-      this.fetchShelf('read', 'finished'),
+      this.fetchShelf('favorites', 'favorites'),
     ])
-    return [...reading, ...read]
+    return [...reading, ...favorites]
   }
 
   private async fetchShelf(shelf: string, status: BookStatus): Promise<Book[]> {

--- a/api/src/adapters/GoodreadsAdapter.ts
+++ b/api/src/adapters/GoodreadsAdapter.ts
@@ -1,0 +1,90 @@
+export type BookStatus = 'reading' | 'finished' | 'want-to-read'
+
+export interface Book {
+  slug: string
+  title: string
+  author: string
+  status: BookStatus
+  started?: string
+  finished?: string
+  cover?: string
+  rating?: number
+}
+
+export interface GoodreadsAdapterOpts {
+  userId: string
+  fetch?: typeof globalThis.fetch
+}
+
+// Extracts content from a named XML tag — handles both CDATA and plain text.
+function field(xml: string, tag: string): string {
+  const m = xml.match(
+    new RegExp(`<${tag}[^>]*>(?:<!\\[CDATA\\[([\\s\\S]*?)\\]\\]>|([^<]*))<\\/${tag}>`),
+  )
+  if (!m) return ''
+  return (m[1] ?? m[2] ?? '').trim()
+}
+
+function toIso(dateStr: string): string | undefined {
+  if (!dateStr) return undefined
+  const d = new Date(dateStr)
+  return isNaN(d.getTime()) ? undefined : d.toISOString()
+}
+
+function parseItems(xml: string, status: BookStatus): Book[] {
+  const books: Book[] = []
+  const blocks = xml.split('</item>')
+  for (const block of blocks) {
+    const start = block.indexOf('<item>')
+    if (start === -1) continue
+    const item = block.slice(start)
+
+    const slug = field(item, 'book_id')
+    if (!slug) {
+      console.warn('[GoodreadsAdapter] skipping item: missing book_id')
+      continue
+    }
+
+    const title = field(item, 'title')
+    const author = field(item, 'author_name')
+    if (!title || !author) {
+      console.warn(`[GoodreadsAdapter] skipping item ${slug}: missing required field`)
+      continue
+    }
+
+    const cover = field(item, 'book_image_url') || undefined
+    const ratingRaw = parseInt(field(item, 'user_rating'), 10)
+    const rating = !isNaN(ratingRaw) && ratingRaw > 0 ? ratingRaw : undefined
+    const started = toIso(field(item, 'user_date_added'))
+    const finished = toIso(field(item, 'user_read_at'))
+
+    books.push({ slug, title, author, status, started, finished, cover, rating })
+  }
+  return books
+}
+
+export class GoodreadsAdapter {
+  private readonly userId: string
+  private readonly fetchFn: typeof globalThis.fetch
+
+  constructor(opts: GoodreadsAdapterOpts) {
+    this.userId = opts.userId
+    this.fetchFn = opts.fetch ?? globalThis.fetch
+  }
+
+  async fetchBooks(): Promise<Book[]> {
+    const [reading, read] = await Promise.all([
+      this.fetchShelf('currently-reading', 'reading'),
+      this.fetchShelf('read', 'finished'),
+    ])
+    return [...reading, ...read]
+  }
+
+  private async fetchShelf(shelf: string, status: BookStatus): Promise<Book[]> {
+    const url = `https://www.goodreads.com/review/list_rss/${this.userId}?shelf=${shelf}`
+    const res = await this.fetchFn(url)
+    if (!res.ok) throw new Error(`Goodreads ${shelf} returned ${res.status}`)
+    const xml = await res.text()
+    return parseItems(xml, status)
+  }
+}

--- a/api/src/adapters/__fixtures__/goodreads-currently-reading.xml
+++ b/api/src/adapters/__fixtures__/goodreads-currently-reading.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title><![CDATA[Goodreads – shelf: currently-reading]]></title>
+    <link>https://www.goodreads.com/review/list_rss/12345678?shelf=currently-reading</link>
+    <description>Goodreads: book reviews and recommendations</description>
+    <item>
+      <guid><![CDATA[https://www.goodreads.com/review/show/9000000001]]></guid>
+      <pubDate>Mon, 05 May 2026 00:00:00 -0700</pubDate>
+      <title><![CDATA[Dune (Dune Chronicles, #1)]]></title>
+      <link><![CDATA[https://www.goodreads.com/book/show/44767458-dune]]></link>
+      <book_id>44767458</book_id>
+      <book_image_url><![CDATA[https://images.gr-assets.com/books/1555447414m/44767458.jpg]]></book_image_url>
+      <author_name><![CDATA[Frank Herbert]]></author_name>
+      <user_rating>0</user_rating>
+      <user_read_at></user_read_at>
+      <user_date_added><![CDATA[Mon May 05 00:00:00 -0700 2026]]></user_date_added>
+      <average_rating>4.26</average_rating>
+    </item>
+  </channel>
+</rss>

--- a/api/src/adapters/__fixtures__/goodreads-read.xml
+++ b/api/src/adapters/__fixtures__/goodreads-read.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title><![CDATA[Goodreads – shelf: read]]></title>
+    <link>https://www.goodreads.com/review/list_rss/12345678?shelf=read</link>
+    <description>Goodreads: book reviews and recommendations</description>
+    <item>
+      <guid><![CDATA[https://www.goodreads.com/review/show/9000000002]]></guid>
+      <pubDate>Tue, 01 Apr 2026 00:00:00 -0700</pubDate>
+      <title><![CDATA[Foundation]]></title>
+      <link><![CDATA[https://www.goodreads.com/book/show/29579-foundation]]></link>
+      <book_id>29579</book_id>
+      <book_image_url><![CDATA[https://images.gr-assets.com/books/1417900846m/29579.jpg]]></book_image_url>
+      <author_name><![CDATA[Isaac Asimov]]></author_name>
+      <user_rating>5</user_rating>
+      <user_read_at><![CDATA[Tue Apr 01 00:00:00 -0700 2026]]></user_read_at>
+      <user_date_added><![CDATA[Mon Mar 01 00:00:00 -0800 2026]]></user_date_added>
+      <average_rating>4.36</average_rating>
+    </item>
+    <item>
+      <guid><![CDATA[https://www.goodreads.com/review/show/9000000003]]></guid>
+      <pubDate>Sat, 01 Feb 2026 00:00:00 -0800</pubDate>
+      <title><![CDATA[1984]]></title>
+      <link><![CDATA[https://www.goodreads.com/book/show/40961427-1984]]></link>
+      <book_id>40961427</book_id>
+      <book_image_url><![CDATA[https://images.gr-assets.com/books/1532714506m/40961427.jpg]]></book_image_url>
+      <author_name><![CDATA[George Orwell]]></author_name>
+      <user_rating>0</user_rating>
+      <user_read_at><![CDATA[Sat Feb 01 00:00:00 -0800 2026]]></user_read_at>
+      <user_date_added><![CDATA[Mon Jan 05 00:00:00 -0800 2026]]></user_date_added>
+      <average_rating>4.19</average_rating>
+    </item>
+    <item>
+      <guid><![CDATA[https://www.goodreads.com/review/show/9000000004]]></guid>
+      <pubDate>Sat, 01 Jan 2026 00:00:00 -0800</pubDate>
+      <title><![CDATA[Malformed No ID Book]]></title>
+      <link><![CDATA[https://www.goodreads.com/book/show/]]></link>
+      <book_id></book_id>
+      <book_image_url></book_image_url>
+      <author_name><![CDATA[Unknown Author]]></author_name>
+      <user_rating>3</user_rating>
+      <user_read_at><![CDATA[Thu Jan 01 00:00:00 -0800 2026]]></user_read_at>
+      <user_date_added><![CDATA[Wed Dec 01 00:00:00 -0800 2025]]></user_date_added>
+      <average_rating>3.00</average_rating>
+    </item>
+  </channel>
+</rss>

--- a/api/src/server.test.ts
+++ b/api/src/server.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import type { Book } from './adapters/GoodreadsAdapter';
+import { GoodreadsShelf, type Book } from './adapters/GoodreadsAdapter';
 import { handle } from './server';
 
 const FIXTURE_BOOKS: Book[] = [
@@ -7,14 +7,14 @@ const FIXTURE_BOOKS: Book[] = [
     slug: '44767458',
     title: 'Dune',
     author: 'Frank Herbert',
-    status: 'reading',
+    status: GoodreadsShelf.CurrentlyReading,
     cover: 'https://images.gr-assets.com/books/1555447414m/44767458.jpg',
   },
   {
     slug: '29579',
     title: 'Foundation',
     author: 'Isaac Asimov',
-    status: 'finished',
+    status: GoodreadsShelf.Favorites,
     rating: 5,
   },
 ]

--- a/api/src/server.test.ts
+++ b/api/src/server.test.ts
@@ -14,7 +14,7 @@ const FIXTURE_BOOKS: Book[] = [
     slug: '29579',
     title: 'Foundation',
     author: 'Isaac Asimov',
-    status: GoodreadsShelf.Favorites,
+    status: GoodreadsShelf.CurrentlyReading,
     rating: 5,
   },
 ]

--- a/api/src/server.test.ts
+++ b/api/src/server.test.ts
@@ -1,5 +1,27 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+import type { Book } from './adapters/GoodreadsAdapter';
 import { handle } from './server';
+
+const FIXTURE_BOOKS: Book[] = [
+  {
+    slug: '44767458',
+    title: 'Dune',
+    author: 'Frank Herbert',
+    status: 'reading',
+    cover: 'https://images.gr-assets.com/books/1555447414m/44767458.jpg',
+  },
+  {
+    slug: '29579',
+    title: 'Foundation',
+    author: 'Isaac Asimov',
+    status: 'finished',
+    rating: 5,
+  },
+]
+
+function makeAdapter(books: Book[] = FIXTURE_BOOKS, fail = false) {
+  return { fetchBooks: vi.fn(async () => { if (fail) throw new Error('upstream'); return books }) }
+}
 
 describe('handle', () => {
   it('GET /api/health → 200 with {ok: true, version}', async () => {
@@ -27,4 +49,63 @@ describe('handle', () => {
 
     expect(res.status).toBe(404);
   });
+});
+
+describe('/api/books', () => {
+  it('returns { books, stale: false } with the adapter results', async () => {
+    const adapter = makeAdapter()
+    const res = await handle(
+      new Request('http://localhost/api/books'),
+      { goodreadsUserId: 'u1', booksAdapter: adapter },
+    )
+
+    expect(res.status).toBe(200)
+    const body = await res.json() as { books: Book[]; stale: boolean }
+    expect(body.stale).toBe(false)
+    expect(body.books).toHaveLength(2)
+    expect(body.books[0]?.slug).toBe('44767458')
+  })
+
+  it('returns empty books (not stale) when goodreadsUserId is absent', async () => {
+    const res = await handle(
+      new Request('http://localhost/api/books'),
+      {},
+    )
+
+    expect(res.status).toBe(200)
+    const body = await res.json() as { books: Book[]; stale: boolean }
+    expect(body.books).toEqual([])
+    expect(body.stale).toBe(false)
+  })
+
+  it('returns empty books with stale:true when adapter throws and cache is cold', async () => {
+    const adapter = makeAdapter([], true)
+    const { CacheLayer } = await import('./cache/CacheLayer')
+    const res = await handle(
+      new Request('http://localhost/api/books'),
+      { goodreadsUserId: 'u1', booksAdapter: adapter, cache: new CacheLayer() },
+    )
+
+    expect(res.status).toBe(200)
+    const body = await res.json() as { books: Book[]; stale: boolean }
+    expect(body.books).toEqual([])
+    expect(body.stale).toBe(true)
+  })
+
+  it('caches: calls fetchBooks only once across two requests within TTL', async () => {
+    const adapter = makeAdapter()
+    const { CacheLayer } = await import('./cache/CacheLayer')
+    const cache = new CacheLayer()
+
+    await handle(
+      new Request('http://localhost/api/books'),
+      { goodreadsUserId: 'u1', booksAdapter: adapter, cache },
+    )
+    await handle(
+      new Request('http://localhost/api/books'),
+      { goodreadsUserId: 'u1', booksAdapter: adapter, cache },
+    )
+
+    expect(adapter.fetchBooks).toHaveBeenCalledTimes(1)
+  })
 });

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -1,18 +1,55 @@
-export type ServerConfig = { version?: string };
+import { CacheLayer } from './cache/CacheLayer';
+import type { GoodreadsAdapter } from './adapters/GoodreadsAdapter';
+import { GoodreadsAdapter as GoodreadsAdapterImpl } from './adapters/GoodreadsAdapter';
+
+export type ServerConfig = {
+  version?: string
+  goodreadsUserId?: string
+  booksAdapter?: Pick<GoodreadsAdapter, 'fetchBooks'>
+  cache?: CacheLayer
+};
+
+const sharedCache = new CacheLayer();
+const BOOKS_TTL_MS = 30 * 60 * 1000; // 30 minutes
 
 export async function handle(
   req: Request,
   config: ServerConfig,
 ): Promise<Response> {
   const url = new URL(req.url);
+
   if (url.pathname === '/api/health') {
     return Response.json({ ok: true, version: config.version ?? 'dev' });
   }
+
+  if (url.pathname === '/api/books') {
+    if (!config.goodreadsUserId) {
+      return Response.json({ books: [], stale: false });
+    }
+    const adapter =
+      config.booksAdapter ??
+      new GoodreadsAdapterImpl({ userId: config.goodreadsUserId });
+    const cache = config.cache ?? sharedCache;
+    try {
+      const { value, stale } = await cache.get(
+        'books',
+        () => adapter.fetchBooks(),
+        { ttl: BOOKS_TTL_MS },
+      );
+      return Response.json({ books: value, stale });
+    } catch {
+      return Response.json({ books: [], stale: true });
+    }
+  }
+
   return new Response('not found', { status: 404 });
 }
 
 if (import.meta.main) {
-  const config: ServerConfig = { version: process.env.BUILD_SHA };
+  const config: ServerConfig = {
+    version: process.env.BUILD_SHA,
+    goodreadsUserId: process.env.GOODREADS_USER_ID,
+  };
   Bun.serve({
     port: 3000,
     hostname: '127.0.0.1',

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -37,8 +37,10 @@ export async function handle(
         { ttl: BOOKS_TTL_MS },
       );
       return Response.json({ books: value, stale });
-    } catch {
-      return Response.json({ books: [], stale: true });
+    } catch(e) {
+      const error = e instanceof Error ? e.message : String(e);
+      console.error('[Server] failed to fetch books', e);
+      return Response.json({ books: [], stale: true, error });
     }
   }
 

--- a/web/src/blog/components/BookCard.tsx
+++ b/web/src/blog/components/BookCard.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react'
 import './BookCard.css'
 
-type BookStatus = 'reading' | 'finished' | 'abandoned' | 'want-to-read'
+type BookStatus = 'reading' | 'finished' | 'favorites' | 'abandoned' | 'want-to-read'
 
 interface BookFromApi {
     slug: string
@@ -22,6 +22,7 @@ interface BooksApiResponse {
 const STATUS_LABELS: Record<BookStatus, string> = {
     reading: 'Reading',
     finished: 'Finished',
+    favorites: 'Favorite',
     abandoned: 'Abandoned',
     'want-to-read': 'Want to Read',
 }

--- a/web/src/blog/components/BookCard.tsx
+++ b/web/src/blog/components/BookCard.tsx
@@ -1,14 +1,14 @@
 import { useState, useEffect } from 'react'
 import './BookCard.css'
 
-type BookStatus = 'reading' | 'finished' | 'favorites' | 'abandoned' | 'want-to-read'
+type BookShelf = 'currently-reading' | 'favorites'
 
 interface BookFromApi {
     slug: string
     title: string
     author: string
-    status: BookStatus
-    started: string
+    status: BookShelf
+    started?: string
     finished?: string
     cover?: string
     rating?: number
@@ -19,12 +19,9 @@ interface BooksApiResponse {
     stale: boolean
 }
 
-const STATUS_LABELS: Record<BookStatus, string> = {
-    reading: 'Reading',
-    finished: 'Finished',
+const STATUS_LABELS: Record<BookShelf, string> = {
+    'currently-reading': 'Reading',
     favorites: 'Favorite',
-    abandoned: 'Abandoned',
-    'want-to-read': 'Want to Read',
 }
 
 // Module-level promise: all <BookCard> instances on a page share one /api/books request.

--- a/web/src/blog/components/BookCard.tsx
+++ b/web/src/blog/components/BookCard.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react'
 import './BookCard.css'
 
-type BookShelf = 'currently-reading' | 'favorites'
+type BookShelf = 'currently-reading'
 
 interface BookFromApi {
     slug: string
@@ -21,7 +21,6 @@ interface BooksApiResponse {
 
 const STATUS_LABELS: Record<BookShelf, string> = {
     'currently-reading': 'Reading',
-    favorites: 'Favorite',
 }
 
 // Module-level promise: all <BookCard> instances on a page share one /api/books request.

--- a/web/src/routes/Lifelog.test.ts
+++ b/web/src/routes/Lifelog.test.ts
@@ -1,57 +1,19 @@
 import { describe, test, expect } from 'vitest'
-import {
-    booksAnchor,
-    noteAnchor,
-    NOTE_FAN_OFFSET_X,
-    NOTE_ROW_STEP_Y,
-} from './Lifelog'
+import { booksAnchor } from './Lifelog'
 
 const viewport = { width: 1200, height: 800 }
-const BOOKS_H = 160
 
-describe('Lifelog note anchor placement', () => {
+describe('Lifelog anchor placement', () => {
     test('books card anchors to horizontal center', () => {
         expect(booksAnchor(viewport).x).toBe(viewport.width / 2)
     })
 
-    test('with 2 notes, note[0] is left of Books, note[1] is right', () => {
-        const books = booksAnchor(viewport)
-        const n0 = noteAnchor(0)(viewport)
-        const n1 = noteAnchor(1)(viewport)
-        expect(n0.x).toBeLessThan(books.x)
-        expect(n1.x).toBeGreaterThan(books.x)
+    test('books card anchors at y=200', () => {
+        expect(booksAnchor(viewport).y).toBe(200)
     })
 
-    test('both notes hang below Books', () => {
-        const books = booksAnchor(viewport)
-        const n0 = noteAnchor(0)(viewport)
-        const n1 = noteAnchor(1)(viewport)
-        expect(n0.y).toBeGreaterThan(books.y)
-        expect(n1.y).toBeGreaterThan(books.y)
-    })
-
-    test('vertical gap from Books to first note exceeds BOOKS_H + 60', () => {
-        const books = booksAnchor(viewport)
-        const n0 = noteAnchor(0)(viewport)
-        expect(n0.y - books.y).toBeGreaterThan(BOOKS_H + 60)
-    })
-
-    test('note x adapts to viewport width on resize', () => {
+    test('books anchor adapts to viewport width', () => {
         const narrow = { width: 800, height: 600 }
-        const n0 = noteAnchor(0)(narrow)
-        expect(n0.x).toBe(narrow.width / 2 - NOTE_FAN_OFFSET_X)
-    })
-
-    test('notes in row 1 (index 2, 3) are further down than row 0', () => {
-        const n0 = noteAnchor(0)(viewport)
-        const n2 = noteAnchor(2)(viewport)
-        expect(n2.y - n0.y).toBe(NOTE_ROW_STEP_Y)
-    })
-
-    test('symmetric fan: note[0] and note[1] are equidistant from books center', () => {
-        const books = booksAnchor(viewport)
-        const n0 = noteAnchor(0)(viewport)
-        const n1 = noteAnchor(1)(viewport)
-        expect(Math.abs(n0.x - books.x)).toBe(Math.abs(n1.x - books.x))
+        expect(booksAnchor(narrow).x).toBe(400)
     })
 })

--- a/web/src/routes/Lifelog.tsx
+++ b/web/src/routes/Lifelog.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react'
 import { PhysicsPage, type CardContent } from '../physics/PhysicsPage'
 import { listNotes } from '../lib/NotesReader'
 import type { PageDef } from '../physics/PageDef'
@@ -27,12 +28,70 @@ export function noteAnchor(i: number) {
     }
 }
 
-const booksChildren = (
-    <div className="lifelog-books">
-        <h2 className="lifelog-books__heading">Books</h2>
-        <p className="lifelog-books__empty">—</p>
-    </div>
-)
+type BookStatus = 'reading' | 'finished' | 'want-to-read'
+
+interface Book {
+    slug: string
+    title: string
+    author: string
+    status: BookStatus
+    started?: string
+    finished?: string
+    cover?: string
+    rating?: number
+}
+
+interface BooksApiResponse {
+    books: Book[]
+    stale: boolean
+}
+
+const STATUS_LABELS: Record<BookStatus, string> = {
+    reading: 'Reading',
+    finished: 'Finished',
+    'want-to-read': 'Want to Read',
+}
+
+function BooksPanel() {
+    const [data, setData] = useState<BooksApiResponse | null>(null)
+
+    useEffect(() => {
+        fetch('/api/books')
+            .then((r) => r.json() as Promise<BooksApiResponse>)
+            .then(setData)
+            .catch(() => setData(null))
+    }, [])
+
+    const books = data?.books ?? []
+
+    return (
+        <div className="lifelog-books">
+            <h2 className="lifelog-books__heading">
+                Books
+                {data?.stale ? (
+                    <span className="lifelog-books__stale">stale</span>
+                ) : null}
+            </h2>
+            {books.length > 0 ? (
+                <ul className="lifelog-books__list">
+                    {books.map((b) => (
+                        <li key={b.slug} className="lifelog-books__item">
+                            <span
+                                className={`lifelog-books__status lifelog-books__status--${b.status}`}
+                            >
+                                {STATUS_LABELS[b.status]}
+                            </span>
+                            <span className="lifelog-books__title">{b.title}</span>
+                            <span className="lifelog-books__author">{b.author}</span>
+                        </li>
+                    ))}
+                </ul>
+            ) : (
+                <p className="lifelog-books__empty">—</p>
+            )}
+        </div>
+    )
+}
 
 const bookNotes = listNotes({ parent: 'lifelog:books' })
 
@@ -61,7 +120,7 @@ const cardContent: Record<string, CardContent> = {
         height: BOOKS_H,
         minimizable: true,
         label: 'Books',
-        children: booksChildren,
+        children: <BooksPanel />,
     },
     ...Object.fromEntries(
         bookNotes.map((n) => [

--- a/web/src/routes/Lifelog.tsx
+++ b/web/src/routes/Lifelog.tsx
@@ -28,7 +28,7 @@ export function noteAnchor(i: number) {
     }
 }
 
-type BookShelf = 'currently-reading' | 'favorites'
+type BookShelf = 'currently-reading'
 
 interface Book {
     slug: string
@@ -48,7 +48,6 @@ interface BooksApiResponse {
 
 const STATUS_LABELS: Record<BookShelf, string> = {
     'currently-reading': 'Reading',
-    favorites: 'Favorite',
 }
 
 function BooksPanel() {

--- a/web/src/routes/Lifelog.tsx
+++ b/web/src/routes/Lifelog.tsx
@@ -1,32 +1,14 @@
 import { useEffect, useState } from 'react'
 import { PhysicsPage, type CardContent } from '../physics/PhysicsPage'
-import { listNotes } from '../lib/NotesReader'
 import type { PageDef } from '../physics/PageDef'
 import type { Vec2, Viewport } from '../physics/PhysicsWorld'
 import './Lifelog.css'
 
-const BOOKS_W = 240
-const BOOKS_H = 160
-const NOTE_W = 200
-const NOTE_H = 240
+const BOOKS_W = 320
+const BOOKS_H = 280
 
 export const booksAnchor = (vp: Viewport): Vec2 => ({ x: vp.width / 2, y: 200 })
 
-export const NOTE_FAN_OFFSET_X = 200
-export const NOTE_BASE_OFFSET_Y = 280
-export const NOTE_ROW_STEP_Y = 260
-
-export function noteAnchor(i: number) {
-    return (vp: Viewport): Vec2 => {
-        const base = booksAnchor(vp)
-        const side = i % 2 === 0 ? -NOTE_FAN_OFFSET_X : NOTE_FAN_OFFSET_X
-        const row = Math.floor(i / 2)
-        return {
-            x: base.x + side,
-            y: base.y + NOTE_BASE_OFFSET_Y + row * NOTE_ROW_STEP_Y,
-        }
-    }
-}
 
 type BookShelf = 'currently-reading'
 
@@ -91,8 +73,6 @@ function BooksPanel() {
     )
 }
 
-const bookNotes = listNotes({ parent: 'lifelog:books' })
-
 const pageDef: PageDef = {
     gravity: 'down',
     cards: [
@@ -102,12 +82,6 @@ const pageDef: PageDef = {
             parent: 'ceiling',
             anchor: booksAnchor,
         },
-        ...bookNotes.map((n, i) => ({
-            id: `note-${n.slug}`,
-            kind: 'note' as const,
-            parent: 'lifelog-books',
-            anchor: noteAnchor(i),
-        })),
     ],
 }
 
@@ -120,24 +94,6 @@ const cardContent: Record<string, CardContent> = {
         label: 'Books',
         children: <BooksPanel />,
     },
-    ...Object.fromEntries(
-        bookNotes.map((n) => [
-            `note-${n.slug}`,
-            {
-                text: n.frontmatter.date,
-                width: NOTE_W,
-                height: NOTE_H,
-                children: (
-                    <>
-                        <time style={{ display: 'block', fontSize: '0.75rem', opacity: 0.6, marginBottom: '0.5rem' }}>
-                            {n.frontmatter.date}
-                        </time>
-                        <n.Component />
-                    </>
-                ),
-            } satisfies CardContent,
-        ]),
-    ),
 }
 
 export default function Lifelog() {

--- a/web/src/routes/Lifelog.tsx
+++ b/web/src/routes/Lifelog.tsx
@@ -28,7 +28,7 @@ export function noteAnchor(i: number) {
     }
 }
 
-type BookStatus = 'reading' | 'finished' | 'want-to-read'
+type BookStatus = 'reading' | 'finished' | 'favorites' | 'want-to-read'
 
 interface Book {
     slug: string
@@ -49,6 +49,7 @@ interface BooksApiResponse {
 const STATUS_LABELS: Record<BookStatus, string> = {
     reading: 'Reading',
     finished: 'Finished',
+    favorites: 'Favorite',
     'want-to-read': 'Want to Read',
 }
 

--- a/web/src/routes/Lifelog.tsx
+++ b/web/src/routes/Lifelog.tsx
@@ -28,13 +28,13 @@ export function noteAnchor(i: number) {
     }
 }
 
-type BookStatus = 'reading' | 'finished' | 'favorites' | 'want-to-read'
+type BookShelf = 'currently-reading' | 'favorites'
 
 interface Book {
     slug: string
     title: string
     author: string
-    status: BookStatus
+    status: BookShelf
     started?: string
     finished?: string
     cover?: string
@@ -46,11 +46,9 @@ interface BooksApiResponse {
     stale: boolean
 }
 
-const STATUS_LABELS: Record<BookStatus, string> = {
-    reading: 'Reading',
-    finished: 'Finished',
+const STATUS_LABELS: Record<BookShelf, string> = {
+    'currently-reading': 'Reading',
     favorites: 'Favorite',
-    'want-to-read': 'Want to Read',
 }
 
 function BooksPanel() {


### PR DESCRIPTION
## Summary

- **`GoodreadsAdapter`** (`api/src/adapters/GoodreadsAdapter.ts`) — fetches the `currently-reading` shelf from Goodreads public RSS, parses XML with a minimal field extractor (no added dep), normalises to `Book` domain type. Slug = `<book_id>` (numeric, stable). Sends a browser `User-Agent` header to avoid 503 bot-detection from Goodreads/Amazon. Malformed items (missing `book_id`) skipped with `console.warn`.
- **`GoodreadsShelf` enum** — shelf strings are defined once as `GoodreadsShelf.CurrentlyReading = 'currently-reading'`; `Book.status` is typed as `GoodreadsShelf` directly (no separate BookStatus translation layer).
- **`/api/books` endpoint** (`api/src/server.ts`) — wraps adapter in `CacheLayer` (30 min TTL); returns `{ books, stale }`; empty-graceful when `GOODREADS_USER_ID` env var absent; `stale: true` + `error` message on upstream failure. Adapter and cache injectable for tests.
- **`Lifelog.tsx`** — replaces placeholder `<p>—</p>` with a `BooksPanel` component that fetches `/api/books` on mount, renders a list using the existing `.lifelog-books__*` CSS classes from PR #38, and shows a `stale` chip when the endpoint reports stale data.
- **PRD.md** — corrects `/api/books` source (MDX → Goodreads RSS) and removes Goodreads from the "won't build" list per session decision.

## Notes / deviations

- PRD originally said books source = `content/books/*.mdx` and listed Goodreads under "won't build." Per explicit session decision this PR ships Goodreads RSS as the live source and updates the PRD accordingly.
- Cache TTL = 30 min (upper bound of issue's 15–30 range).
- Goodreads RSS only supports built-in shelves (`currently-reading`, `read`, `to-read`) — custom shelves (e.g. `favorites`) return errors from the RSS endpoint regardless of auth. Only `currently-reading` is fetched for now.
- The `currently-reading` shelf must be set to **public** in Goodreads privacy settings or the RSS returns "shelf is private".
- `GOODREADS_USER_ID` (numeric user ID, not username) is already set in `/etc/chaipalaka.env` on the Hetzner box.
- `GOODREADS_USER_ID` goes in `/etc/chaipalaka.env` on the Hetzner box — separate human step post-merge, per `deploy/SECRETS.md`.

## Acceptance criteria

- [x] `GoodreadsAdapter` fetches and normalises Goodreads RSS into `Book[]`
- [x] `GoodreadsAdapter` tests: happy-path parse, status mapping, rating handling, malformed-skip
- [x] `/api/books` returns `{ books, stale }`, 30 min CacheLayer TTL
- [x] `GOODREADS_USER_ID` env var required; endpoint returns empty gracefully when absent
- [x] `/lifelog` books card shows live reading list (BooksPanel with status badges + stale indicator)
- [ ] `<BookCard slug>` renders a book from Goodreads data — unchanged component, will work once deployed and `/api/books` returns real data

## Test plan

```sh
# API
cd api && npm run typecheck && npm run test

# Web
cd web && npm run typecheck && npm run test && npm run build

# End-to-end (local)
GOODREADS_USER_ID=<your-id> bun run api/src/server.ts &
curl http://localhost:3000/api/books   # should return { books: [...], stale: false }
```

Closes #40