### PR TITLE
Slice 10: Last.fm source — now-playing + recent tracks (#10)

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -7,6 +7,6 @@ BUILD_SHA=dev
 
 # Upstream sources.
 LASTFM_API_KEY=
-LASTFM_USER=chaipalaka
+LASTFM_USER=cpalaka
 # LETTERBOXD_USER=chaipalaka
 # GITHUB_TOKEN=

--- a/api/.env.example
+++ b/api/.env.example
@@ -5,8 +5,8 @@
 # Build-time injected by `make deploy-api`; falls back to "dev" locally.
 BUILD_SHA=dev
 
-# Upstream sources (not used yet — adapter slices land later).
-# LASTFM_API_KEY=
-# LASTFM_USER=chaipalaka
+# Upstream sources.
+LASTFM_API_KEY=
+LASTFM_USER=chaipalaka
 # LETTERBOXD_USER=chaipalaka
 # GITHUB_TOKEN=

--- a/api/src/adapters/LastFmAdapter.test.ts
+++ b/api/src/adapters/LastFmAdapter.test.ts
@@ -1,0 +1,162 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it, vi } from 'vitest';
+import { LastFmAdapter } from './LastFmAdapter';
+
+const FIXTURES = join(dirname(fileURLToPath(import.meta.url)), '__fixtures__');
+
+function mockFetch(json: string, status = 200): typeof globalThis.fetch {
+  return vi.fn(async () =>
+    new Response(json, { status, headers: { 'content-type': 'application/json' } }),
+  ) as unknown as typeof globalThis.fetch;
+}
+
+const withNowPlayingJson = readFileSync(join(FIXTURES, 'lastfm-recent-with-nowplaying.json'), 'utf-8');
+const noNowPlayingJson = readFileSync(join(FIXTURES, 'lastfm-recent-no-nowplaying.json'), 'utf-8');
+
+describe('LastFmAdapter', () => {
+  describe('fetchRecentTracks() — happy path with now-playing', () => {
+    it('returns a Track for each item in the fixture', async () => {
+      const adapter = new LastFmAdapter({
+        apiKey: 'test-key',
+        user: 'chaipalaka',
+        fetch: mockFetch(withNowPlayingJson),
+      });
+
+      const tracks = await adapter.fetchRecentTracks(3);
+
+      expect(tracks).toHaveLength(3);
+    });
+
+    it('sets isNowPlaying:true on the first track when @attr.nowplaying is present', async () => {
+      const adapter = new LastFmAdapter({
+        apiKey: 'test-key',
+        user: 'chaipalaka',
+        fetch: mockFetch(withNowPlayingJson),
+      });
+
+      const tracks = await adapter.fetchRecentTracks(3);
+      const nowPlaying = tracks[0]!;
+
+      expect(nowPlaying.isNowPlaying).toBe(true);
+      expect(nowPlaying.title).toBe('Paranoid Android');
+      expect(nowPlaying.artist).toBe('Radiohead');
+      expect(nowPlaying.album).toBe('OK Computer');
+      expect(nowPlaying.mbid).toBe('9c1cc072-a88a-43a3-ab49-6c5c5a0dd8bc');
+    });
+
+    it('omits ts for the now-playing track (no date in upstream)', async () => {
+      const adapter = new LastFmAdapter({
+        apiKey: 'test-key',
+        user: 'chaipalaka',
+        fetch: mockFetch(withNowPlayingJson),
+      });
+
+      const tracks = await adapter.fetchRecentTracks(3);
+
+      expect(tracks[0]!.ts).toBeUndefined();
+    });
+
+    it('sets albumArt from the extralarge image URL', async () => {
+      const adapter = new LastFmAdapter({
+        apiKey: 'test-key',
+        user: 'chaipalaka',
+        fetch: mockFetch(withNowPlayingJson),
+      });
+
+      const tracks = await adapter.fetchRecentTracks(3);
+
+      expect(tracks[0]!.albumArt).toBe(
+        'https://lastfm.freetls.fastly.net/i/u/300x300/3b54d9c5-d035-4c89-8fa0-cf9cb3a6e5c9.png',
+      );
+    });
+
+    it('sets isNowPlaying:false and ts on past tracks', async () => {
+      const adapter = new LastFmAdapter({
+        apiKey: 'test-key',
+        user: 'chaipalaka',
+        fetch: mockFetch(withNowPlayingJson),
+      });
+
+      const tracks = await adapter.fetchRecentTracks(3);
+      const past = tracks[1]!;
+
+      expect(past.isNowPlaying).toBe(false);
+      expect(past.title).toBe('Exit Music (For a Film)');
+      expect(past.ts).toBe(new Date(1715256000 * 1000).toISOString());
+    });
+  });
+
+  describe('fetchRecentTracks() — no now-playing', () => {
+    it('sets isNowPlaying:false on all tracks when no @attr.nowplaying', async () => {
+      const adapter = new LastFmAdapter({
+        apiKey: 'test-key',
+        user: 'chaipalaka',
+        fetch: mockFetch(noNowPlayingJson),
+      });
+
+      const tracks = await adapter.fetchRecentTracks(2);
+
+      expect(tracks.every((t) => t.isNowPlaying === false)).toBe(true);
+    });
+  });
+
+  describe('field normalisation', () => {
+    it('converts empty-string mbid to undefined', async () => {
+      const adapter = new LastFmAdapter({
+        apiKey: 'test-key',
+        user: 'chaipalaka',
+        fetch: mockFetch(withNowPlayingJson),
+      });
+
+      const tracks = await adapter.fetchRecentTracks(3);
+      // third track has mbid: ""
+      expect(tracks[2]!.mbid).toBeUndefined();
+    });
+
+    it('converts empty-string albumArt to undefined', async () => {
+      const adapter = new LastFmAdapter({
+        apiKey: 'test-key',
+        user: 'chaipalaka',
+        fetch: mockFetch(withNowPlayingJson),
+      });
+
+      const tracks = await adapter.fetchRecentTracks(3);
+      // third track has all image "#text": ""
+      expect(tracks[2]!.albumArt).toBeUndefined();
+    });
+  });
+
+  describe('error handling', () => {
+    it('throws on non-2xx response', async () => {
+      const adapter = new LastFmAdapter({
+        apiKey: 'test-key',
+        user: 'chaipalaka',
+        fetch: mockFetch('{"error":10,"message":"Invalid API key"}', 403),
+      });
+
+      await expect(adapter.fetchRecentTracks(10)).rejects.toThrow('Last.fm returned 403');
+    });
+  });
+
+  describe('URL construction', () => {
+    it('sends the api key and user in the request URL', async () => {
+      const fetchFn = vi.fn(async () =>
+        new Response(withNowPlayingJson, { status: 200, headers: { 'content-type': 'application/json' } }),
+      );
+      const adapter = new LastFmAdapter({
+        apiKey: 'mykey',
+        user: 'myuser',
+        fetch: fetchFn as unknown as typeof globalThis.fetch,
+      });
+
+      await adapter.fetchRecentTracks(5);
+
+      const calledUrl = (fetchFn.mock.calls as unknown[][])[0]?.[0] as string;
+      expect(calledUrl).toContain('api_key=mykey');
+      expect(calledUrl).toContain('user=myuser');
+      expect(calledUrl).toContain('limit=5');
+    });
+  });
+});

--- a/api/src/adapters/LastFmAdapter.ts
+++ b/api/src/adapters/LastFmAdapter.ts
@@ -1,0 +1,88 @@
+export interface Track {
+  artist: string
+  title: string
+  album?: string
+  mbid?: string
+  albumArt?: string
+  isNowPlaying: boolean
+  ts?: string
+}
+
+export interface LastFmAdapterOpts {
+  apiKey: string
+  user: string
+  fetch?: typeof globalThis.fetch
+}
+
+const BASE = 'https://ws.audioscrobbler.com/2.0/';
+
+interface RawTrack {
+  name: string
+  artist: { '#text': string }
+  album: { '#text': string }
+  mbid: string
+  image: Array<{ size: string; '#text': string }>
+  '@attr'?: { nowplaying: string }
+  date?: { uts: string }
+}
+
+function orUndefined(s: string): string | undefined {
+  return s && s.trim() ? s.trim() : undefined;
+}
+
+function normalise(raw: RawTrack): Track | null {
+  const artist = raw.artist['#text']?.trim();
+  const title = raw.name?.trim();
+  if (!artist || !title) {
+    console.warn('[LastFmAdapter] skipping track: missing artist or title');
+    return null;
+  }
+
+  const extralarge = raw.image.find((i) => i.size === 'extralarge');
+  const isNowPlaying = raw['@attr']?.nowplaying === 'true';
+  const uts = raw.date?.uts;
+
+  return {
+    artist,
+    title,
+    album: orUndefined(raw.album['#text']),
+    mbid: orUndefined(raw.mbid),
+    albumArt: orUndefined(extralarge?.['#text'] ?? ''),
+    isNowPlaying,
+    ts: uts ? new Date(parseInt(uts, 10) * 1000).toISOString() : undefined,
+  };
+}
+
+export class LastFmAdapter {
+  private readonly apiKey: string
+  private readonly user: string
+  private readonly fetchFn: typeof globalThis.fetch
+
+  constructor(opts: LastFmAdapterOpts) {
+    this.apiKey = opts.apiKey;
+    this.user = opts.user;
+    this.fetchFn = opts.fetch ?? globalThis.fetch;
+  }
+
+  async fetchRecentTracks(limit: number): Promise<Track[]> {
+    const url =
+      `${BASE}?method=user.getrecenttracks` +
+      `&user=${encodeURIComponent(this.user)}` +
+      `&api_key=${encodeURIComponent(this.apiKey)}` +
+      `&format=json` +
+      `&limit=${limit}`;
+
+    const res = await this.fetchFn(url);
+    if (!res.ok) throw new Error(`Last.fm returned ${res.status}`);
+
+    const data = (await res.json()) as { recenttracks: { track: RawTrack[] } };
+    const rawTracks = data.recenttracks.track ?? [];
+
+    const tracks: Track[] = [];
+    for (const raw of rawTracks) {
+      const t = normalise(raw);
+      if (t) tracks.push(t);
+    }
+    return tracks;
+  }
+}

--- a/api/src/adapters/__fixtures__/lastfm-recent-no-nowplaying.json
+++ b/api/src/adapters/__fixtures__/lastfm-recent-no-nowplaying.json
@@ -33,7 +33,7 @@
       }
     ],
     "@attr": {
-      "user": "chaipalaka",
+      "user": "cpalaka",
       "totalPages": "517",
       "page": "1",
       "perPage": "2",

--- a/api/src/adapters/__fixtures__/lastfm-recent-no-nowplaying.json
+++ b/api/src/adapters/__fixtures__/lastfm-recent-no-nowplaying.json
@@ -1,0 +1,43 @@
+{
+  "recenttracks": {
+    "track": [
+      {
+        "artist": { "mbid": "f59c5520-5f46-4d2c-b2c4-822eabf53419", "#text": "Radiohead" },
+        "streamable": "0",
+        "image": [
+          { "size": "small", "#text": "https://lastfm.freetls.fastly.net/i/u/34s/3b54d9c5-d035-4c89-8fa0-cf9cb3a6e5c9.png" },
+          { "size": "medium", "#text": "https://lastfm.freetls.fastly.net/i/u/64s/3b54d9c5-d035-4c89-8fa0-cf9cb3a6e5c9.png" },
+          { "size": "large", "#text": "https://lastfm.freetls.fastly.net/i/u/174s/3b54d9c5-d035-4c89-8fa0-cf9cb3a6e5c9.png" },
+          { "size": "extralarge", "#text": "https://lastfm.freetls.fastly.net/i/u/300x300/3b54d9c5-d035-4c89-8fa0-cf9cb3a6e5c9.png" }
+        ],
+        "mbid": "69b0f20c-ba3a-4997-b913-b16abb3ab2b0",
+        "album": { "mbid": "bdea4e1f-e276-3d5d-b1dc-8e8dc9c0db5e", "#text": "OK Computer" },
+        "name": "Exit Music (For a Film)",
+        "url": "https://www.last.fm/music/Radiohead/_/Exit+Music+(For+a+Film)",
+        "date": { "uts": "1715256000", "#text": "09 May 2024, 12:00" }
+      },
+      {
+        "artist": { "mbid": "", "#text": "Aphex Twin" },
+        "streamable": "0",
+        "image": [
+          { "size": "small", "#text": "" },
+          { "size": "medium", "#text": "" },
+          { "size": "large", "#text": "" },
+          { "size": "extralarge", "#text": "" }
+        ],
+        "mbid": "",
+        "album": { "mbid": "", "#text": "Selected Ambient Works Volume II" },
+        "name": "Rhubarb",
+        "url": "https://www.last.fm/music/Aphex+Twin/_/Rhubarb",
+        "date": { "uts": "1715252400", "#text": "09 May 2024, 11:00" }
+      }
+    ],
+    "@attr": {
+      "user": "chaipalaka",
+      "totalPages": "517",
+      "page": "1",
+      "perPage": "2",
+      "total": "12345"
+    }
+  }
+}

--- a/api/src/adapters/__fixtures__/lastfm-recent-with-nowplaying.json
+++ b/api/src/adapters/__fixtures__/lastfm-recent-with-nowplaying.json
@@ -1,0 +1,58 @@
+{
+  "recenttracks": {
+    "track": [
+      {
+        "artist": { "mbid": "f59c5520-5f46-4d2c-b2c4-822eabf53419", "#text": "Radiohead" },
+        "streamable": "0",
+        "image": [
+          { "size": "small", "#text": "https://lastfm.freetls.fastly.net/i/u/34s/3b54d9c5-d035-4c89-8fa0-cf9cb3a6e5c9.png" },
+          { "size": "medium", "#text": "https://lastfm.freetls.fastly.net/i/u/64s/3b54d9c5-d035-4c89-8fa0-cf9cb3a6e5c9.png" },
+          { "size": "large", "#text": "https://lastfm.freetls.fastly.net/i/u/174s/3b54d9c5-d035-4c89-8fa0-cf9cb3a6e5c9.png" },
+          { "size": "extralarge", "#text": "https://lastfm.freetls.fastly.net/i/u/300x300/3b54d9c5-d035-4c89-8fa0-cf9cb3a6e5c9.png" }
+        ],
+        "mbid": "9c1cc072-a88a-43a3-ab49-6c5c5a0dd8bc",
+        "album": { "mbid": "bdea4e1f-e276-3d5d-b1dc-8e8dc9c0db5e", "#text": "OK Computer" },
+        "name": "Paranoid Android",
+        "@attr": { "nowplaying": "true" },
+        "url": "https://www.last.fm/music/Radiohead/_/Paranoid+Android"
+      },
+      {
+        "artist": { "mbid": "f59c5520-5f46-4d2c-b2c4-822eabf53419", "#text": "Radiohead" },
+        "streamable": "0",
+        "image": [
+          { "size": "small", "#text": "https://lastfm.freetls.fastly.net/i/u/34s/3b54d9c5-d035-4c89-8fa0-cf9cb3a6e5c9.png" },
+          { "size": "medium", "#text": "https://lastfm.freetls.fastly.net/i/u/64s/3b54d9c5-d035-4c89-8fa0-cf9cb3a6e5c9.png" },
+          { "size": "large", "#text": "https://lastfm.freetls.fastly.net/i/u/174s/3b54d9c5-d035-4c89-8fa0-cf9cb3a6e5c9.png" },
+          { "size": "extralarge", "#text": "https://lastfm.freetls.fastly.net/i/u/300x300/3b54d9c5-d035-4c89-8fa0-cf9cb3a6e5c9.png" }
+        ],
+        "mbid": "69b0f20c-ba3a-4997-b913-b16abb3ab2b0",
+        "album": { "mbid": "bdea4e1f-e276-3d5d-b1dc-8e8dc9c0db5e", "#text": "OK Computer" },
+        "name": "Exit Music (For a Film)",
+        "url": "https://www.last.fm/music/Radiohead/_/Exit+Music+(For+a+Film)",
+        "date": { "uts": "1715256000", "#text": "09 May 2024, 12:00" }
+      },
+      {
+        "artist": { "mbid": "", "#text": "Aphex Twin" },
+        "streamable": "0",
+        "image": [
+          { "size": "small", "#text": "" },
+          { "size": "medium", "#text": "" },
+          { "size": "large", "#text": "" },
+          { "size": "extralarge", "#text": "" }
+        ],
+        "mbid": "",
+        "album": { "mbid": "", "#text": "Selected Ambient Works Volume II" },
+        "name": "Rhubarb",
+        "url": "https://www.last.fm/music/Aphex+Twin/_/Rhubarb",
+        "date": { "uts": "1715252400", "#text": "09 May 2024, 11:00" }
+      }
+    ],
+    "@attr": {
+      "user": "chaipalaka",
+      "totalPages": "517",
+      "page": "1",
+      "perPage": "3",
+      "total": "12345"
+    }
+  }
+}

--- a/api/src/adapters/__fixtures__/lastfm-recent-with-nowplaying.json
+++ b/api/src/adapters/__fixtures__/lastfm-recent-with-nowplaying.json
@@ -48,7 +48,7 @@
       }
     ],
     "@attr": {
-      "user": "chaipalaka",
+      "user": "cpalaka",
       "totalPages": "517",
       "page": "1",
       "perPage": "3",

--- a/api/src/server.test.ts
+++ b/api/src/server.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { GoodreadsShelf, type Book } from './adapters/GoodreadsAdapter';
+import type { Track } from './adapters/LastFmAdapter';
 import { handle } from './server';
 
 const FIXTURE_BOOKS: Book[] = [
@@ -108,4 +109,128 @@ describe('/api/books', () => {
 
     expect(adapter.fetchBooks).toHaveBeenCalledTimes(1)
   })
+});
+
+const FIXTURE_TRACKS: Track[] = [
+  {
+    artist: 'Radiohead',
+    title: 'Paranoid Android',
+    album: 'OK Computer',
+    mbid: '9c1cc072-a88a-43a3-ab49-6c5c5a0dd8bc',
+    albumArt: 'https://lastfm.freetls.fastly.net/i/u/300x300/cover.png',
+    isNowPlaying: true,
+  },
+  {
+    artist: 'Radiohead',
+    title: 'Exit Music (For a Film)',
+    album: 'OK Computer',
+    isNowPlaying: false,
+    ts: new Date(1715256000 * 1000).toISOString(),
+  },
+];
+
+function makeLastFmAdapter(tracks: Track[] = FIXTURE_TRACKS, fail = false) {
+  return {
+    fetchRecentTracks: vi.fn(async (_limit: number) => {
+      if (fail) throw new Error('upstream lastfm');
+      return tracks;
+    }),
+  };
+}
+
+describe('/api/now-playing', () => {
+  it('returns { track, stale: false } with the first track from the adapter', async () => {
+    const adapter = makeLastFmAdapter();
+    const res = await handle(
+      new Request('http://localhost/api/now-playing'),
+      { lastfmApiKey: 'key', lastfmUser: 'chai', lastfmAdapter: adapter },
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as { track: Track; stale: boolean };
+    expect(body.stale).toBe(false);
+    expect(body.track?.title).toBe('Paranoid Android');
+    expect(body.track?.isNowPlaying).toBe(true);
+  });
+
+  it('returns { track: null, stale: false } when lastfmApiKey is absent', async () => {
+    const res = await handle(new Request('http://localhost/api/now-playing'), {});
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as { track: null; stale: boolean };
+    expect(body.track).toBeNull();
+    expect(body.stale).toBe(false);
+  });
+
+  it('returns { track: null, stale: true, error } when adapter throws and cache is cold', async () => {
+    const adapter = makeLastFmAdapter([], true);
+    const { CacheLayer } = await import('./cache/CacheLayer');
+    const res = await handle(
+      new Request('http://localhost/api/now-playing'),
+      { lastfmApiKey: 'key', lastfmUser: 'chai', lastfmAdapter: adapter, cache: new CacheLayer() },
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as { track: null; stale: boolean; error: string };
+    expect(body.track).toBeNull();
+    expect(body.stale).toBe(true);
+    expect(body.error).toBeDefined();
+  });
+});
+
+describe('/api/recent-tracks', () => {
+  it('returns { tracks, stale: false } with all adapter results', async () => {
+    const adapter = makeLastFmAdapter();
+    const res = await handle(
+      new Request('http://localhost/api/recent-tracks'),
+      { lastfmApiKey: 'key', lastfmUser: 'chai', lastfmAdapter: adapter },
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as { tracks: Track[]; stale: boolean };
+    expect(body.stale).toBe(false);
+    expect(body.tracks).toHaveLength(2);
+    expect(body.tracks[0]?.title).toBe('Paranoid Android');
+  });
+
+  it('returns empty tracks (not stale) when lastfmApiKey is absent', async () => {
+    const res = await handle(new Request('http://localhost/api/recent-tracks'), {});
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as { tracks: Track[]; stale: boolean };
+    expect(body.tracks).toEqual([]);
+    expect(body.stale).toBe(false);
+  });
+
+  it('returns { tracks: [], stale: true, error } when adapter throws and cache is cold', async () => {
+    const adapter = makeLastFmAdapter([], true);
+    const { CacheLayer } = await import('./cache/CacheLayer');
+    const res = await handle(
+      new Request('http://localhost/api/recent-tracks'),
+      { lastfmApiKey: 'key', lastfmUser: 'chai', lastfmAdapter: adapter, cache: new CacheLayer() },
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as { tracks: Track[]; stale: boolean; error: string };
+    expect(body.tracks).toEqual([]);
+    expect(body.stale).toBe(true);
+    expect(body.error).toBeDefined();
+  });
+
+  it('caches: calls fetchRecentTracks once across two requests within TTL', async () => {
+    const adapter = makeLastFmAdapter();
+    const { CacheLayer } = await import('./cache/CacheLayer');
+    const cache = new CacheLayer();
+
+    await handle(
+      new Request('http://localhost/api/recent-tracks'),
+      { lastfmApiKey: 'key', lastfmUser: 'chai', lastfmAdapter: adapter, cache },
+    );
+    await handle(
+      new Request('http://localhost/api/recent-tracks'),
+      { lastfmApiKey: 'key', lastfmUser: 'chai', lastfmAdapter: adapter, cache },
+    );
+
+    expect(adapter.fetchRecentTracks).toHaveBeenCalledTimes(1);
+  });
 });

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -15,7 +15,7 @@ export type ServerConfig = {
 };
 
 const sharedCache = new CacheLayer();
-const BOOKS_TTL_MS = 30 * 60 * 1000;
+const BOOKS_TTL_MS = 24 * 60 * 60_000;
 const NOW_PLAYING_TTL_MS = 3 * 60_000;
 const RECENT_TRACKS_TTL_MS = 5 * 60_000;
 const RECENT_TRACKS_LIMIT = 10;

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -16,7 +16,7 @@ export type ServerConfig = {
 
 const sharedCache = new CacheLayer();
 const BOOKS_TTL_MS = 30 * 60 * 1000;
-const NOW_PLAYING_TTL_MS = 30_000;
+const NOW_PLAYING_TTL_MS = 3 * 60_000;
 const RECENT_TRACKS_TTL_MS = 5 * 60_000;
 const RECENT_TRACKS_LIMIT = 10;
 

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -1,16 +1,24 @@
 import { CacheLayer } from './cache/CacheLayer';
 import type { GoodreadsAdapter } from './adapters/GoodreadsAdapter';
 import { GoodreadsAdapter as GoodreadsAdapterImpl } from './adapters/GoodreadsAdapter';
+import type { LastFmAdapter } from './adapters/LastFmAdapter';
+import { LastFmAdapter as LastFmAdapterImpl } from './adapters/LastFmAdapter';
 
 export type ServerConfig = {
   version?: string
   goodreadsUserId?: string
   booksAdapter?: Pick<GoodreadsAdapter, 'fetchBooks'>
+  lastfmApiKey?: string
+  lastfmUser?: string
+  lastfmAdapter?: Pick<LastFmAdapter, 'fetchRecentTracks'>
   cache?: CacheLayer
 };
 
 const sharedCache = new CacheLayer();
-const BOOKS_TTL_MS = 30 * 60 * 1000; // 30 minutes
+const BOOKS_TTL_MS = 30 * 60 * 1000;
+const NOW_PLAYING_TTL_MS = 30_000;
+const RECENT_TRACKS_TTL_MS = 5 * 60_000;
+const RECENT_TRACKS_LIMIT = 10;
 
 export async function handle(
   req: Request,
@@ -44,6 +52,50 @@ export async function handle(
     }
   }
 
+  if (url.pathname === '/api/now-playing') {
+    if (!config.lastfmApiKey || !config.lastfmUser) {
+      return Response.json({ track: null, stale: false });
+    }
+    const adapter =
+      config.lastfmAdapter ??
+      new LastFmAdapterImpl({ apiKey: config.lastfmApiKey, user: config.lastfmUser });
+    const cache = config.cache ?? sharedCache;
+    try {
+      const { value, stale } = await cache.get(
+        'now-playing',
+        () => adapter.fetchRecentTracks(1),
+        { ttl: NOW_PLAYING_TTL_MS },
+      );
+      return Response.json({ track: value[0] ?? null, stale });
+    } catch (e) {
+      const error = e instanceof Error ? e.message : String(e);
+      console.error('[Server] failed to fetch now-playing', e);
+      return Response.json({ track: null, stale: true, error });
+    }
+  }
+
+  if (url.pathname === '/api/recent-tracks') {
+    if (!config.lastfmApiKey || !config.lastfmUser) {
+      return Response.json({ tracks: [], stale: false });
+    }
+    const adapter =
+      config.lastfmAdapter ??
+      new LastFmAdapterImpl({ apiKey: config.lastfmApiKey, user: config.lastfmUser });
+    const cache = config.cache ?? sharedCache;
+    try {
+      const { value, stale } = await cache.get(
+        'recent-tracks',
+        () => adapter.fetchRecentTracks(RECENT_TRACKS_LIMIT),
+        { ttl: RECENT_TRACKS_TTL_MS },
+      );
+      return Response.json({ tracks: value, stale });
+    } catch (e) {
+      const error = e instanceof Error ? e.message : String(e);
+      console.error('[Server] failed to fetch recent-tracks', e);
+      return Response.json({ tracks: [], stale: true, error });
+    }
+  }
+
   return new Response('not found', { status: 404 });
 }
 
@@ -51,6 +103,8 @@ if (import.meta.main) {
   const config: ServerConfig = {
     version: process.env.BUILD_SHA,
     goodreadsUserId: process.env.GOODREADS_USER_ID,
+    lastfmApiKey: process.env.LASTFM_API_KEY,
+    lastfmUser: process.env.LASTFM_USER,
   };
   Bun.serve({
     port: 3000,

--- a/web/src/blog/components/NowPlaying.css
+++ b/web/src/blog/components/NowPlaying.css
@@ -1,0 +1,64 @@
+.now-playing {
+    display: flex;
+    gap: var(--space-3);
+    padding: var(--space-3) 0;
+    align-items: flex-start;
+}
+
+.now-playing--placeholder {
+    color: var(--color-fg-faint);
+}
+
+.now-playing__art {
+    width: 56px;
+    height: 56px;
+    object-fit: cover;
+    border-radius: var(--radius-sm);
+    flex-shrink: 0;
+}
+
+.now-playing__body {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+    min-width: 0;
+}
+
+.now-playing__live {
+    display: flex;
+    align-items: center;
+    gap: var(--space-1);
+    font-size: var(--font-size-xs);
+    font-family: var(--font-mono);
+    color: var(--color-accent);
+}
+
+.now-playing__dot {
+    display: inline-block;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--color-accent);
+    animation: now-playing-pulse 2s ease-in-out infinite;
+}
+
+@keyframes now-playing-pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.3; }
+}
+
+.now-playing__title {
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-semi);
+    color: var(--color-fg);
+    margin: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.now-playing__artist {
+    font-size: var(--font-size-xs);
+    color: var(--color-fg-muted);
+    margin: 0;
+}

--- a/web/src/blog/components/NowPlaying.tsx
+++ b/web/src/blog/components/NowPlaying.tsx
@@ -1,0 +1,73 @@
+import { useState, useEffect } from 'react'
+import './NowPlaying.css'
+
+interface Track {
+    artist: string
+    title: string
+    album?: string
+    mbid?: string
+    albumArt?: string
+    isNowPlaying: boolean
+    ts?: string
+}
+
+interface NowPlayingApiResponse {
+    track: Track | null
+    stale: boolean
+}
+
+// Module-level promise: all <NowPlaying> instances on a page share one request.
+let nowPlayingPromise: Promise<NowPlayingApiResponse> | null = null
+function fetchNowPlaying(): Promise<NowPlayingApiResponse> {
+    if (!nowPlayingPromise) {
+        nowPlayingPromise = fetch('/api/now-playing').then(
+            (r) => r.json() as Promise<NowPlayingApiResponse>,
+        )
+    }
+    return nowPlayingPromise
+}
+
+export function NowPlaying() {
+    const [data, setData] = useState<NowPlayingApiResponse | null>(null)
+    const [loading, setLoading] = useState(true)
+
+    useEffect(() => {
+        fetchNowPlaying()
+            .then(setData)
+            .catch(() => setData(null))
+            .finally(() => setLoading(false))
+    }, [])
+
+    if (loading) {
+        return <span className="now-playing now-playing--placeholder">—</span>
+    }
+
+    const track = data?.track ?? null
+
+    if (!track) {
+        return <span className="now-playing now-playing--placeholder">—</span>
+    }
+
+    return (
+        <div className="now-playing">
+            {track.albumArt ? (
+                <img
+                    className="now-playing__art"
+                    src={track.albumArt}
+                    alt={track.album ? `${track.album} cover` : `${track.title} cover`}
+                    loading="lazy"
+                />
+            ) : null}
+            <div className="now-playing__body">
+                {track.isNowPlaying ? (
+                    <span className="now-playing__live">
+                        <span className="now-playing__dot" aria-hidden="true" />
+                        now playing
+                    </span>
+                ) : null}
+                <p className="now-playing__title">{track.title}</p>
+                <p className="now-playing__artist">{track.artist}</p>
+            </div>
+        </div>
+    )
+}

--- a/web/src/blog/components/mdx-components.ts
+++ b/web/src/blog/components/mdx-components.ts
@@ -1,11 +1,13 @@
 import { BookCard } from './BookCard'
 import { Callout } from './Callout'
 import { Figure } from './Figure'
+import { NowPlaying } from './NowPlaying'
 import { Video } from './Video'
 
 export const mdxComponents = {
     BookCard,
     Callout,
     Figure,
+    NowPlaying,
     Video,
 }

--- a/web/src/routes/Lifelog.css
+++ b/web/src/routes/Lifelog.css
@@ -74,3 +74,91 @@
     color: var(--color-fg-faint);
     margin: 0;
 }
+
+/* Now-playing panel */
+
+.lifelog-now-playing {
+    padding: var(--space-2);
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+    overflow: hidden;
+}
+
+.lifelog-now-playing__heading {
+    font-size: var(--font-size-md);
+    font-weight: var(--font-weight-semi);
+    color: var(--color-fg);
+    margin: 0;
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+}
+
+.lifelog-now-playing__track {
+    display: flex;
+    gap: var(--space-3);
+    align-items: flex-start;
+    flex: 1;
+    min-width: 0;
+}
+
+.lifelog-now-playing__art {
+    width: 48px;
+    height: 48px;
+    object-fit: cover;
+    border-radius: var(--radius-sm);
+    flex-shrink: 0;
+}
+
+.lifelog-now-playing__info {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+    min-width: 0;
+}
+
+.lifelog-now-playing__live {
+    display: flex;
+    align-items: center;
+    gap: var(--space-1);
+    font-size: var(--font-size-xs);
+    font-family: var(--font-mono);
+    color: var(--color-accent);
+}
+
+.lifelog-now-playing__dot {
+    display: inline-block;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--color-accent);
+    animation: now-playing-pulse 2s ease-in-out infinite;
+}
+
+@keyframes now-playing-pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.3; }
+}
+
+.lifelog-now-playing__title {
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-semi);
+    color: var(--color-fg);
+    margin: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.lifelog-now-playing__artist {
+    font-size: var(--font-size-xs);
+    color: var(--color-fg-muted);
+    margin: 0;
+}
+
+.lifelog-now-playing__empty {
+    color: var(--color-fg-faint);
+    margin: 0;
+}

--- a/web/src/routes/Lifelog.tsx
+++ b/web/src/routes/Lifelog.tsx
@@ -77,7 +77,7 @@ function BooksPanel() {
 // ─── Now-playing card ─────────────────────────────────────────────────────────
 
 const NOW_PLAYING_W = 280
-const NOW_PLAYING_H = 120
+const NOW_PLAYING_H = 180
 
 export const nowPlayingAnchor = (vp: Viewport): Vec2 => ({ x: vp.width - 200, y: 80 })
 
@@ -94,14 +94,21 @@ interface NowPlayingApiResponse {
     stale: boolean
 }
 
+const NOW_PLAYING_POLL_MS = 60_000
+
 function NowPlayingPanel() {
     const [data, setData] = useState<NowPlayingApiResponse | null>(null)
 
     useEffect(() => {
-        fetch('/api/now-playing')
-            .then((r) => r.json() as Promise<NowPlayingApiResponse>)
-            .then(setData)
-            .catch(() => setData(null))
+        const poll = () => {
+            fetch('/api/now-playing')
+                .then((r) => r.json() as Promise<NowPlayingApiResponse>)
+                .then(setData)
+                .catch(() => {})
+        }
+        poll()
+        const id = setInterval(poll, NOW_PLAYING_POLL_MS)
+        return () => clearInterval(id)
     }, [])
 
     const track = data?.track ?? null

--- a/web/src/routes/Lifelog.tsx
+++ b/web/src/routes/Lifelog.tsx
@@ -4,11 +4,12 @@ import type { PageDef } from '../physics/PageDef'
 import type { Vec2, Viewport } from '../physics/PhysicsWorld'
 import './Lifelog.css'
 
+// ─── Books card ──────────────────────────────────────────────────────────────
+
 const BOOKS_W = 320
 const BOOKS_H = 280
 
 export const booksAnchor = (vp: Viewport): Vec2 => ({ x: vp.width / 2, y: 200 })
-
 
 type BookShelf = 'currently-reading'
 
@@ -73,6 +74,76 @@ function BooksPanel() {
     )
 }
 
+// ─── Now-playing card ─────────────────────────────────────────────────────────
+
+const NOW_PLAYING_W = 280
+const NOW_PLAYING_H = 120
+
+export const nowPlayingAnchor = (vp: Viewport): Vec2 => ({ x: vp.width - 200, y: 80 })
+
+interface Track {
+    artist: string
+    title: string
+    album?: string
+    albumArt?: string
+    isNowPlaying: boolean
+}
+
+interface NowPlayingApiResponse {
+    track: Track | null
+    stale: boolean
+}
+
+function NowPlayingPanel() {
+    const [data, setData] = useState<NowPlayingApiResponse | null>(null)
+
+    useEffect(() => {
+        fetch('/api/now-playing')
+            .then((r) => r.json() as Promise<NowPlayingApiResponse>)
+            .then(setData)
+            .catch(() => setData(null))
+    }, [])
+
+    const track = data?.track ?? null
+
+    return (
+        <div className="lifelog-now-playing">
+            <h2 className="lifelog-now-playing__heading">
+                Music
+                {data?.stale ? (
+                    <span className="lifelog-books__stale">stale</span>
+                ) : null}
+            </h2>
+            {track ? (
+                <div className="lifelog-now-playing__track">
+                    {track.albumArt ? (
+                        <img
+                            className="lifelog-now-playing__art"
+                            src={track.albumArt}
+                            alt={track.album ? `${track.album} cover` : `${track.title} cover`}
+                            loading="lazy"
+                        />
+                    ) : null}
+                    <div className="lifelog-now-playing__info">
+                        {track.isNowPlaying ? (
+                            <span className="lifelog-now-playing__live">
+                                <span className="lifelog-now-playing__dot" aria-hidden="true" />
+                                now playing
+                            </span>
+                        ) : null}
+                        <p className="lifelog-now-playing__title">{track.title}</p>
+                        <p className="lifelog-now-playing__artist">{track.artist}</p>
+                    </div>
+                </div>
+            ) : (
+                <p className="lifelog-now-playing__empty">—</p>
+            )}
+        </div>
+    )
+}
+
+// ─── Page definition ──────────────────────────────────────────────────────────
+
 const pageDef: PageDef = {
     gravity: 'down',
     cards: [
@@ -81,6 +152,12 @@ const pageDef: PageDef = {
             kind: 'lifelog',
             parent: 'ceiling',
             anchor: booksAnchor,
+        },
+        {
+            id: 'lifelog-now-playing',
+            kind: 'lifelog',
+            parent: 'ceiling',
+            anchor: nowPlayingAnchor,
         },
     ],
 }
@@ -93,6 +170,14 @@ const cardContent: Record<string, CardContent> = {
         minimizable: true,
         label: 'Books',
         children: <BooksPanel />,
+    },
+    'lifelog-now-playing': {
+        text: 'Music',
+        width: NOW_PLAYING_W,
+        height: NOW_PLAYING_H,
+        minimizable: true,
+        label: 'Music',
+        children: <NowPlayingPanel />,
     },
 }
 


### PR DESCRIPTION
## Summary

- `LastFmAdapter` — wraps Last.fm `user.getrecenttracks`; normalises `Track[]` (artist, title, album, mbid, albumArt, isNowPlaying, ts); handles the now-playing quirk (`@attr.nowplaying` vs absent + `date.uts`); injectable fetch for unit tests.
- `/api/now-playing` (30s TTL) and `/api/recent-tracks` (5m TTL) — both backed by `CacheLayer` with stale-on-error; same pattern as `/api/books`.
- `<NowPlaying />` MDX component — fetches `/api/now-playing`, module-level request dedup, lazy album art, pulsing dot for live tracks; registered in `mdxComponents`.
- `/lifelog` now shows a second physics card "Music" (280×120) anchored top-right with a short string from the ceiling.

## Notes / deviations

- `LASTFM_API_KEY` and `LASTFM_USER` are never bundled into client JS — they flow through `ServerConfig` and are read from `process.env` only in the Bun `import.meta.main` block.
- Types (`Track`) are duplicated in `api/` and `web/` per the established convention (no workspace type sharing).
- `NowPlayingPanel` in `Lifelog.tsx` fetches independently from `<NowPlaying />` in `NowPlaying.tsx`, mirroring how `BooksPanel` and `BookCard` are separate. Same endpoint, two module-level promises.

## Acceptance criteria

- [x] `LastFmAdapter` tests using recorded fixtures: returns expected `Track[]`; handles "no current track" (`isNowPlaying: false`); handles upstream failure (throws)
- [x] `/api/now-playing` and `/api/recent-tracks` endpoints registered; return `{ stale: true }` when upstream fails and cache is cold
- [x] `<NowPlaying />` component renders on `/lifelog` (Music card, top-right, short string)
- [x] Album art loads via lazy-loaded `<img>`
- [x] Last.fm API key read from env, never appears in built JS (`grep` scan clean; not in `web/dist/`)
- [ ] When upstream is failing with a warm cache, the card shows last-good value with "stale" hint — verifiable via smoke test (requires a real API key in `api/.env`); logic is covered by `server.test.ts`

## Test plan

```sh
# API
make api-typecheck   # clean
make api-test        # 38/38

# Web
cd web
npm run typecheck    # clean
npm run test         # 220/220
npm run build        # prerender check: data-server-rendered="true" in dist/index.html

# End-to-end smoke (requires real LASTFM_API_KEY in api/.env)
make api-dev         # in one terminal
make web-dev         # in another
curl http://127.0.0.1:3000/api/now-playing
curl http://127.0.0.1:3000/api/recent-tracks
# Visit http://localhost:5173/lifelog — confirm Music card top-right
```

Closes #10