### PR TITLE
fix: site-name links home; drop redundant /home nav button

### DIFF
--- a/web/src/canvas/FrameBar.css
+++ b/web/src/canvas/FrameBar.css
@@ -46,6 +46,17 @@
 .frame-bar__site-name {
     font-weight: var(--font-weight-bold);
     letter-spacing: 0.04em;
+    color: var(--color-fg);
+    text-decoration: none;
+}
+
+.frame-bar__site-name:hover {
+    text-decoration: underline;
+    text-underline-offset: 2px;
+}
+
+.frame-bar__site-name[data-active='true'] {
+    color: var(--color-accent);
 }
 
 .frame-bar__current-page {

--- a/web/src/canvas/FrameBar.test.tsx
+++ b/web/src/canvas/FrameBar.test.tsx
@@ -15,9 +15,32 @@ function renderInRouter(initialPath = '/') {
 }
 
 describe('FrameBar', () => {
-    test('renders site name "chaipalaka"', () => {
+    test('renders site name "chaipalaka" as a link to /', () => {
         renderInRouter()
-        expect(screen.getByText('chaipalaka')).toBeInTheDocument()
+        const link = screen.getByRole('link', { name: 'chaipalaka' })
+        expect(link).toBeInTheDocument()
+        expect(link).toHaveAttribute('href', '/')
+    })
+
+    test('site-name link is active when at /', () => {
+        renderInRouter('/')
+        expect(screen.getByRole('link', { name: 'chaipalaka' })).toHaveAttribute(
+            'data-active',
+            'true',
+        )
+    })
+
+    test('site-name link is NOT active when at /blog', () => {
+        renderInRouter('/blog')
+        expect(screen.getByRole('link', { name: 'chaipalaka' })).toHaveAttribute(
+            'data-active',
+            'false',
+        )
+    })
+
+    test('home nav link is not rendered (site name handles home navigation)', () => {
+        renderInRouter()
+        expect(screen.queryByRole('link', { name: 'home' })).not.toBeInTheDocument()
     })
 
     test('shows current pathname in the current-page indicator', () => {
@@ -34,24 +57,6 @@ describe('FrameBar', () => {
         renderInRouter('/blog')
         const link = screen.getByRole('link', { name: 'blog' })
         expect(link).toHaveAttribute('data-active', 'true')
-    })
-
-    test('home nav link is active when at /', () => {
-        renderInRouter('/')
-        const link = screen.getByRole('link', { name: 'home' })
-        expect(link).toHaveAttribute('data-active', 'true')
-    })
-
-    test('home nav link is NOT active when at /blog', () => {
-        renderInRouter('/blog')
-        const link = screen.getByRole('link', { name: 'home' })
-        expect(link).toHaveAttribute('data-active', 'false')
-    })
-
-    test('home nav link is NOT active when at /blog/foo (prefix not root)', () => {
-        renderInRouter('/blog/foo')
-        const link = screen.getByRole('link', { name: 'home' })
-        expect(link).toHaveAttribute('data-active', 'false')
     })
 
     test('settings menu is absent on initial render', () => {

--- a/web/src/canvas/FrameBar.tsx
+++ b/web/src/canvas/FrameBar.tsx
@@ -10,7 +10,6 @@ import manifest from './scenes/manifest.json'
 import './FrameBar.css'
 
 const SECTIONS = [
-    { path: '/', label: 'home' },
     { path: '/blog', label: 'blog' },
     { path: '/lifelog', label: 'lifelog' },
     { path: '/stuff', label: 'stuff' },
@@ -107,7 +106,13 @@ export function FrameBar() {
     return (
         <header role="banner" className="frame-bar">
             <div className="frame-bar__title">
-                <span className="frame-bar__site-name">chaipalaka</span>
+                <Link
+                    to="/"
+                    className="frame-bar__site-name"
+                    data-active={pathname === '/' ? 'true' : 'false'}
+                >
+                    chaipalaka
+                </Link>
                 {pathname !== '/' ? (
                     <span className="frame-bar__current-page">{pathname}</span>
                 ) : null}


### PR DESCRIPTION
## Summary
- The frame-bar had a non-interactive "chaipalaka" label on the left **and** a "home" entry in the section nav — redundant.
- Made "chaipalaka" itself a `<Link to="/">` with the same `data-active` styling the section buttons use.
- Dropped `{ path: '/', label: 'home' }` from `SECTIONS`. Nav is now `blog / lifelog / stuff`.
- CSS: site-name link inherits `--color-fg`, no underline by default, underlines on hover, accent color when active.

## Notes / deviations
- No PRD section to deviate from — this is a UX nit, not a planned slice.
- Updated tests instead of adding new ones: the three former "home link…" assertions become equivalent assertions on the site-name link; added a guard that no `home` link exists anywhere in the bar.

## Acceptance criteria
- [x] No "home" item in the section nav.
- [x] Clicking "chaipalaka" routes to `/`.
- [x] On `/`, "chaipalaka" picks up the active styling (`data-active="true"`, accent color).
- [x] Off `/`, "chaipalaka" is `data-active="false"` and inherits the normal text color.
- [x] `npm run typecheck`, `npm run test` (243 pass), `npm run build` (SSR prerender intact, `data-server-rendered="true"` present in `dist/index.html`).

## Test plan
- [ ] `npm run dev` in `web/`, visit `/`, confirm the chaipalaka mark is the only home-linking element in the bar and shows accent color.
- [ ] Navigate to `/blog`, `/lifelog`, `/stuff` — confirm the site-name de-activates and clicking it returns to `/`.
- [ ] Tab through the bar — confirm the site name is now keyboard-focusable (it was a `<span>` before).