### PR TITLE
fix: rename vite assetsDir to _app to unblock deploy (#69)

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -37,6 +37,9 @@ async function getBlogSlugs(): Promise<string[]> {
 }
 
 export default defineConfig({
+    build: {
+        assetsDir: '_app',
+    },
     plugins: [
         {
             enforce: 'pre',


### PR DESCRIPTION
## Summary

- Adds `build: { assetsDir: '_app' }` to `web/vite.config.ts` — one-line change
- Vite now emits hashed JS/CSS bundles to `dist/_app/` (served at `/_app/...`) instead of `dist/assets/`
- The `--exclude='assets/'` in `make deploy-web` continues to protect user-content at `/var/www/chaipalaka/assets/` without accidentally excluding the build bundles

## Notes / deviations

None — exactly as described in #69.

## Acceptance criteria

- [x] `npm run build` emits to `dist/_app/`, not `dist/assets/`
- [x] `index.html` references `/_app/...` asset URLs
- [ ] After `make deploy-web`, all JS/CSS assets return HTTP 200 *(requires production deploy — human reviewer step)*
- [ ] Site fully hydrates in browser *(requires production deploy — human reviewer step)*

## Test plan

```sh
# Local build verification
cd web && npm run build
ls dist/_app/                    # should contain app-*.js, app-*.css, fonts, etc.
test ! -d dist/assets && echo "no dist/assets — good"
grep -o '/_app/[^"]*' dist/index.html | head -5   # should show /_app/ references

# Post-deploy smoke check (run after make deploy-web)
curl -sS -o /dev/null -w 'HTTP %{http_code} %{size_download}B\n' \
    "https://www.chaipalaka.com/_app/$(ls dist/_app/ | grep '^app-.*\.js$')"
# Expected: HTTP 200, non-zero bytes
```

Closes #69