### PR TITLE
chore: proxy /api to localhost:3000 in vite dev server

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -61,6 +61,9 @@ export default defineConfig({
         fs: {
             allow: ['..'],
         },
+        proxy: {
+            '/api': 'http://localhost:3000',
+        },
     },
     ssgOptions: {
         script: 'async',


### PR DESCRIPTION
## Summary

- Adds a Vite dev server proxy so `/api/*` requests forwarded to `http://localhost:3000` during `make web-dev`
- Mirrors the Caddy `reverse_proxy localhost:3000` rule in production — no CORS hacks or manual port-switching needed when running the Bun API locally alongside the dev server

## Notes / deviations

No issue number — discovered when first running `make deploy`; the proxy was already in the working tree as an uncommitted change.

## Test plan

1. `make web-dev` + `make api-dev` simultaneously
2. Any route that calls `/api/*` should resolve to the local Bun server without CORS errors