### PR TITLE
Slice 12: GitHub activity source (#12)

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -9,4 +9,5 @@ BUILD_SHA=dev
 LASTFM_API_KEY=
 LASTFM_USER=cpalaka
 LETTERBOXD_USER=cpalaka
-# GITHUB_TOKEN=
+GITHUB_USER=cpalaka
+# GITHUB_TOKEN= (not needed for public events; add if rate-limited)

--- a/api/src/adapters/GitHubAdapter.test.ts
+++ b/api/src/adapters/GitHubAdapter.test.ts
@@ -1,0 +1,183 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it, vi } from 'vitest';
+import { GitHubAdapter } from './GitHubAdapter';
+
+const FIXTURES = join(dirname(fileURLToPath(import.meta.url)), '__fixtures__');
+const eventsJson = readFileSync(join(FIXTURES, 'github-events.json'), 'utf-8');
+
+function mockFetch(body: string, status = 200): typeof globalThis.fetch {
+  return vi.fn(async () =>
+    new Response(body, { status, headers: { 'content-type': 'application/json' } }),
+  ) as unknown as typeof globalThis.fetch;
+}
+
+describe('GitHubAdapter', () => {
+  describe('fetchActivity() — PushEvent', () => {
+    it('normalises PushEvent to type "push"', async () => {
+      const adapter = new GitHubAdapter({ user: 'cpalaka', fetch: mockFetch(eventsJson) });
+      const activity = await adapter.fetchActivity();
+      const push = activity.find((a) => a.type === 'push');
+      expect(push).toBeDefined();
+    });
+
+    it('includes commit count and branch in summary', async () => {
+      const adapter = new GitHubAdapter({ user: 'cpalaka', fetch: mockFetch(eventsJson) });
+      const activity = await adapter.fetchActivity();
+      const push = activity.find((a) => a.type === 'push');
+      expect(push?.summary).toBe('Pushed 2 commits to main');
+    });
+
+    it('sets url to the repo commit url', async () => {
+      const adapter = new GitHubAdapter({ user: 'cpalaka', fetch: mockFetch(eventsJson) });
+      const activity = await adapter.fetchActivity();
+      const push = activity.find((a) => a.type === 'push');
+      expect(push?.url).toBe('https://github.com/cpalaka/chaipalaka.com/commit/abc123def456');
+    });
+
+    it('sets repo to the repo name', async () => {
+      const adapter = new GitHubAdapter({ user: 'cpalaka', fetch: mockFetch(eventsJson) });
+      const activity = await adapter.fetchActivity();
+      const push = activity.find((a) => a.type === 'push');
+      expect(push?.repo).toBe('cpalaka/chaipalaka.com');
+    });
+
+    it('sets ts as ISO string', async () => {
+      const adapter = new GitHubAdapter({ user: 'cpalaka', fetch: mockFetch(eventsJson) });
+      const activity = await adapter.fetchActivity();
+      const push = activity.find((a) => a.type === 'push');
+      expect(push?.ts).toBe('2026-05-11T10:00:00Z');
+    });
+  });
+
+  describe('fetchActivity() — PullRequestEvent', () => {
+    it('normalises opened PR to type "pull_request" with "opened PR:" summary', async () => {
+      const adapter = new GitHubAdapter({ user: 'cpalaka', fetch: mockFetch(eventsJson) });
+      const activity = await adapter.fetchActivity(20);
+      const opened = activity.find(
+        (a) => a.type === 'pull_request' && a.summary.startsWith('opened PR:'),
+      );
+      expect(opened?.summary).toBe('opened PR: Add GitHub activity source');
+      expect(opened?.url).toBe('https://github.com/cpalaka/chaipalaka.com/pull/72');
+    });
+
+    it('uses "merged PR:" for a closed+merged PR', async () => {
+      const adapter = new GitHubAdapter({ user: 'cpalaka', fetch: mockFetch(eventsJson) });
+      const activity = await adapter.fetchActivity(20);
+      const merged = activity.find(
+        (a) => a.type === 'pull_request' && a.summary.startsWith('merged PR:'),
+      );
+      expect(merged?.summary).toBe('merged PR: Fix letterboxd adapter');
+      expect(merged?.url).toBe('https://github.com/cpalaka/chaipalaka.com/pull/71');
+    });
+  });
+
+  describe('fetchActivity() — IssuesEvent', () => {
+    it('normalises IssuesEvent to type "issue"', async () => {
+      const adapter = new GitHubAdapter({ user: 'cpalaka', fetch: mockFetch(eventsJson) });
+      const activity = await adapter.fetchActivity();
+      const issue = activity.find((a) => a.type === 'issue');
+      expect(issue).toBeDefined();
+    });
+
+    it('builds summary as "<action> issue: <title>"', async () => {
+      const adapter = new GitHubAdapter({ user: 'cpalaka', fetch: mockFetch(eventsJson) });
+      const activity = await adapter.fetchActivity();
+      const issue = activity.find((a) => a.type === 'issue');
+      expect(issue?.summary).toBe('opened issue: Bug: something is broken');
+      expect(issue?.url).toBe('https://github.com/cpalaka/other-repo/issues/5');
+    });
+  });
+
+  describe('fetchActivity() — ReleaseEvent', () => {
+    it('normalises ReleaseEvent to type "release"', async () => {
+      const adapter = new GitHubAdapter({ user: 'cpalaka', fetch: mockFetch(eventsJson) });
+      const activity = await adapter.fetchActivity();
+      const release = activity.find((a) => a.type === 'release');
+      expect(release).toBeDefined();
+    });
+
+    it('builds summary as "Released <tag>"', async () => {
+      const adapter = new GitHubAdapter({ user: 'cpalaka', fetch: mockFetch(eventsJson) });
+      const activity = await adapter.fetchActivity();
+      const release = activity.find((a) => a.type === 'release');
+      expect(release?.summary).toBe('Released v1.2.0');
+      expect(release?.url).toBe('https://github.com/cpalaka/chaipalaka.com/releases/tag/v1.2.0');
+    });
+  });
+
+  describe('fetchActivity() — WatchEvent', () => {
+    it('normalises WatchEvent to type "star"', async () => {
+      const adapter = new GitHubAdapter({ user: 'cpalaka', fetch: mockFetch(eventsJson) });
+      const activity = await adapter.fetchActivity();
+      const star = activity.find((a) => a.type === 'star');
+      expect(star).toBeDefined();
+    });
+
+    it('builds summary as "Starred <repo>"', async () => {
+      const adapter = new GitHubAdapter({ user: 'cpalaka', fetch: mockFetch(eventsJson) });
+      const activity = await adapter.fetchActivity();
+      const star = activity.find((a) => a.type === 'star');
+      expect(star?.summary).toBe('Starred vitejs/vite');
+      expect(star?.url).toBe('https://github.com/vitejs/vite');
+    });
+  });
+
+  describe('unhandled event types', () => {
+    it('silently drops ForkEvent (not in the result list)', async () => {
+      const adapter = new GitHubAdapter({ user: 'cpalaka', fetch: mockFetch(eventsJson) });
+      const activity = await adapter.fetchActivity(30);
+      const fork = activity.find((a) => a.repo === 'some/project');
+      expect(fork).toBeUndefined();
+    });
+
+    it('silently drops null-type events', async () => {
+      const adapter = new GitHubAdapter({ user: 'cpalaka', fetch: mockFetch(eventsJson) });
+      const activity = await adapter.fetchActivity(30);
+      // fixture has 8 items: 1 push + 2 PRs + 1 issue + 1 release + 1 star + 1 fork (drop) + 1 null-type (drop)
+      expect(activity.length).toBe(6);
+    });
+  });
+
+  describe('limit parameter', () => {
+    it('returns at most limit items', async () => {
+      const adapter = new GitHubAdapter({ user: 'cpalaka', fetch: mockFetch(eventsJson) });
+      const activity = await adapter.fetchActivity(3);
+      expect(activity.length).toBe(3);
+    });
+
+    it('defaults to 10 items', async () => {
+      const body = JSON.stringify(
+        Array.from({ length: 15 }, (_, i) => ({
+          id: String(i),
+          type: 'WatchEvent',
+          repo: { name: `user/repo-${i}` },
+          payload: { action: 'started' },
+          created_at: '2026-05-11T00:00:00Z',
+        })),
+      );
+      const adapter = new GitHubAdapter({ user: 'cpalaka', fetch: mockFetch(body) });
+      const activity = await adapter.fetchActivity();
+      expect(activity.length).toBe(10);
+    });
+  });
+
+  describe('upstream failure', () => {
+    it('throws when the upstream returns 503', async () => {
+      const adapter = new GitHubAdapter({
+        user: 'cpalaka',
+        fetch: mockFetch('Service Unavailable', 503),
+      });
+      await expect(adapter.fetchActivity()).rejects.toThrow('503');
+    });
+
+    it('throws when the upstream returns 403 (rate limited)', async () => {
+      const adapter = new GitHubAdapter({
+        user: 'cpalaka',
+        fetch: mockFetch('rate limited', 403),
+      });
+      await expect(adapter.fetchActivity()).rejects.toThrow('403');
+    });
+  });
+});

--- a/api/src/adapters/GitHubAdapter.ts
+++ b/api/src/adapters/GitHubAdapter.ts
@@ -1,0 +1,118 @@
+export interface Activity {
+  type: 'push' | 'pull_request' | 'issue' | 'release' | 'star'
+  repo: string
+  summary: string
+  url: string
+  ts: string
+}
+
+export interface GitHubAdapterOpts {
+  user: string
+  fetch?: typeof globalThis.fetch
+}
+
+const BASE = 'https://api.github.com';
+
+interface RawEvent {
+  id: string
+  type: string | null
+  repo: { name: string }
+  payload: Record<string, unknown>
+  created_at: string
+}
+
+function normalise(raw: RawEvent): Activity | null {
+  const repo = raw.repo?.name;
+  const ts = raw.created_at;
+  if (!repo || !ts || !raw.type) return null;
+
+  switch (raw.type) {
+    case 'PushEvent': {
+      const p = raw.payload as { size: number; ref: string; head: string };
+      const branch = (p.ref ?? '').replace('refs/heads/', '');
+      const count = p.size ?? 0;
+      return {
+        type: 'push',
+        repo,
+        summary: `Pushed ${count} commit${count !== 1 ? 's' : ''} to ${branch}`,
+        url: `https://github.com/${repo}/commit/${p.head}`,
+        ts,
+      };
+    }
+    case 'PullRequestEvent': {
+      const p = raw.payload as {
+        action: string
+        pull_request: { title: string; merged: boolean; html_url: string }
+      };
+      const pr = p.pull_request;
+      if (!pr?.title || !pr?.html_url) return null;
+      const verb = p.action === 'closed' && pr.merged ? 'merged' : p.action;
+      return {
+        type: 'pull_request',
+        repo,
+        summary: `${verb} PR: ${pr.title}`,
+        url: pr.html_url,
+        ts,
+      };
+    }
+    case 'IssuesEvent': {
+      const p = raw.payload as { action: string; issue: { title: string; html_url: string } };
+      const issue = p.issue;
+      if (!issue?.title || !issue?.html_url) return null;
+      return {
+        type: 'issue',
+        repo,
+        summary: `${p.action} issue: ${issue.title}`,
+        url: issue.html_url,
+        ts,
+      };
+    }
+    case 'ReleaseEvent': {
+      const p = raw.payload as { release: { tag_name: string; html_url: string } };
+      const release = p.release;
+      if (!release?.tag_name || !release?.html_url) return null;
+      return {
+        type: 'release',
+        repo,
+        summary: `Released ${release.tag_name}`,
+        url: release.html_url,
+        ts,
+      };
+    }
+    case 'WatchEvent': {
+      return {
+        type: 'star',
+        repo,
+        summary: `Starred ${repo}`,
+        url: `https://github.com/${repo}`,
+        ts,
+      };
+    }
+    default:
+      return null;
+  }
+}
+
+export class GitHubAdapter {
+  private readonly user: string
+  private readonly fetchFn: typeof globalThis.fetch
+
+  constructor(opts: GitHubAdapterOpts) {
+    this.user = opts.user;
+    this.fetchFn = opts.fetch ?? globalThis.fetch;
+  }
+
+  async fetchActivity(limit = 10): Promise<Activity[]> {
+    const url = `${BASE}/users/${encodeURIComponent(this.user)}/events/public?per_page=30`;
+    const res = await this.fetchFn(url);
+    if (!res.ok) throw new Error(`GitHub returned ${res.status}`);
+
+    const events = (await res.json()) as RawEvent[];
+    const activity: Activity[] = [];
+    for (const raw of events) {
+      const a = normalise(raw);
+      if (a) activity.push(a);
+    }
+    return activity.slice(0, limit);
+  }
+}

--- a/api/src/adapters/__fixtures__/github-events.json
+++ b/api/src/adapters/__fixtures__/github-events.json
@@ -1,0 +1,111 @@
+[
+  {
+    "id": "39000000001",
+    "type": "PushEvent",
+    "actor": { "login": "cpalaka" },
+    "repo": { "name": "cpalaka/chaipalaka.com" },
+    "payload": {
+      "push_id": 1,
+      "size": 2,
+      "distinct_size": 2,
+      "ref": "refs/heads/main",
+      "head": "abc123def456",
+      "before": "000111222333",
+      "commits": [
+        { "sha": "abc123", "message": "feat: add thing" },
+        { "sha": "def456", "message": "fix: bug" }
+      ]
+    },
+    "public": true,
+    "created_at": "2026-05-11T10:00:00Z"
+  },
+  {
+    "id": "39000000002",
+    "type": "PullRequestEvent",
+    "actor": { "login": "cpalaka" },
+    "repo": { "name": "cpalaka/chaipalaka.com" },
+    "payload": {
+      "action": "opened",
+      "pull_request": {
+        "title": "Add GitHub activity source",
+        "merged": false,
+        "html_url": "https://github.com/cpalaka/chaipalaka.com/pull/72"
+      }
+    },
+    "public": true,
+    "created_at": "2026-05-10T15:00:00Z"
+  },
+  {
+    "id": "39000000003",
+    "type": "PullRequestEvent",
+    "actor": { "login": "cpalaka" },
+    "repo": { "name": "cpalaka/chaipalaka.com" },
+    "payload": {
+      "action": "closed",
+      "pull_request": {
+        "title": "Fix letterboxd adapter",
+        "merged": true,
+        "html_url": "https://github.com/cpalaka/chaipalaka.com/pull/71"
+      }
+    },
+    "public": true,
+    "created_at": "2026-05-10T12:00:00Z"
+  },
+  {
+    "id": "39000000004",
+    "type": "IssuesEvent",
+    "actor": { "login": "cpalaka" },
+    "repo": { "name": "cpalaka/other-repo" },
+    "payload": {
+      "action": "opened",
+      "issue": {
+        "title": "Bug: something is broken",
+        "html_url": "https://github.com/cpalaka/other-repo/issues/5"
+      }
+    },
+    "public": true,
+    "created_at": "2026-05-09T08:00:00Z"
+  },
+  {
+    "id": "39000000005",
+    "type": "ReleaseEvent",
+    "actor": { "login": "cpalaka" },
+    "repo": { "name": "cpalaka/chaipalaka.com" },
+    "payload": {
+      "action": "published",
+      "release": {
+        "tag_name": "v1.2.0",
+        "html_url": "https://github.com/cpalaka/chaipalaka.com/releases/tag/v1.2.0"
+      }
+    },
+    "public": true,
+    "created_at": "2026-05-08T12:00:00Z"
+  },
+  {
+    "id": "39000000006",
+    "type": "WatchEvent",
+    "actor": { "login": "cpalaka" },
+    "repo": { "name": "vitejs/vite" },
+    "payload": { "action": "started" },
+    "public": true,
+    "created_at": "2026-05-07T20:00:00Z"
+  },
+  {
+    "id": "39000000007",
+    "type": "ForkEvent",
+    "actor": { "login": "cpalaka" },
+    "repo": { "name": "some/project" },
+    "payload": {},
+    "public": true,
+    "created_at": "2026-05-07T19:00:00Z"
+  },
+  {
+    "id": "39000000008",
+    "type": null,
+    "actor": { "login": "cpalaka" },
+    "repo": { "name": "cpalaka/chaipalaka.com" },
+    "payload": {},
+    "public": true,
+    "created_at": "2026-05-07T18:00:00Z"
+  }
+]

--- a/api/src/server.test.ts
+++ b/api/src/server.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { GoodreadsShelf, type Book } from './adapters/GoodreadsAdapter';
 import type { Track } from './adapters/LastFmAdapter';
 import type { Film } from './adapters/LetterboxdAdapter';
+import type { Activity } from './adapters/GitHubAdapter';
 import { handle } from './server';
 
 const FIXTURE_BOOKS: Book[] = [
@@ -323,5 +324,88 @@ describe('/api/films', () => {
     );
 
     expect(adapter.fetchFilms).toHaveBeenCalledTimes(1);
+  });
+});
+
+const FIXTURE_ACTIVITY: Activity[] = [
+  {
+    type: 'push',
+    repo: 'cpalaka/chaipalaka.com',
+    summary: 'Pushed 2 commits to main',
+    url: 'https://github.com/cpalaka/chaipalaka.com/commit/abc123',
+    ts: '2026-05-11T10:00:00Z',
+  },
+  {
+    type: 'star',
+    repo: 'vitejs/vite',
+    summary: 'Starred vitejs/vite',
+    url: 'https://github.com/vitejs/vite',
+    ts: '2026-05-10T20:00:00Z',
+  },
+];
+
+function makeActivityAdapter(activity: Activity[] = FIXTURE_ACTIVITY, fail = false) {
+  return {
+    fetchActivity: vi.fn(async () => {
+      if (fail) throw new Error('upstream github');
+      return activity;
+    }),
+  };
+}
+
+describe('/api/github', () => {
+  it('returns { activity, stale: false } with the adapter results', async () => {
+    const adapter = makeActivityAdapter();
+    const res = await handle(
+      new Request('http://localhost/api/github'),
+      { githubUser: 'cpalaka', activityAdapter: adapter },
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as { activity: Activity[]; stale: boolean };
+    expect(body.stale).toBe(false);
+    expect(body.activity).toHaveLength(2);
+    expect(body.activity[0]?.type).toBe('push');
+  });
+
+  it('returns empty activity (not stale) when githubUser is absent', async () => {
+    const res = await handle(new Request('http://localhost/api/github'), {});
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as { activity: Activity[]; stale: boolean };
+    expect(body.activity).toEqual([]);
+    expect(body.stale).toBe(false);
+  });
+
+  it('returns empty activity with stale:true when adapter throws and cache is cold', async () => {
+    const adapter = makeActivityAdapter([], true);
+    const { CacheLayer } = await import('./cache/CacheLayer');
+    const res = await handle(
+      new Request('http://localhost/api/github'),
+      { githubUser: 'cpalaka', activityAdapter: adapter, cache: new CacheLayer() },
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as { activity: Activity[]; stale: boolean; error: string };
+    expect(body.activity).toEqual([]);
+    expect(body.stale).toBe(true);
+    expect(body.error).toBeDefined();
+  });
+
+  it('caches: calls fetchActivity only once across two requests within TTL', async () => {
+    const adapter = makeActivityAdapter();
+    const { CacheLayer } = await import('./cache/CacheLayer');
+    const cache = new CacheLayer();
+
+    await handle(
+      new Request('http://localhost/api/github'),
+      { githubUser: 'cpalaka', activityAdapter: adapter, cache },
+    );
+    await handle(
+      new Request('http://localhost/api/github'),
+      { githubUser: 'cpalaka', activityAdapter: adapter, cache },
+    );
+
+    expect(adapter.fetchActivity).toHaveBeenCalledTimes(1);
   });
 });

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -5,6 +5,8 @@ import type { LastFmAdapter } from './adapters/LastFmAdapter';
 import { LastFmAdapter as LastFmAdapterImpl } from './adapters/LastFmAdapter';
 import type { LetterboxdAdapter } from './adapters/LetterboxdAdapter';
 import { LetterboxdAdapter as LetterboxdAdapterImpl } from './adapters/LetterboxdAdapter';
+import type { GitHubAdapter } from './adapters/GitHubAdapter';
+import { GitHubAdapter as GitHubAdapterImpl } from './adapters/GitHubAdapter';
 
 export type ServerConfig = {
   version?: string
@@ -15,6 +17,8 @@ export type ServerConfig = {
   lastfmAdapter?: Pick<LastFmAdapter, 'fetchRecentTracks'>
   letterboxdUser?: string
   filmsAdapter?: Pick<LetterboxdAdapter, 'fetchFilms'>
+  githubUser?: string
+  activityAdapter?: Pick<GitHubAdapter, 'fetchActivity'>
   cache?: CacheLayer
 };
 
@@ -24,6 +28,7 @@ const NOW_PLAYING_TTL_MS = 3 * 60_000;
 const RECENT_TRACKS_TTL_MS = 5 * 60_000;
 const RECENT_TRACKS_LIMIT = 10;
 const FILMS_TTL_MS = 24 * 60 * 60_000;
+const ACTIVITY_TTL_MS = 5 * 60_000;
 
 export async function handle(
   req: Request,
@@ -123,6 +128,28 @@ export async function handle(
     }
   }
 
+  if (url.pathname === '/api/github') {
+    if (!config.githubUser) {
+      return Response.json({ activity: [], stale: false });
+    }
+    const adapter =
+      config.activityAdapter ??
+      new GitHubAdapterImpl({ user: config.githubUser });
+    const cache = config.cache ?? sharedCache;
+    try {
+      const { value, stale } = await cache.get(
+        'activity',
+        () => adapter.fetchActivity(),
+        { ttl: ACTIVITY_TTL_MS },
+      );
+      return Response.json({ activity: value, stale });
+    } catch (e) {
+      const error = e instanceof Error ? e.message : String(e);
+      console.error('[Server] failed to fetch github activity', e);
+      return Response.json({ activity: [], stale: true, error });
+    }
+  }
+
   return new Response('not found', { status: 404 });
 }
 
@@ -133,6 +160,7 @@ if (import.meta.main) {
     lastfmApiKey: process.env.LASTFM_API_KEY,
     lastfmUser: process.env.LASTFM_USER,
     letterboxdUser: process.env.LETTERBOXD_USER,
+    githubUser: process.env.GITHUB_USER,
   };
   Bun.serve({
     port: 3000,

--- a/deploy/SECRETS.md
+++ b/deploy/SECRETS.md
@@ -34,6 +34,7 @@ LASTFM_API_KEY=xxxxxxxxxxxxxxxxxxxx
 LASTFM_USER=cpalaka
 GOODREADS_USER_ID=<your-numeric-id>
 LETTERBOXD_USER=cpalaka
+GITHUB_USER=cpalaka
 GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxx
 ```
 

--- a/web/src/routes/Lifelog.css
+++ b/web/src/routes/Lifelog.css
@@ -246,3 +246,100 @@
     color: var(--color-fg-faint);
     margin: 0;
 }
+
+/* Activity panel */
+
+.lifelog-activity {
+    padding: var(--space-2);
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+    overflow: hidden;
+}
+
+.lifelog-activity__heading {
+    font-size: var(--font-size-md);
+    font-weight: var(--font-weight-semi);
+    color: var(--color-fg);
+    margin: 0;
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+}
+
+.lifelog-activity__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+    overflow-y: auto;
+    flex: 1;
+}
+
+.lifelog-activity__item {
+    display: flex;
+    gap: var(--space-2);
+    align-items: flex-start;
+}
+
+.lifelog-activity__badge {
+    font-size: var(--font-size-xs);
+    font-family: var(--font-mono);
+    border-radius: var(--radius-pill);
+    padding: 2px var(--space-2);
+    flex-shrink: 0;
+    background: color-mix(in srgb, var(--color-fg-faint) 20%, transparent);
+    color: var(--color-fg-muted);
+}
+
+.lifelog-activity__badge--push {
+    background: color-mix(in srgb, var(--color-accent) 15%, transparent);
+    color: var(--color-accent);
+}
+
+.lifelog-activity__badge--pull_request {
+    background: color-mix(in srgb, var(--color-fg) 15%, transparent);
+    color: var(--color-fg);
+}
+
+.lifelog-activity__badge--release {
+    background: color-mix(in srgb, var(--color-accent) 25%, transparent);
+    color: var(--color-accent);
+}
+
+.lifelog-activity__body {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+    min-width: 0;
+}
+
+.lifelog-activity__summary {
+    font-size: var(--font-size-xs);
+    color: var(--color-fg);
+    text-decoration: none;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.lifelog-activity__summary:hover {
+    text-decoration: underline;
+}
+
+.lifelog-activity__meta {
+    font-size: var(--font-size-xs);
+    font-family: var(--font-mono);
+    color: var(--color-fg-faint);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.lifelog-activity__empty {
+    color: var(--color-fg-faint);
+    margin: 0;
+}

--- a/web/src/routes/Lifelog.tsx
+++ b/web/src/routes/Lifelog.tsx
@@ -245,6 +245,97 @@ function FilmsPanel() {
     )
 }
 
+// ─── Activity card ────────────────────────────────────────────────────────────
+
+const ACTIVITY_W = 280
+const ACTIVITY_H = 360
+
+export const activityAnchor = (vp: Viewport): Vec2 => ({ x: 200, y: vp.height / 2 })
+
+type ActivityType = 'push' | 'pull_request' | 'issue' | 'release' | 'star'
+
+interface Activity {
+    type: ActivityType
+    repo: string
+    summary: string
+    url: string
+    ts: string
+}
+
+interface ActivityApiResponse {
+    activity: Activity[]
+    stale: boolean
+}
+
+const ACTIVITY_BADGE_LABELS: Record<ActivityType, string> = {
+    push: 'push',
+    pull_request: 'PR',
+    issue: 'issue',
+    release: 'release',
+    star: 'star',
+}
+
+function relTime(iso: string): string {
+    const diff = Date.now() - new Date(iso).getTime()
+    const min = Math.floor(diff / 60_000)
+    if (min < 60) return `${min}m ago`
+    const hrs = Math.floor(min / 60)
+    if (hrs < 24) return `${hrs}h ago`
+    const days = Math.floor(hrs / 24)
+    if (days < 30) return `${days}d ago`
+    return `${Math.floor(days / 7)}wk ago`
+}
+
+function ActivityPanel() {
+    const [data, setData] = useState<ActivityApiResponse | null>(null)
+
+    useEffect(() => {
+        fetch('/api/github')
+            .then((r) => r.json() as Promise<ActivityApiResponse>)
+            .then(setData)
+            .catch(() => setData(null))
+    }, [])
+
+    const items = data?.activity ?? []
+
+    return (
+        <div className="lifelog-activity">
+            <h2 className="lifelog-activity__heading">
+                GitHub
+                {data?.stale ? (
+                    <span className="lifelog-books__stale">stale</span>
+                ) : null}
+            </h2>
+            {items.length > 0 ? (
+                <ul className="lifelog-activity__list">
+                    {items.map((a, i) => (
+                        <li key={`${a.ts}-${i}`} className="lifelog-activity__item">
+                            <span className={`lifelog-activity__badge lifelog-activity__badge--${a.type}`}>
+                                {ACTIVITY_BADGE_LABELS[a.type]}
+                            </span>
+                            <div className="lifelog-activity__body">
+                                <a
+                                    className="lifelog-activity__summary"
+                                    href={a.url}
+                                    target="_blank"
+                                    rel="noreferrer"
+                                >
+                                    {a.summary}
+                                </a>
+                                <span className="lifelog-activity__meta">
+                                    {a.repo} · {relTime(a.ts)}
+                                </span>
+                            </div>
+                        </li>
+                    ))}
+                </ul>
+            ) : (
+                <p className="lifelog-activity__empty">—</p>
+            )}
+        </div>
+    )
+}
+
 // ─── Page definition ──────────────────────────────────────────────────────────
 
 const pageDef: PageDef = {
@@ -267,6 +358,12 @@ const pageDef: PageDef = {
             kind: 'lifelog',
             parent: 'ceiling',
             anchor: filmsAnchor,
+        },
+        {
+            id: 'lifelog-activity',
+            kind: 'lifelog',
+            parent: 'ceiling',
+            anchor: activityAnchor,
         },
     ],
 }
@@ -295,6 +392,14 @@ const cardContent: Record<string, CardContent> = {
         minimizable: true,
         label: 'Films',
         children: <FilmsPanel />,
+    },
+    'lifelog-activity': {
+        text: 'GitHub',
+        width: ACTIVITY_W,
+        height: ACTIVITY_H,
+        minimizable: true,
+        label: 'GitHub',
+        children: <ActivityPanel />,
     },
 }
 


### PR DESCRIPTION
## Summary

- Added `GitHubAdapter` wrapping `GET /users/<user>/events/public` — normalises PushEvent, PullRequestEvent (open/closed/merged), IssuesEvent, ReleaseEvent, and WatchEvent into `Activity[]`; unrecognised event types silently dropped; non-OK responses throw so `CacheLayer` returns last-good with `stale: true`
- Added `/api/github` endpoint via `CacheLayer` (5 min TTL); `GITHUB_USER` read from env, no token needed for public events
- Added `ActivityPanel` to `/lifelog` — fetches on mount, shows up to 10 recent events with type badge, linked summary, repo, and relative time; stale hint reuses existing `.lifelog-books__stale` class

## Notes / deviations

None — implementation follows the Letterboxd/LastFm pattern exactly.

## Acceptance criteria

- [x] `GitHubAdapter` tests using a recorded fixture covering all five handled event types; unrecognized types are silently dropped; rate-limit responses surface as recoverable errors
- [x] `/api/github` returns parsed activity via `CacheLayer` (5m TTL)
- [x] `<ActivityPanel />` renders all five event types correctly (badge label, summary, repo, relative time)
- [x] Activity card on `/lifelog` shows recent events
- [x] GitHub username configured via `/etc/chaipalaka.env` (`GITHUB_USER=cpalaka`) — no token needed for public events
- [x] When upstream is failing or rate-limited, card shows last-good value with "stale" hint (CacheLayer stale-on-throw, same pattern as other panels)

## Test plan

```sh
# API tests (81 pass, 0 fail)
cd api && bun test

# Web typecheck + tests + build
cd web && npm run typecheck && npm run test && npm run build

# Smoke check with GITHUB_USER set
cd api && GITHUB_USER=cpalaka bun run src/server.ts &
curl localhost:3000/api/github | jq .
# → { activity: [...], stale: false }

# Without GITHUB_USER
curl localhost:3000/api/github | jq .
# → { activity: [], stale: false }

# Visit /lifelog in browser — GitHub card visible with events, type badges, relative times
```

Closes #12