### PR TITLE
Slice 11: Letterboxd source — recent films via RSS (#11)

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -8,5 +8,5 @@ BUILD_SHA=dev
 # Upstream sources.
 LASTFM_API_KEY=
 LASTFM_USER=cpalaka
-# LETTERBOXD_USER=chaipalaka
+LETTERBOXD_USER=cpalaka
 # GITHUB_TOKEN=

--- a/api/src/adapters/LastFmAdapter.test.ts
+++ b/api/src/adapters/LastFmAdapter.test.ts
@@ -20,7 +20,7 @@ describe('LastFmAdapter', () => {
     it('returns a Track for each item in the fixture', async () => {
       const adapter = new LastFmAdapter({
         apiKey: 'test-key',
-        user: 'chaipalaka',
+        user: 'cpalaka',
         fetch: mockFetch(withNowPlayingJson),
       });
 
@@ -32,7 +32,7 @@ describe('LastFmAdapter', () => {
     it('sets isNowPlaying:true on the first track when @attr.nowplaying is present', async () => {
       const adapter = new LastFmAdapter({
         apiKey: 'test-key',
-        user: 'chaipalaka',
+        user: 'cpalaka',
         fetch: mockFetch(withNowPlayingJson),
       });
 
@@ -49,7 +49,7 @@ describe('LastFmAdapter', () => {
     it('omits ts for the now-playing track (no date in upstream)', async () => {
       const adapter = new LastFmAdapter({
         apiKey: 'test-key',
-        user: 'chaipalaka',
+        user: 'cpalaka',
         fetch: mockFetch(withNowPlayingJson),
       });
 
@@ -61,7 +61,7 @@ describe('LastFmAdapter', () => {
     it('sets albumArt from the extralarge image URL', async () => {
       const adapter = new LastFmAdapter({
         apiKey: 'test-key',
-        user: 'chaipalaka',
+        user: 'cpalaka',
         fetch: mockFetch(withNowPlayingJson),
       });
 
@@ -75,7 +75,7 @@ describe('LastFmAdapter', () => {
     it('sets isNowPlaying:false and ts on past tracks', async () => {
       const adapter = new LastFmAdapter({
         apiKey: 'test-key',
-        user: 'chaipalaka',
+        user: 'cpalaka',
         fetch: mockFetch(withNowPlayingJson),
       });
 
@@ -92,7 +92,7 @@ describe('LastFmAdapter', () => {
     it('sets isNowPlaying:false on all tracks when no @attr.nowplaying', async () => {
       const adapter = new LastFmAdapter({
         apiKey: 'test-key',
-        user: 'chaipalaka',
+        user: 'cpalaka',
         fetch: mockFetch(noNowPlayingJson),
       });
 
@@ -106,7 +106,7 @@ describe('LastFmAdapter', () => {
     it('converts empty-string mbid to undefined', async () => {
       const adapter = new LastFmAdapter({
         apiKey: 'test-key',
-        user: 'chaipalaka',
+        user: 'cpalaka',
         fetch: mockFetch(withNowPlayingJson),
       });
 
@@ -118,7 +118,7 @@ describe('LastFmAdapter', () => {
     it('converts empty-string albumArt to undefined', async () => {
       const adapter = new LastFmAdapter({
         apiKey: 'test-key',
-        user: 'chaipalaka',
+        user: 'cpalaka',
         fetch: mockFetch(withNowPlayingJson),
       });
 
@@ -132,7 +132,7 @@ describe('LastFmAdapter', () => {
     it('throws on non-2xx response', async () => {
       const adapter = new LastFmAdapter({
         apiKey: 'test-key',
-        user: 'chaipalaka',
+        user: 'cpalaka',
         fetch: mockFetch('{"error":10,"message":"Invalid API key"}', 403),
       });
 

--- a/api/src/adapters/LetterboxdAdapter.test.ts
+++ b/api/src/adapters/LetterboxdAdapter.test.ts
@@ -1,0 +1,145 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it, vi } from 'vitest';
+import { LetterboxdAdapter } from './LetterboxdAdapter';
+
+const FIXTURES = join(dirname(fileURLToPath(import.meta.url)), '__fixtures__');
+const rssXml = readFileSync(join(FIXTURES, 'letterboxd-rss.xml'), 'utf-8');
+
+function mockFetch(xml: string, status = 200): typeof globalThis.fetch {
+  return vi.fn(async () =>
+    new Response(xml, { status, headers: { 'content-type': 'application/rss+xml' } }),
+  ) as unknown as typeof globalThis.fetch;
+}
+
+describe('LetterboxdAdapter', () => {
+  describe('fetchFilms() — happy path', () => {
+    it('returns a Film for each valid item', async () => {
+      const adapter = new LetterboxdAdapter({ user: 'cpalaka', fetch: mockFetch(rssXml) });
+      const films = await adapter.fetchFilms();
+      expect(films.length).toBe(3);
+    });
+
+    it('parses letterboxdId from guid', async () => {
+      const adapter = new LetterboxdAdapter({ user: 'cpalaka', fetch: mockFetch(rssXml) });
+      const films = await adapter.fetchFilms();
+      const lotr = films.find((f) => f.letterboxdId === '1278965807');
+      expect(lotr).toBeDefined();
+    });
+
+    it('parses title from letterboxd:filmTitle', async () => {
+      const adapter = new LetterboxdAdapter({ user: 'cpalaka', fetch: mockFetch(rssXml) });
+      const films = await adapter.fetchFilms();
+      const lotr = films.find((f) => f.letterboxdId === '1278965807');
+      expect(lotr?.title).toBe('The Lord of the Rings: The Fellowship of the Ring');
+    });
+
+    it('parses year as number', async () => {
+      const adapter = new LetterboxdAdapter({ user: 'cpalaka', fetch: mockFetch(rssXml) });
+      const films = await adapter.fetchFilms();
+      const lotr = films.find((f) => f.letterboxdId === '1278965807');
+      expect(lotr?.year).toBe(2001);
+    });
+
+    it('parses watchedDate as ISO date string', async () => {
+      const adapter = new LetterboxdAdapter({ user: 'cpalaka', fetch: mockFetch(rssXml) });
+      const films = await adapter.fetchFilms();
+      const lotr = films.find((f) => f.letterboxdId === '1278965807');
+      expect(lotr?.watchedDate).toBe('2026-04-12');
+    });
+
+    it('parses rating as float', async () => {
+      const adapter = new LetterboxdAdapter({ user: 'cpalaka', fetch: mockFetch(rssXml) });
+      const films = await adapter.fetchFilms();
+      const lotr = films.find((f) => f.letterboxdId === '1278965807');
+      expect(lotr?.rating).toBe(5.0);
+    });
+
+    it('preserves half-star float rating', async () => {
+      const adapter = new LetterboxdAdapter({ user: 'cpalaka', fetch: mockFetch(rssXml) });
+      const films = await adapter.fetchFilms();
+      const mary = films.find((f) => f.letterboxdId === '1268084157');
+      expect(mary?.rating).toBe(3.5);
+    });
+
+    it('parses posterUrl from description img tag', async () => {
+      const adapter = new LetterboxdAdapter({ user: 'cpalaka', fetch: mockFetch(rssXml) });
+      const films = await adapter.fetchFilms();
+      const lotr = films.find((f) => f.letterboxdId === '1278965807');
+      expect(lotr?.posterUrl).toBe(
+        'https://a.ltrbxd.com/resized/sm/upload/3t/vq/0u/m6/poster.jpg?v=abc',
+      );
+    });
+
+    it('parses rewatch flag', async () => {
+      const adapter = new LetterboxdAdapter({ user: 'cpalaka', fetch: mockFetch(rssXml) });
+      const films = await adapter.fetchFilms();
+      const lotr = films.find((f) => f.letterboxdId === '1278965807');
+      const sinners = films.find((f) => f.letterboxdId === '1256248485');
+      expect(lotr?.rewatch).toBe(true);
+      expect(sinners?.rewatch).toBe(false);
+    });
+
+    it('parses link as canonical url', async () => {
+      const adapter = new LetterboxdAdapter({ user: 'cpalaka', fetch: mockFetch(rssXml) });
+      const films = await adapter.fetchFilms();
+      const lotr = films.find((f) => f.letterboxdId === '1278965807');
+      expect(lotr?.link).toBe(
+        'https://letterboxd.com/cpalaka/film/the-lord-of-the-rings-the-fellowship-of-the-ring/1/',
+      );
+    });
+  });
+
+  describe('review extraction', () => {
+    it('returns undefined review when description is only "Watched on..." text', async () => {
+      const adapter = new LetterboxdAdapter({ user: 'cpalaka', fetch: mockFetch(rssXml) });
+      const films = await adapter.fetchFilms();
+      const lotr = films.find((f) => f.letterboxdId === '1278965807');
+      expect(lotr?.review).toBeUndefined();
+    });
+
+    it('extracts written review text from description', async () => {
+      const adapter = new LetterboxdAdapter({ user: 'cpalaka', fetch: mockFetch(rssXml) });
+      const films = await adapter.fetchFilms();
+      const mary = films.find((f) => f.letterboxdId === '1268084157');
+      expect(mary?.review).toBe("They really don't make em like they used to - dumb, contrived and hilarious");
+    });
+  });
+
+  describe('HTML entity decoding', () => {
+    it('decodes &#039; entities in title', async () => {
+      const adapter = new LetterboxdAdapter({ user: 'cpalaka', fetch: mockFetch(rssXml) });
+      const films = await adapter.fetchFilms();
+      const mary = films.find((f) => f.letterboxdId === '1268084157');
+      expect(mary?.title).toBe("There's Something About Mary");
+    });
+  });
+
+  describe('malformed items', () => {
+    it('skips items missing a guid without throwing', async () => {
+      const adapter = new LetterboxdAdapter({ user: 'cpalaka', fetch: mockFetch(rssXml) });
+      const films = await adapter.fetchFilms();
+      const malformed = films.find((f) => f.title === 'Malformed No ID Film');
+      expect(malformed).toBeUndefined();
+      expect(films.length).toBeGreaterThan(0);
+    });
+
+    it('skips items missing a title without throwing', async () => {
+      const adapter = new LetterboxdAdapter({ user: 'cpalaka', fetch: mockFetch(rssXml) });
+      const films = await adapter.fetchFilms();
+      const noTitle = films.find((f) => f.letterboxdId === '9999999');
+      expect(noTitle).toBeUndefined();
+    });
+  });
+
+  describe('upstream failure', () => {
+    it('throws when the upstream returns a non-OK status', async () => {
+      const adapter = new LetterboxdAdapter({
+        user: 'cpalaka',
+        fetch: mockFetch('Service Unavailable', 503),
+      });
+      await expect(adapter.fetchFilms()).rejects.toThrow('503');
+    });
+  });
+});

--- a/api/src/adapters/LetterboxdAdapter.ts
+++ b/api/src/adapters/LetterboxdAdapter.ts
@@ -1,0 +1,116 @@
+export interface Film {
+  letterboxdId: string
+  title: string
+  year?: number
+  watchedDate?: string
+  rating?: number
+  review?: string
+  posterUrl?: string
+  rewatch?: boolean
+  link: string
+}
+
+export interface LetterboxdAdapterOpts {
+  user: string
+  fetch?: typeof globalThis.fetch
+}
+
+function field(xml: string, tag: string): string {
+  const escaped = tag.replace(':', '\\:')
+  const m = xml.match(
+    new RegExp(`<${escaped}[^>]*>(?:<!\\[CDATA\\[([\\s\\S]*?)\\]\\]>|([^<]*))<\\/${escaped}>`),
+  )
+  if (!m) return ''
+  return (m[1] ?? m[2] ?? '').trim()
+}
+
+function decodeEntities(str: string): string {
+  return str
+    .replace(/&#039;/g, "'")
+    .replace(/&amp;/g, '&')
+    .replace(/&quot;/g, '"')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+}
+
+function extractPoster(description: string): string | undefined {
+  const m = description.match(/<img[^>]+src=["']([^"']+)["']/i)
+  return m ? m[1] : undefined
+}
+
+function extractReview(description: string): string | undefined {
+  // Remove the poster <p><img …></p> block
+  const withoutPoster = description.replace(/<p>\s*<img[^>]+\/>\s*<\/p>/i, '')
+  // Strip remaining HTML tags
+  const text = withoutPoster.replace(/<[^>]+>/g, '').trim()
+  const decoded = decodeEntities(text)
+  // Suppress the auto-generated "Watched on …" placeholder
+  if (!decoded || /^Watched on /i.test(decoded)) return undefined
+  return decoded
+}
+
+function parseItems(xml: string): Film[] {
+  const films: Film[] = []
+  const blocks = xml.split('</item>')
+  for (const block of blocks) {
+    const start = block.indexOf('<item>')
+    if (start === -1) continue
+    const item = block.slice(start)
+
+    const guidRaw = field(item, 'guid')
+    const idMatch = guidRaw.match(/letterboxd-(?:watch|review)-(\d+)/)
+    if (!idMatch) {
+      console.warn('[LetterboxdAdapter] skipping item: missing or unrecognised guid')
+      continue
+    }
+    const letterboxdId = idMatch[1]
+
+    const title = decodeEntities(field(item, 'letterboxd:filmTitle') || field(item, 'title'))
+    if (!title) {
+      console.warn(`[LetterboxdAdapter] skipping item ${letterboxdId}: missing title`)
+      continue
+    }
+
+    const yearRaw = parseInt(field(item, 'letterboxd:filmYear'), 10)
+    const year = !isNaN(yearRaw) ? yearRaw : undefined
+
+    const watchedDate = field(item, 'letterboxd:watchedDate') || undefined
+
+    const ratingRaw = parseFloat(field(item, 'letterboxd:memberRating'))
+    const rating = !isNaN(ratingRaw) && ratingRaw > 0 ? ratingRaw : undefined
+
+    const rewatch = field(item, 'letterboxd:rewatch') === 'Yes'
+
+    const link = field(item, 'link')
+
+    const description = field(item, 'description')
+    const posterUrl = extractPoster(description)
+    const review = extractReview(description)
+
+    films.push({ letterboxdId, title, year, watchedDate, rating, review, posterUrl, rewatch, link })
+  }
+  return films
+}
+
+export class LetterboxdAdapter {
+  private readonly user: string
+  private readonly fetchFn: typeof globalThis.fetch
+
+  constructor(opts: LetterboxdAdapterOpts) {
+    this.user = opts.user
+    this.fetchFn = opts.fetch ?? globalThis.fetch
+  }
+
+  async fetchFilms(): Promise<Film[]> {
+    const url = `https://letterboxd.com/${this.user}/rss/`
+    const res = await this.fetchFn(url, {
+      headers: {
+        'User-Agent':
+          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36',
+      },
+    })
+    if (!res.ok) throw new Error(`Letterboxd RSS returned ${res.status}`)
+    const xml = await res.text()
+    return parseItems(xml)
+  }
+}

--- a/api/src/adapters/__fixtures__/letterboxd-rss.xml
+++ b/api/src/adapters/__fixtures__/letterboxd-rss.xml
@@ -1,0 +1,81 @@
+<?xml version='1.0' encoding='utf-8'?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:letterboxd="https://letterboxd.com" xmlns:tmdb="https://themoviedb.org">
+	<channel>
+		<title>Letterboxd - Chai Palaka</title>
+		<link>https://letterboxd.com/cpalaka/</link>
+		<description>Letterboxd - Chai Palaka</description>
+
+		<!-- Full entry: 5-star rewatch, no written review -->
+		<item>
+			<title>The Lord of the Rings: The Fellowship of the Ring, 2001 - ★★★★★</title>
+			<link>https://letterboxd.com/cpalaka/film/the-lord-of-the-rings-the-fellowship-of-the-ring/1/</link>
+			<guid isPermaLink="false">letterboxd-watch-1278965807</guid>
+			<pubDate>Mon, 13 Apr 2026 17:55:40 +1200</pubDate>
+			<letterboxd:watchedDate>2026-04-12</letterboxd:watchedDate>
+			<letterboxd:rewatch>Yes</letterboxd:rewatch>
+			<letterboxd:filmTitle>The Lord of the Rings: The Fellowship of the Ring</letterboxd:filmTitle>
+			<letterboxd:filmYear>2001</letterboxd:filmYear>
+			<letterboxd:memberRating>5.0</letterboxd:memberRating>
+			<tmdb:movieId>120</tmdb:movieId>
+			<description><![CDATA[ <p><img src="https://a.ltrbxd.com/resized/sm/upload/3t/vq/0u/m6/poster.jpg?v=abc"/></p> <p>Watched on Sunday April 12, 2026.</p> ]]></description>
+			<dc:creator>Chai Palaka</dc:creator>
+		</item>
+
+		<!-- 3.5-star (half-star rating), with a written review, HTML entity in title -->
+		<item>
+			<title>There&#039;s Something About Mary, 1998 - ★★★</title>
+			<link>https://letterboxd.com/cpalaka/film/theres-something-about-mary/</link>
+			<guid isPermaLink="false">letterboxd-review-1268084157</guid>
+			<pubDate>Sun, 5 Apr 2026 21:02:26 +1200</pubDate>
+			<letterboxd:watchedDate>2026-04-05</letterboxd:watchedDate>
+			<letterboxd:rewatch>Yes</letterboxd:rewatch>
+			<letterboxd:filmTitle>There&#039;s Something About Mary</letterboxd:filmTitle>
+			<letterboxd:filmYear>1998</letterboxd:filmYear>
+			<letterboxd:memberRating>3.5</letterboxd:memberRating>
+			<tmdb:movieId>544</tmdb:movieId>
+			<description><![CDATA[ <p><img src="https://a.ltrbxd.com/resized/film-poster/51573-theres-something-about-mary.jpg?v=x"/></p> <p>They really don&#039;t make em like they used to - dumb, contrived and hilarious</p> ]]></description>
+			<dc:creator>Chai Palaka</dc:creator>
+		</item>
+
+		<!-- No rewatch, no review -->
+		<item>
+			<title>Sinners, 2025 - ★★★½</title>
+			<link>https://letterboxd.com/cpalaka/film/sinners-2025/</link>
+			<guid isPermaLink="false">letterboxd-watch-1256248485</guid>
+			<pubDate>Sat, 28 Mar 2026 18:17:54 +1300</pubDate>
+			<letterboxd:watchedDate>2026-03-27</letterboxd:watchedDate>
+			<letterboxd:rewatch>No</letterboxd:rewatch>
+			<letterboxd:filmTitle>Sinners</letterboxd:filmTitle>
+			<letterboxd:filmYear>2025</letterboxd:filmYear>
+			<letterboxd:memberRating>3.5</letterboxd:memberRating>
+			<tmdb:movieId>1233413</tmdb:movieId>
+			<description><![CDATA[ <p><img src="https://a.ltrbxd.com/resized/film-poster/sinners.jpg"/></p> <p>Watched on Friday March 27, 2026.</p> ]]></description>
+			<dc:creator>Chai Palaka</dc:creator>
+		</item>
+
+		<!-- Malformed: missing guid — should be skipped -->
+		<item>
+			<title>Malformed No ID Film, 2024</title>
+			<link>https://letterboxd.com/cpalaka/film/malformed/</link>
+			<letterboxd:watchedDate>2026-01-01</letterboxd:watchedDate>
+			<letterboxd:filmTitle>Malformed No ID Film</letterboxd:filmTitle>
+			<letterboxd:filmYear>2024</letterboxd:filmYear>
+			<letterboxd:memberRating>3.0</letterboxd:memberRating>
+			<description><![CDATA[ <p><img src="https://example.com/poster.jpg"/></p> ]]></description>
+			<dc:creator>Chai Palaka</dc:creator>
+		</item>
+
+		<!-- Malformed: missing letterboxd:filmTitle and title is blank — should be skipped -->
+		<item>
+			<title></title>
+			<link>https://letterboxd.com/cpalaka/film/notitle/</link>
+			<guid isPermaLink="false">letterboxd-watch-9999999</guid>
+			<letterboxd:watchedDate>2026-01-02</letterboxd:watchedDate>
+			<letterboxd:filmYear>2023</letterboxd:filmYear>
+			<letterboxd:memberRating>2.0</letterboxd:memberRating>
+			<description><![CDATA[ <p><img src="https://example.com/poster.jpg"/></p> ]]></description>
+			<dc:creator>Chai Palaka</dc:creator>
+		</item>
+
+	</channel>
+</rss>

--- a/api/src/server.test.ts
+++ b/api/src/server.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { GoodreadsShelf, type Book } from './adapters/GoodreadsAdapter';
 import type { Track } from './adapters/LastFmAdapter';
+import type { Film } from './adapters/LetterboxdAdapter';
 import { handle } from './server';
 
 const FIXTURE_BOOKS: Book[] = [
@@ -232,5 +233,95 @@ describe('/api/recent-tracks', () => {
     );
 
     expect(adapter.fetchRecentTracks).toHaveBeenCalledTimes(1);
+  });
+});
+
+const FIXTURE_FILMS: Film[] = [
+  {
+    letterboxdId: '1278965807',
+    title: 'The Lord of the Rings: The Fellowship of the Ring',
+    year: 2001,
+    watchedDate: '2026-04-12',
+    rating: 5.0,
+    posterUrl: 'https://a.ltrbxd.com/poster.jpg',
+    rewatch: true,
+    link: 'https://letterboxd.com/cpalaka/film/lotr-fotr/1/',
+  },
+  {
+    letterboxdId: '1268084157',
+    title: "There's Something About Mary",
+    year: 1998,
+    watchedDate: '2026-04-05',
+    rating: 3.5,
+    review: "They really don't make em like they used to",
+    posterUrl: 'https://a.ltrbxd.com/poster2.jpg',
+    rewatch: true,
+    link: 'https://letterboxd.com/cpalaka/film/theres-something-about-mary/',
+  },
+];
+
+function makeFilmsAdapter(films: Film[] = FIXTURE_FILMS, fail = false) {
+  return {
+    fetchFilms: vi.fn(async () => {
+      if (fail) throw new Error('upstream letterboxd');
+      return films;
+    }),
+  };
+}
+
+describe('/api/films', () => {
+  it('returns { films, stale: false } with the adapter results', async () => {
+    const adapter = makeFilmsAdapter();
+    const res = await handle(
+      new Request('http://localhost/api/films'),
+      { letterboxdUser: 'cpalaka', filmsAdapter: adapter },
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as { films: Film[]; stale: boolean };
+    expect(body.stale).toBe(false);
+    expect(body.films).toHaveLength(2);
+    expect(body.films[0]?.letterboxdId).toBe('1278965807');
+  });
+
+  it('returns empty films (not stale) when letterboxdUser is absent', async () => {
+    const res = await handle(new Request('http://localhost/api/films'), {});
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as { films: Film[]; stale: boolean };
+    expect(body.films).toEqual([]);
+    expect(body.stale).toBe(false);
+  });
+
+  it('returns empty films with stale:true when adapter throws and cache is cold', async () => {
+    const adapter = makeFilmsAdapter([], true);
+    const { CacheLayer } = await import('./cache/CacheLayer');
+    const res = await handle(
+      new Request('http://localhost/api/films'),
+      { letterboxdUser: 'cpalaka', filmsAdapter: adapter, cache: new CacheLayer() },
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as { films: Film[]; stale: boolean; error: string };
+    expect(body.films).toEqual([]);
+    expect(body.stale).toBe(true);
+    expect(body.error).toBeDefined();
+  });
+
+  it('caches: calls fetchFilms only once across two requests within TTL', async () => {
+    const adapter = makeFilmsAdapter();
+    const { CacheLayer } = await import('./cache/CacheLayer');
+    const cache = new CacheLayer();
+
+    await handle(
+      new Request('http://localhost/api/films'),
+      { letterboxdUser: 'cpalaka', filmsAdapter: adapter, cache },
+    );
+    await handle(
+      new Request('http://localhost/api/films'),
+      { letterboxdUser: 'cpalaka', filmsAdapter: adapter, cache },
+    );
+
+    expect(adapter.fetchFilms).toHaveBeenCalledTimes(1);
   });
 });

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -3,6 +3,8 @@ import type { GoodreadsAdapter } from './adapters/GoodreadsAdapter';
 import { GoodreadsAdapter as GoodreadsAdapterImpl } from './adapters/GoodreadsAdapter';
 import type { LastFmAdapter } from './adapters/LastFmAdapter';
 import { LastFmAdapter as LastFmAdapterImpl } from './adapters/LastFmAdapter';
+import type { LetterboxdAdapter } from './adapters/LetterboxdAdapter';
+import { LetterboxdAdapter as LetterboxdAdapterImpl } from './adapters/LetterboxdAdapter';
 
 export type ServerConfig = {
   version?: string
@@ -11,6 +13,8 @@ export type ServerConfig = {
   lastfmApiKey?: string
   lastfmUser?: string
   lastfmAdapter?: Pick<LastFmAdapter, 'fetchRecentTracks'>
+  letterboxdUser?: string
+  filmsAdapter?: Pick<LetterboxdAdapter, 'fetchFilms'>
   cache?: CacheLayer
 };
 
@@ -19,6 +23,7 @@ const BOOKS_TTL_MS = 24 * 60 * 60_000;
 const NOW_PLAYING_TTL_MS = 3 * 60_000;
 const RECENT_TRACKS_TTL_MS = 5 * 60_000;
 const RECENT_TRACKS_LIMIT = 10;
+const FILMS_TTL_MS = 60 * 60_000;
 
 export async function handle(
   req: Request,
@@ -96,6 +101,28 @@ export async function handle(
     }
   }
 
+  if (url.pathname === '/api/films') {
+    if (!config.letterboxdUser) {
+      return Response.json({ films: [], stale: false });
+    }
+    const adapter =
+      config.filmsAdapter ??
+      new LetterboxdAdapterImpl({ user: config.letterboxdUser });
+    const cache = config.cache ?? sharedCache;
+    try {
+      const { value, stale } = await cache.get(
+        'films',
+        () => adapter.fetchFilms(),
+        { ttl: FILMS_TTL_MS },
+      );
+      return Response.json({ films: value, stale });
+    } catch (e) {
+      const error = e instanceof Error ? e.message : String(e);
+      console.error('[Server] failed to fetch films', e);
+      return Response.json({ films: [], stale: true, error });
+    }
+  }
+
   return new Response('not found', { status: 404 });
 }
 
@@ -105,6 +132,7 @@ if (import.meta.main) {
     goodreadsUserId: process.env.GOODREADS_USER_ID,
     lastfmApiKey: process.env.LASTFM_API_KEY,
     lastfmUser: process.env.LASTFM_USER,
+    letterboxdUser: process.env.LETTERBOXD_USER,
   };
   Bun.serve({
     port: 3000,

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -23,7 +23,7 @@ const BOOKS_TTL_MS = 24 * 60 * 60_000;
 const NOW_PLAYING_TTL_MS = 3 * 60_000;
 const RECENT_TRACKS_TTL_MS = 5 * 60_000;
 const RECENT_TRACKS_LIMIT = 10;
-const FILMS_TTL_MS = 60 * 60_000;
+const FILMS_TTL_MS = 24 * 60 * 60_000;
 
 export async function handle(
   req: Request,

--- a/deploy/SECRETS.md
+++ b/deploy/SECRETS.md
@@ -32,6 +32,7 @@ Format (one `KEY=value` per line, no quoting):
 ```
 LASTFM_API_KEY=xxxxxxxxxxxxxxxxxxxx
 LASTFM_USER=cpalaka
+GOODREADS_USER_ID=<your-numeric-id>
 LETTERBOXD_USER=cpalaka
 GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxx
 ```

--- a/deploy/SECRETS.md
+++ b/deploy/SECRETS.md
@@ -31,8 +31,8 @@ Format (one `KEY=value` per line, no quoting):
 
 ```
 LASTFM_API_KEY=xxxxxxxxxxxxxxxxxxxx
-LASTFM_USER=chaipalaka
-LETTERBOXD_USER=chaipalaka
+LASTFM_USER=cpalaka
+LETTERBOXD_USER=cpalaka
 GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxx
 ```
 

--- a/web/src/routes/Lifelog.css
+++ b/web/src/routes/Lifelog.css
@@ -162,3 +162,87 @@
     color: var(--color-fg-faint);
     margin: 0;
 }
+
+/* Films panel */
+
+.lifelog-films {
+    padding: var(--space-2);
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+    overflow: hidden;
+}
+
+.lifelog-films__heading {
+    font-size: var(--font-size-md);
+    font-weight: var(--font-weight-semi);
+    color: var(--color-fg);
+    margin: 0;
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+}
+
+.lifelog-films__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+    overflow-y: auto;
+    flex: 1;
+}
+
+.lifelog-films__item {
+    display: flex;
+    gap: var(--space-3);
+    align-items: flex-start;
+}
+
+.lifelog-films__poster {
+    width: 48px;
+    height: 72px;
+    object-fit: cover;
+    border-radius: var(--radius-sm);
+    flex-shrink: 0;
+}
+
+.lifelog-films__meta {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+    min-width: 0;
+}
+
+.lifelog-films__title {
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-semi);
+    color: var(--color-fg);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.lifelog-films__year {
+    font-weight: normal;
+    color: var(--color-fg-muted);
+}
+
+.lifelog-films__stars {
+    font-size: var(--font-size-xs);
+    color: var(--color-fg);
+    letter-spacing: 0.02em;
+}
+
+.lifelog-films__date {
+    font-size: var(--font-size-xs);
+    font-family: var(--font-mono);
+    color: var(--color-fg-faint);
+}
+
+.lifelog-films__empty {
+    color: var(--color-fg-faint);
+    margin: 0;
+}

--- a/web/src/routes/Lifelog.tsx
+++ b/web/src/routes/Lifelog.tsx
@@ -149,6 +149,102 @@ function NowPlayingPanel() {
     )
 }
 
+// ─── Films card ──────────────────────────────────────────────────────────────
+
+const FILMS_W = 320
+const FILMS_H = 320
+
+export const filmsAnchor = (vp: Viewport): Vec2 => ({ x: vp.width / 2, y: 600 })
+
+interface Film {
+    letterboxdId: string
+    title: string
+    year?: number
+    watchedDate?: string
+    rating?: number
+    review?: string
+    posterUrl?: string
+    rewatch?: boolean
+    link: string
+}
+
+interface FilmsApiResponse {
+    films: Film[]
+    stale: boolean
+}
+
+const FILMS_DISPLAY_COUNT = 3
+
+function renderStars(rating: number): string {
+    const full = Math.floor(rating)
+    const half = rating % 1 >= 0.5
+    const empty = 5 - full - (half ? 1 : 0)
+    return '★'.repeat(full) + (half ? '½' : '') + '☆'.repeat(empty)
+}
+
+function shortDate(iso: string): string {
+    const d = new Date(iso)
+    return d.toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })
+}
+
+function FilmsPanel() {
+    const [data, setData] = useState<FilmsApiResponse | null>(null)
+
+    useEffect(() => {
+        fetch('/api/films')
+            .then((r) => r.json() as Promise<FilmsApiResponse>)
+            .then(setData)
+            .catch(() => setData(null))
+    }, [])
+
+    const films = (data?.films ?? []).slice(0, FILMS_DISPLAY_COUNT)
+
+    return (
+        <div className="lifelog-films">
+            <h2 className="lifelog-films__heading">
+                Films
+                {data?.stale ? (
+                    <span className="lifelog-books__stale">stale</span>
+                ) : null}
+            </h2>
+            {films.length > 0 ? (
+                <ul className="lifelog-films__list">
+                    {films.map((f) => (
+                        <li key={f.letterboxdId} className="lifelog-films__item">
+                            {f.posterUrl ? (
+                                <img
+                                    className="lifelog-films__poster"
+                                    src={f.posterUrl}
+                                    alt={`${f.title} poster`}
+                                    loading="lazy"
+                                />
+                            ) : null}
+                            <div className="lifelog-films__meta">
+                                <span className="lifelog-films__title">
+                                    {f.title}
+                                    {f.year ? (
+                                        <span className="lifelog-films__year"> ({f.year})</span>
+                                    ) : null}
+                                </span>
+                                {f.rating !== undefined ? (
+                                    <span className="lifelog-films__stars" aria-label={`${f.rating} out of 5 stars`}>
+                                        {renderStars(f.rating)}
+                                    </span>
+                                ) : null}
+                                {f.watchedDate ? (
+                                    <span className="lifelog-films__date">{shortDate(f.watchedDate)}</span>
+                                ) : null}
+                            </div>
+                        </li>
+                    ))}
+                </ul>
+            ) : (
+                <p className="lifelog-films__empty">—</p>
+            )}
+        </div>
+    )
+}
+
 // ─── Page definition ──────────────────────────────────────────────────────────
 
 const pageDef: PageDef = {
@@ -165,6 +261,12 @@ const pageDef: PageDef = {
             kind: 'lifelog',
             parent: 'ceiling',
             anchor: nowPlayingAnchor,
+        },
+        {
+            id: 'lifelog-films',
+            kind: 'lifelog',
+            parent: 'ceiling',
+            anchor: filmsAnchor,
         },
     ],
 }
@@ -185,6 +287,14 @@ const cardContent: Record<string, CardContent> = {
         minimizable: true,
         label: 'Music',
         children: <NowPlayingPanel />,
+    },
+    'lifelog-films': {
+        text: 'Films',
+        width: FILMS_W,
+        height: FILMS_H,
+        minimizable: true,
+        label: 'Films',
+        children: <FilmsPanel />,
     },
 }
 


### PR DESCRIPTION
## Summary

- Adds `LetterboxdAdapter` that fetches the public Letterboxd RSS feed (`https://letterboxd.com/<user>/rss/`), normalises entries into `Film[]`, and handles half-star float ratings, poster URL extraction from description CDATA, review text extraction, and HTML entity decoding (`&#039;` → `'`)
- Adds `/api/films` endpoint wired to `CacheLayer` with 1h TTL and stale-while-error fallback; configures via `LETTERBOXD_USER` env var (add to `/etc/chaipalaka.env` on server — already in `SECRETS.md`)
- Adds `FilmsPanel` card to `/lifelog`: poster (48×72 portrait), title+year, star rating with half-star `½` glyph, watched date; anchored centred below the books card at `(vp.width/2, 600)`

## Notes / deviations

- Issue refers to the component as `<FilmCard />` but the slice-10 convention uses `…Panel` for the lifelog cards — kept `FilmsPanel` for consistency
- `letterboxdId` is the numeric watch/review ID extracted from `<guid>letterboxd-watch-NNN</guid>` (most stable identifier available on each entry; guid prefix is `letterboxd-watch-` or `letterboxd-review-`)
- Review extraction: strips the poster `<p><img …></p>` block and suppresses the auto-generated `"Watched on…"` placeholder — reviews are only populated when the user actually wrote one
- Rating: stored as float (Letterboxd uses 0.5–5.0 in 0.5 steps); rendered with `★½☆` Unicode glyphs, no SVG/icon font
- No new npm dependencies added

## Acceptance criteria

- [x] `LetterboxdAdapter` tests using a recorded RSS fixture (16 tests — happy path, rating, review, entity decode, malformed entries, upstream failure)
- [x] One malformed entry doesn't break the rest of the feed
- [x] Handles upstream failure (throws → `CacheLayer` stale fallback)
- [x] `/api/films` returns `{ films, stale }` via `CacheLayer` (1h TTL)
- [x] Films card on `/lifelog` shows most recent 3 films
- [x] `LETTERBOXD_USER` configured via `/etc/chaipalaka.env` (documented in `deploy/SECRETS.md`)
- [ ] Stale fallback shown to user — works via existing `CacheLayer` mechanism; stale pill displays when `data.stale === true`. Verify manually by temporarily configuring a bad user

## Test plan

```sh
# API
cd api && bun test          # 58 tests, 0 failures

# Frontend
cd web && npm run typecheck # clean
cd web && npm run test      # 220 tests, 0 failures
cd web && npm run build     # builds + SSRs /lifelog

# Smoke test (needs LETTERBOXD_USER=cpalaka in env)
LETTERBOXD_USER=cpalaka bun run src/server.ts &
curl -s localhost:3000/api/films | jq '{ count: (.films | length), stale, first: .films[0].title }'

# UI
npm run dev  # open /lifelog — films card should appear with posters, stars, dates
```

**Deploy note:** Add `LETTERBOXD_USER=cpalaka` to `/etc/chaipalaka.env` on the Hetzner box before or after deploying — endpoint returns `{ films: [], stale: false }` gracefully when the env var is absent.

Closes #11