### PR TITLE
Slice 21: TransitionDirector + cross-route physics transitions (#21)

### DIFF
--- a/web/src/canvas/BackgroundCanvas.tsx
+++ b/web/src/canvas/BackgroundCanvas.tsx
@@ -2,6 +2,7 @@ import { Canvas } from '@react-three/fiber'
 import { lazy, Suspense, useEffect, useRef, useState } from 'react'
 import { detectWebGL } from './detect-webgl'
 import { useGallery } from './useGallery'
+import { usePrefersReducedMotion } from '../lib/usePrefersReducedMotion'
 import type { BackgroundScene } from './types'
 import './BackgroundCanvas.css'
 
@@ -51,18 +52,6 @@ function getLazyScene(scene: BackgroundScene) {
         sceneLazyCache.set(scene.id, lazyComp)
     }
     return sceneLazyCache.get(scene.id)!
-}
-
-function usePrefersReducedMotion(): boolean {
-    const [reduced, setReduced] = useState(false)
-    useEffect(() => {
-        const mq = window.matchMedia('(prefers-reduced-motion: reduce)')
-        setReduced(mq.matches)
-        const handler = (e: MediaQueryListEvent) => setReduced(e.matches)
-        mq.addEventListener('change', handler)
-        return () => mq.removeEventListener('change', handler)
-    }, [])
-    return reduced
 }
 
 // useFadeSwap: tracks the outgoing scene during a cross-fade window (~250ms).

--- a/web/src/layouts/CanvasLayout.tsx
+++ b/web/src/layouts/CanvasLayout.tsx
@@ -6,6 +6,10 @@ import { PhysicsProvider } from '../physics/PhysicsContext'
 import { FrameBar } from '../canvas/FrameBar'
 import { StringLayer } from '../canvas/StringLayer'
 import { useFrameEdge } from '../canvas/useFrameEdge'
+import { TransitionDirector } from '../transitions/TransitionDirector'
+import { PhysicsLayer } from '../transitions/PhysicsLayer'
+import { pageDefs } from '../transitions/pageDefs'
+import { edges } from '../transitions/edges'
 import './CanvasLayout.css'
 
 export default function CanvasLayout() {
@@ -19,16 +23,19 @@ export default function CanvasLayout() {
 
     return (
         <PhysicsProvider>
-            <div
-                data-layout="canvas"
-                data-canvas-marker={CANVAS_ONLY_BUNDLE_MARKER}
-                data-frame-edge={edge}
-            >
-                <BackgroundCanvas />
-                <StringLayer />
-                <FrameBar />
-                <Outlet />
-            </div>
+            <TransitionDirector pageDefs={pageDefs} edges={edges}>
+                <div
+                    data-layout="canvas"
+                    data-canvas-marker={CANVAS_ONLY_BUNDLE_MARKER}
+                    data-frame-edge={edge}
+                >
+                    <BackgroundCanvas />
+                    <PhysicsLayer />
+                    <StringLayer />
+                    <FrameBar />
+                    <Outlet />
+                </div>
+            </TransitionDirector>
         </PhysicsProvider>
     )
 }

--- a/web/src/lib/usePrefersReducedMotion.ts
+++ b/web/src/lib/usePrefersReducedMotion.ts
@@ -1,0 +1,14 @@
+import { useEffect, useState } from 'react'
+
+export function usePrefersReducedMotion(): boolean {
+    const [reduced, setReduced] = useState(false)
+    useEffect(() => {
+        if (typeof window === 'undefined' || !window.matchMedia) return
+        const mq = window.matchMedia('(prefers-reduced-motion: reduce)')
+        setReduced(mq.matches)
+        const handler = (e: MediaQueryListEvent) => setReduced(e.matches)
+        mq.addEventListener('change', handler)
+        return () => mq.removeEventListener('change', handler)
+    }, [])
+    return reduced
+}

--- a/web/src/physics/PageDef.ts
+++ b/web/src/physics/PageDef.ts
@@ -5,6 +5,12 @@ export type Buoyancy = 'heavy' | 'balloon'
 export type ParentRef = 'ceiling' | 'floor' | string | null
 export type CardKind = 'lifelog' | 'blog' | 'portfolio' | 'note' | 'link' | 'headline'
 
+export type TransitionId =
+    | 'string-cut-drop'
+    | 'pour-in-drop'
+    | 'anchor-slide'
+    | 'cross-fade'
+
 export interface CardSpec {
     id: string
     kind: CardKind
@@ -15,6 +21,11 @@ export interface CardSpec {
 export interface PageDef {
     gravity: Cardinal
     cards: CardSpec[]
+    transitions?: {
+        exit?: TransitionId
+        enter?: TransitionId
+    }
+    siblingOrder?: 'left' | 'right'
 }
 
 export function buoyancyForKind(kind: CardKind): Buoyancy {

--- a/web/src/physics/PhysicsCard.test.tsx
+++ b/web/src/physics/PhysicsCard.test.tsx
@@ -2,6 +2,8 @@ import { describe, test, expect, afterEach } from 'vitest'
 import { render, cleanup } from '@testing-library/react'
 import { PhysicsProvider } from './PhysicsContext'
 import { PhysicsCard } from './PhysicsCard'
+import { CardRegistryProvider } from '../transitions/CardRegistry'
+import { PhysicsLayer } from '../transitions/PhysicsLayer'
 
 afterEach(() => {
     cleanup()
@@ -16,39 +18,45 @@ function fireRealPointerDown(el: Element) {
     el.dispatchEvent(ev)
 }
 
+function renderWith(children: React.ReactNode) {
+    return render(
+        <PhysicsProvider>
+            <CardRegistryProvider>
+                <PhysicsLayer />
+                {children}
+            </CardRegistryProvider>
+        </PhysicsProvider>,
+    )
+}
+
 describe('PhysicsCard — draggable prop', () => {
     test('default (draggable=true) sets cursor to grabbing on pointerdown', () => {
-        const { container } = render(
-            <PhysicsProvider>
-                <PhysicsCard
-                    id="default-drag"
-                    text="default"
-                    width={120}
-                    height={80}
-                    anchor={{ x: 100, y: 100 }}
-                />
-            </PhysicsProvider>,
+        const { container } = renderWith(
+            <PhysicsCard
+                id="default-drag"
+                text="default"
+                width={120}
+                height={80}
+                anchor={{ x: 100, y: 100 }}
+            />,
         )
         const article = container.querySelector('article.physics-card') as HTMLElement
         expect(article).toBeTruthy()
-        // happy-dom may not implement setPointerCapture; stub it
         article.setPointerCapture = () => {}
         fireRealPointerDown(article)
         expect(article.style.cursor).toBe('grabbing')
     })
 
     test('draggable={false} does NOT set cursor to grabbing on pointerdown', () => {
-        const { container } = render(
-            <PhysicsProvider>
-                <PhysicsCard
-                    id="no-drag"
-                    text="frozen"
-                    width={120}
-                    height={80}
-                    anchor={{ x: 100, y: 100 }}
-                    draggable={false}
-                />
-            </PhysicsProvider>,
+        const { container } = renderWith(
+            <PhysicsCard
+                id="no-drag"
+                text="frozen"
+                width={120}
+                height={80}
+                anchor={{ x: 100, y: 100 }}
+                draggable={false}
+            />,
         )
         const article = container.querySelector('article.physics-card') as HTMLElement
         expect(article).toBeTruthy()

--- a/web/src/physics/PhysicsCard.tsx
+++ b/web/src/physics/PhysicsCard.tsx
@@ -1,20 +1,14 @@
-import { useEffect, useRef } from 'react'
-import { usePhysicsWorld } from './PhysicsContext'
-import { useIsMinimized, useMinimizedRegistry } from '../canvas/useMinimizedRegistry'
-import { flipMorph } from '../canvas/flip'
-import type { PhysicsHandle, PhysicsWorld, TetherHandle, Vec2 } from './PhysicsWorld'
+import { useEffect, useId, useMemo } from 'react'
+import { useCardRegistry } from '../transitions/CardRegistry'
+import type {
+    PhysicsHandle,
+    PhysicsWorld,
+    TetherHandle,
+    Vec2,
+} from './PhysicsWorld'
 import type { Buoyancy, ParentRef } from './PageDef'
-import './PhysicsCard.css'
 
 type ParentKind = 'ceiling' | 'floor' | 'card'
-
-function resolveParent(world: PhysicsWorld, p: ParentRef): { handle: PhysicsHandle | null; kind: ParentKind } {
-    if (p === 'ceiling') return { handle: world.ceilingHandle, kind: 'ceiling' }
-    if (p === 'floor') return { handle: world.floorHandle, kind: 'floor' }
-    if (p == null) return { handle: null, kind: 'card' }
-    const h = world.getHandleById(p)
-    return { handle: h ?? null, kind: 'card' }
-}
 
 export function wireTetherFor(
     world: PhysicsWorld,
@@ -25,10 +19,12 @@ export function wireTetherFor(
 ): TetherHandle {
     const parentBodyPos = world.getPosition(parentHandle)
     if (parentKind === 'card') {
-        const length = Math.hypot(childAnchor.x - parentBodyPos.x, childAnchor.y - parentBodyPos.y)
+        const length = Math.hypot(
+            childAnchor.x - parentBodyPos.x,
+            childAnchor.y - parentBodyPos.y,
+        )
         return world.tether(parentHandle, childHandle, length)
     }
-    // ceiling | floor: rope hangs straight from the surface directly above/below the child anchor.
     const parentAnchor = world.getAnchor(parentHandle)
     const anchorA = {
         x: childAnchor.x - parentBodyPos.x,
@@ -48,8 +44,6 @@ export interface PhysicsCardProps {
     variant?: string
     className?: string
     style?: React.CSSProperties
-    physicsHandleRef?: React.MutableRefObject<PhysicsHandle | null>
-    cardRef?: React.MutableRefObject<HTMLElement | null>
     minimizable?: boolean
     id?: string
     label?: string
@@ -59,236 +53,62 @@ export interface PhysicsCardProps {
     draggable?: boolean
 }
 
-export function PhysicsCard({
-    text,
-    width,
-    height,
-    anchor,
-    children,
-    header,
-    variant,
-    className,
-    style,
-    physicsHandleRef,
-    cardRef,
-    minimizable = false,
-    id,
-    label,
-    kind = 'card',
-    parent,
-    buoyancy,
-    draggable = true,
-}: PhysicsCardProps) {
-    const world = usePhysicsWorld()
-    const elRef = useRef<HTMLElement | null>(null)
-    const handleRef = useRef<PhysicsHandle | null>(null)
-    const anchorRef = useRef(anchor)
-    anchorRef.current = anchor
-    const tetherHandleRef = useRef<TetherHandle | null>(null)
+export function PhysicsCard(props: PhysicsCardProps) {
+    const generatedId = useId()
+    const id = props.id ?? generatedId
+    const registry = useCardRegistry()
 
-    const registry = useMinimizedRegistry()
-    const isMinimized = useIsMinimized(minimizable ? id : undefined)
-
-    useEffect(() => {
-        if (isMinimized) return
-        const el = elRef.current
-        if (!el) return
-
-        const { x, y } = anchorRef.current
-        const w = width
-        const h = height
-
-        // Spawn 20px in gravity direction so the card visibly settles to anchor on load.
-        const SPAWN_OFFSET = 20
-        const g = world.getGravityVector()
-        const gLen = Math.hypot(g.x, g.y)
-        const gx = gLen > 0 ? g.x / gLen : 0
-        const gy = gLen > 0 ? g.y / gLen : 1
-        const sx = x + gx * SPAWN_OFFSET
-        const sy = y + gy * SPAWN_OFFSET
-
-        el.style.width = `${w}px`
-        el.style.height = `${h}px`
-        el.style.transform = `translate(${sx - w / 2}px, ${sy - h / 2}px)`
-
-        const handle = id
-            ? world.registerById(id, { x: sx, y: sy }, { width: w, height: h }, {
-                onTransform: ({ x: px, y: py, rotation }) => {
-                    el.style.transform = `translate(${px - w / 2}px, ${py - h / 2}px) rotate(${rotation}rad)`
-                },
-            })
-            : world.register(
-                { x: sx, y: sy },
-                { width: w, height: h },
-                {
-                    onTransform: ({ x: px, y: py, rotation }) => {
-                        el.style.transform = `translate(${px - w / 2}px, ${py - h / 2}px) rotate(${rotation}rad)`
-                    },
-                },
-            )
-        handleRef.current = handle
-        if (physicsHandleRef) physicsHandleRef.current = handle
-
-        if (buoyancy) world.setBuoyancy(handle, buoyancy)
-
-        // Wire tether if parent declared.
-        let rafId = 0
-        if (parent) {
-            const { handle: ph, kind } = resolveParent(world, parent)
-            if (ph != null) {
-                tetherHandleRef.current = wireTetherFor(world, ph, kind, handle, anchorRef.current)
-            } else {
-                rafId = requestAnimationFrame(() => {
-                    const retried = resolveParent(world, parent)
-                    if (retried.handle == null) {
-                        console.warn(`PhysicsCard: parent "${parent}" not found after one frame; tether skipped`)
-                        return
-                    }
-                    tetherHandleRef.current = wireTetherFor(world, retried.handle, retried.kind, handle, anchorRef.current)
-                })
-            }
-        }
-
-        let dragging = false
-        let lastX = 0
-        let lastY = 0
-        let lastT = 0
-        let velX = 0
-        let velY = 0
-        const FLING_VELOCITY_SCALE = 16
-        const FLING_PAUSE_MS = 50
-
-        const onPointerDown = (e: PointerEvent) => {
-            if ((e.target as Element | null)?.closest('[data-card-header], a, button')) return
-            e.preventDefault()
-            dragging = true
-            lastX = e.clientX
-            lastY = e.clientY
-            lastT = e.timeStamp
-            velX = 0
-            velY = 0
-            world.setDragging(handle, true)
-            el.setPointerCapture(e.pointerId)
-            el.style.cursor = 'grabbing'
-        }
-        const onPointerMove = (e: PointerEvent) => {
-            if (!dragging) return
-            const dx = e.clientX - lastX
-            const dy = e.clientY - lastY
-            const dt = Math.max(e.timeStamp - lastT, 1)
-            velX = dx / dt
-            velY = dy / dt
-            const cur = world.getPosition(handle)
-            world.setPosition(handle, { x: cur.x + dx, y: cur.y + dy })
-            lastX = e.clientX
-            lastY = e.clientY
-            lastT = e.timeStamp
-        }
-        const onPointerUp = (e: PointerEvent) => {
-            if (!dragging) return
-            dragging = false
-            world.setDragging(handle, false)
-            const sinceLastMove = e.timeStamp - lastT
-            if (sinceLastMove > FLING_PAUSE_MS) {
-                velX = 0
-                velY = 0
-            }
-            world.setVelocity(handle, {
-                x: velX * FLING_VELOCITY_SCALE,
-                y: velY * FLING_VELOCITY_SCALE,
-            })
-            el.releasePointerCapture(e.pointerId)
-            el.style.cursor = 'grab'
-        }
-
-        if (draggable) {
-            el.addEventListener('pointerdown', onPointerDown)
-            window.addEventListener('pointermove', onPointerMove)
-            window.addEventListener('pointerup', onPointerUp)
-        }
-
-        return () => {
-            cancelAnimationFrame(rafId)
-            if (tetherHandleRef.current !== null) {
-                world.untether(tetherHandleRef.current)
-                tetherHandleRef.current = null
-            }
-            world.unregister(handle)
-            handleRef.current = null
-            if (physicsHandleRef) physicsHandleRef.current = null
-            if (draggable) {
-                el.removeEventListener('pointerdown', onPointerDown)
-                window.removeEventListener('pointermove', onPointerMove)
-                window.removeEventListener('pointerup', onPointerUp)
-            }
-        }
-    }, [world, width, height, isMinimized, draggable])
-
-    useEffect(() => {
-        if (handleRef.current === null) return
-        world.setAnchor(handleRef.current, anchor)
-        // Body-local pointA depends on anchor.x for ceiling/floor parents — re-wire on resize.
-        if (tetherHandleRef.current !== null && parent) {
-            world.untether(tetherHandleRef.current)
-            tetherHandleRef.current = null
-            const { handle: ph, kind } = resolveParent(world, parent)
-            if (ph != null) {
-                tetherHandleRef.current = wireTetherFor(world, ph, kind, handleRef.current, anchor)
-            }
-        }
-    }, [world, anchor.x, anchor.y, parent])
-
-    useEffect(() => {
-        if (isMinimized || !id || !minimizable) return
-        const el = elRef.current
-        if (!el) return
-        const fromChipRect = registry.consumeRestoreRect(id)
-        if (!fromChipRect) return
-        const endTransform = el.style.transform
-        requestAnimationFrame(() => {
-            flipMorph(fromChipRect, el, { opacityFrom: 0.5, endTransform })
-        })
-    }, [isMinimized, id, minimizable, registry])
-
-    if (isMinimized) return null
-
-    function handleMinimize() {
-        const el = elRef.current
-        if (!el || !id) return
-        const fromRect = el.getBoundingClientRect()
-        registry.minimize(id, { label: label ?? text, kind, fromRect })
-    }
-
-    const showHeader = header != null || minimizable
-    const cls = ['physics-card', className].filter(Boolean).join(' ')
-
-    return (
-        <article
-            ref={(el) => {
-                elRef.current = el
-                if (cardRef) cardRef.current = el
-            }}
-            className={cls}
-            data-variant={variant}
-            style={style}
-        >
-            {showHeader ? (
-                <div data-card-header>
-                    {minimizable ? (
-                        <button
-                            type="button"
-                            title="Minimize"
-                            className="physics-card__minimize-btn"
-                            onPointerDown={(e) => e.stopPropagation()}
-                            onClick={handleMinimize}
-                        >
-                            −
-                        </button>
-                    ) : null}
-                    {header}
-                </div>
-            ) : null}
-            {children ?? text}
-        </article>
+    const entry = useMemo(
+        () => ({
+            id,
+            parent: props.parent ?? null,
+            kind: props.kind ?? 'card',
+            buoyancy: props.buoyancy ?? 'heavy',
+            anchor: props.anchor,
+            content: {
+                text: props.text,
+                width: props.width,
+                height: props.height,
+                children: props.children,
+                header: props.header,
+                minimizable: props.minimizable,
+                label: props.label,
+                draggable: props.draggable,
+                variant: props.variant,
+                className: props.className,
+                style: props.style,
+            },
+        }),
+        [
+            id,
+            props.parent,
+            props.kind,
+            props.buoyancy,
+            props.anchor.x,
+            props.anchor.y,
+            props.text,
+            props.width,
+            props.height,
+            props.children,
+            props.header,
+            props.minimizable,
+            props.label,
+            props.draggable,
+            props.variant,
+            props.className,
+            props.style,
+        ],
     )
+
+    useEffect(() => {
+        registry.register(entry)
+    }, [registry, entry])
+
+    useEffect(() => {
+        return () => {
+            registry.requestUnregister(id)
+        }
+    }, [registry, id])
+
+    return null
 }

--- a/web/src/physics/PhysicsContext.tsx
+++ b/web/src/physics/PhysicsContext.tsx
@@ -7,6 +7,7 @@ import {
 } from 'react'
 import { PhysicsWorld } from './PhysicsWorld'
 import { useFrameEdge, getFrameEdgeController } from '../canvas/useFrameEdge'
+import { CardRegistryProvider } from '../transitions/CardRegistry'
 import type { FrameEdge } from '../canvas/useFrameEdge'
 
 const FRAME_BAR_HEIGHT = 40
@@ -77,7 +78,7 @@ export function PhysicsProvider({ children }: PhysicsProviderProps) {
 
     return (
         <PhysicsContext.Provider value={world}>
-            {children}
+            <CardRegistryProvider>{children}</CardRegistryProvider>
         </PhysicsContext.Provider>
     )
 }

--- a/web/src/physics/PhysicsPage.test.tsx
+++ b/web/src/physics/PhysicsPage.test.tsx
@@ -2,6 +2,7 @@ import { describe, test, expect } from 'vitest'
 import { render, cleanup, screen } from '@testing-library/react'
 import { PhysicsProvider } from './PhysicsContext'
 import { PhysicsPage } from './PhysicsPage'
+import { PhysicsLayer } from '../transitions/PhysicsLayer'
 import type { PageDef } from './PageDef'
 
 const pageDef: PageDef = {
@@ -21,6 +22,7 @@ describe('PhysicsPage', () => {
     test('renders one DOM card per spec', () => {
         render(
             <PhysicsProvider>
+                <PhysicsLayer />
                 <PhysicsPage pageDef={pageDef} cardContent={cardContent} />
             </PhysicsProvider>,
         )

--- a/web/src/physics/PhysicsPage.tsx
+++ b/web/src/physics/PhysicsPage.tsx
@@ -10,9 +10,13 @@ export interface CardContent {
     width: number
     height: number
     children?: ReactNode
+    header?: ReactNode
     minimizable?: boolean
     label?: string
     draggable?: boolean
+    variant?: string
+    className?: string
+    style?: React.CSSProperties
 }
 
 function getViewport(): Viewport {

--- a/web/src/physics/PhysicsWorld.ts
+++ b/web/src/physics/PhysicsWorld.ts
@@ -317,6 +317,12 @@ export class PhysicsWorld {
         reg.buoyancy = b
     }
 
+    getBuoyancy(handle: PhysicsHandle): 'heavy' | 'balloon' {
+        const reg = this.registrations.get(handle)
+        if (!reg) throw new Error(`PhysicsWorld: unknown handle ${handle}`)
+        return reg.buoyancy
+    }
+
     setVelocity(handle: PhysicsHandle, velocity: Vec2): void {
         const reg = this.registrations.get(handle)
         if (!reg) throw new Error(`PhysicsWorld: unknown handle ${handle}`)
@@ -478,12 +484,14 @@ export class PhysicsWorld {
         parent: PhysicsHandle
         child: PhysicsHandle
         length: number
+        anchorA?: Vec2
     }> {
         const out: Array<{
             handle: TetherHandle
             parent: PhysicsHandle
             child: PhysicsHandle
             length: number
+            anchorA?: Vec2
         }> = []
         for (const [handle, rec] of this.tethers) {
             out.push({
@@ -491,6 +499,7 @@ export class PhysicsWorld {
                 parent: rec.parent,
                 child: rec.child,
                 length: rec.length,
+                ...(rec.anchorA ? { anchorA: { ...rec.anchorA } } : {}),
             })
         }
         return out

--- a/web/src/physics/PhysicsWorld.ts
+++ b/web/src/physics/PhysicsWorld.ts
@@ -254,6 +254,12 @@ export class PhysicsWorld {
         }
     }
 
+    getVelocity(handle: PhysicsHandle): Vec2 {
+        const reg = this.registrations.get(handle)
+        if (!reg) throw new Error(`PhysicsWorld: unknown handle ${handle}`)
+        return { x: reg.body.velocity.x, y: reg.body.velocity.y }
+    }
+
     applyImpulse(handle: PhysicsHandle, impulse: Vec2): void {
         const reg = this.registrations.get(handle)
         if (!reg) throw new Error(`PhysicsWorld: unknown handle ${handle}`)
@@ -465,6 +471,29 @@ export class PhysicsWorld {
     subscribeTetherSetChange(cb: () => void): () => void {
         this.tetherChangeListeners.add(cb)
         return () => this.tetherChangeListeners.delete(cb)
+    }
+
+    listTetherRecords(): Array<{
+        handle: TetherHandle
+        parent: PhysicsHandle
+        child: PhysicsHandle
+        length: number
+    }> {
+        const out: Array<{
+            handle: TetherHandle
+            parent: PhysicsHandle
+            child: PhysicsHandle
+            length: number
+        }> = []
+        for (const [handle, rec] of this.tethers) {
+            out.push({
+                handle,
+                parent: rec.parent,
+                child: rec.child,
+                length: rec.length,
+            })
+        }
+        return out
     }
 
     setSensor(handle: PhysicsHandle, isSensor: boolean): void {

--- a/web/src/routes/Home.tsx
+++ b/web/src/routes/Home.tsx
@@ -5,7 +5,7 @@ import type { CardContent } from '../physics/PhysicsPage'
 const CARD_W = 280
 const CARD_H = 160
 
-const pageDef: PageDef = {
+export const pageDef: PageDef = {
     gravity: 'down',
     cards: [
         {

--- a/web/src/routes/Lifelog.tsx
+++ b/web/src/routes/Lifelog.tsx
@@ -338,7 +338,7 @@ function ActivityPanel() {
 
 // ─── Page definition ──────────────────────────────────────────────────────────
 
-const pageDef: PageDef = {
+export const pageDef: PageDef = {
     gravity: 'down',
     cards: [
         {

--- a/web/src/routes/NotFound.tsx
+++ b/web/src/routes/NotFound.tsx
@@ -6,7 +6,7 @@ import type { CardContent } from '../physics/PhysicsPage'
 
 const recentPosts = getPosts().slice(0, 3)
 
-const pageDef: PageDef = {
+export const pageDef: PageDef = {
     gravity: 'up',
     cards: [
         {

--- a/web/src/routes/Stuff.tsx
+++ b/web/src/routes/Stuff.tsx
@@ -3,7 +3,7 @@ import { PhysicsPage } from '../physics/PhysicsPage'
 import type { PageDef } from '../physics/PageDef'
 import type { CardContent } from '../physics/PhysicsPage'
 
-const pageDef: PageDef = {
+export const pageDef: PageDef = {
     gravity: 'down',
     cards: [
         {

--- a/web/src/routes/sandbox/Cards.tsx
+++ b/web/src/routes/sandbox/Cards.tsx
@@ -15,11 +15,10 @@ export default function Cards() {
     )
     const [playgroundMinimized, setPlaygroundMinimized] = useState(false)
 
-    const playgroundCardRef = useRef<HTMLElement | null>(null)
     const playgroundChipRef = useRef<HTMLButtonElement | null>(null)
 
     function flipMinimize() {
-        const cardEl = playgroundCardRef.current
+        const cardEl = (document.querySelector('[data-card-id="playground-card"]') as HTMLElement | null)
         const fromRect = cardEl?.getBoundingClientRect() ?? null
         setPlaygroundMinimized(true)
         if (!fromRect) return
@@ -55,7 +54,7 @@ export default function Cards() {
         setPlaygroundMinimized(false)
         if (!fromRect) return
         requestAnimationFrame(() => {
-            const cardEl = playgroundCardRef.current
+            const cardEl = (document.querySelector('[data-card-id="playground-card"]') as HTMLElement | null)
             if (!cardEl) return
             const toRect = cardEl.getBoundingClientRect()
             const scaleX = fromRect.width / toRect.width
@@ -114,7 +113,6 @@ export default function Cards() {
                         <Playground
                             minimized={playgroundMinimized}
                             onMinimize={handleMinimize}
-                            cardRef={playgroundCardRef}
                         />
                     </div>
                 </div>

--- a/web/src/sandbox/cards/Playground.tsx
+++ b/web/src/sandbox/cards/Playground.tsx
@@ -1,13 +1,11 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { PhysicsCard } from '../../physics/PhysicsCard'
-import type { PhysicsHandle } from '../../physics/PhysicsWorld'
 import { HiddenScroll } from './HiddenScroll'
 import { CardHeader } from './CardHeader'
 
 interface PlaygroundProps {
     minimized: boolean
     onMinimize: () => void
-    cardRef?: import('react').MutableRefObject<HTMLElement | null>
 }
 
 const DEFAULT_W = 320
@@ -25,8 +23,7 @@ function computeAnchor(): { x: number; y: number } {
 const LOREM =
     'Type specimen — the quick brown fox jumps over the lazy dog. Sphinx of black quartz, judge my vow. Now is the time for bold decisions.'
 
-export function Playground({ minimized, onMinimize, cardRef }: PlaygroundProps) {
-    const handleRef = useRef<PhysicsHandle | null>(null)
+export function Playground({ minimized, onMinimize }: PlaygroundProps) {
     const [anchor, setAnchor] = useState<{ x: number; y: number }>(() =>
         typeof window !== 'undefined' ? computeAnchor() : { x: 400, y: 350 },
     )
@@ -42,13 +39,12 @@ export function Playground({ minimized, onMinimize, cardRef }: PlaygroundProps) 
 
     return (
         <PhysicsCard
+            id="playground-card"
             text={LOREM}
             anchor={anchor}
             width={cardSize.width}
             height={cardSize.height}
             variant="playground"
-            physicsHandleRef={handleRef}
-            cardRef={cardRef}
             header={<CardHeader onMinimize={onMinimize} />}
         >
             <div

--- a/web/src/transitions/CardRegistry.test.tsx
+++ b/web/src/transitions/CardRegistry.test.tsx
@@ -1,0 +1,126 @@
+import { describe, test, expect } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { CardRegistryProvider, useCardRegistry } from './CardRegistry'
+import type { RegisterArgs } from './CardRegistry'
+import type { ReactNode } from 'react'
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+    <CardRegistryProvider>{children}</CardRegistryProvider>
+)
+
+const entryA: RegisterArgs = {
+    id: 'a',
+    parent: 'ceiling',
+    kind: 'headline',
+    buoyancy: 'heavy',
+    anchor: { x: 100, y: 100 },
+    content: { text: 'hello', width: 200, height: 100 },
+}
+
+const entryB: RegisterArgs = {
+    id: 'b',
+    parent: 'floor',
+    kind: 'note',
+    buoyancy: 'balloon',
+    anchor: { x: 200, y: 400 },
+    content: { text: 'world', width: 200, height: 100 },
+}
+
+describe('CardRegistry', () => {
+    test('register adds an entry visible in snapshot', () => {
+        const { result } = renderHook(() => useCardRegistry(), { wrapper })
+
+        act(() => {
+            result.current.register(entryA)
+        })
+
+        const entries = result.current.snapshot()
+        expect(entries).toHaveLength(1)
+        expect(entries[0]).toMatchObject({ id: 'a', state: 'active' })
+    })
+
+    test('requestUnregister removes entry when not exiting', () => {
+        const { result } = renderHook(() => useCardRegistry(), { wrapper })
+
+        act(() => {
+            result.current.register(entryA)
+            result.current.requestUnregister('a')
+        })
+
+        expect(result.current.snapshot()).toHaveLength(0)
+    })
+
+    test('markExiting + requestUnregister defers removal until release', () => {
+        const { result } = renderHook(() => useCardRegistry(), { wrapper })
+
+        act(() => {
+            result.current.register(entryA)
+            result.current.markExiting('a')
+            result.current.requestUnregister('a')
+        })
+
+        const exiting = result.current.snapshot()
+        expect(exiting).toHaveLength(1)
+        expect(exiting[0]?.state).toBe('exiting')
+
+        act(() => {
+            result.current.release('a')
+        })
+
+        expect(result.current.snapshot()).toHaveLength(0)
+    })
+
+    test('register with existing id preserves lifecycle state (upsert)', () => {
+        const { result } = renderHook(() => useCardRegistry(), { wrapper })
+
+        act(() => {
+            result.current.register(entryA)
+            result.current.markExiting('a')
+        })
+        expect(result.current.snapshot()[0]?.state).toBe('exiting')
+
+        act(() => {
+            result.current.register({
+                ...entryA,
+                content: { ...entryA.content, text: 'updated' },
+            })
+        })
+
+        const updated = result.current.snapshot()
+        expect(updated).toHaveLength(1)
+        expect(updated[0]?.state).toBe('exiting')
+        expect(updated[0]?.content.text).toBe('updated')
+    })
+
+    test('multiple entries + selective release', () => {
+        const { result } = renderHook(() => useCardRegistry(), { wrapper })
+
+        act(() => {
+            result.current.register(entryA)
+            result.current.register(entryB)
+            result.current.markExiting('a')
+            result.current.markExiting('b')
+        })
+        expect(result.current.snapshot()).toHaveLength(2)
+
+        act(() => {
+            result.current.release('a')
+        })
+
+        const remaining = result.current.snapshot()
+        expect(remaining).toHaveLength(1)
+        expect(remaining[0]?.id).toBe('b')
+    })
+
+    test('snapshot returns stable reference when no changes occur', () => {
+        const { result } = renderHook(() => useCardRegistry(), { wrapper })
+
+        act(() => {
+            result.current.register(entryA)
+        })
+
+        const first = result.current.snapshot()
+        const second = result.current.snapshot()
+        expect(first).toBe(second)
+    })
+})

--- a/web/src/transitions/CardRegistry.tsx
+++ b/web/src/transitions/CardRegistry.tsx
@@ -1,0 +1,110 @@
+import {
+    createContext,
+    use,
+    useState,
+    useSyncExternalStore,
+    type ReactNode,
+} from 'react'
+import type { Buoyancy, ParentRef } from '../physics/PageDef'
+import type { CardContent } from '../physics/PhysicsPage'
+
+export type CardLifecycle = 'active' | 'exiting'
+
+export interface PhysicsCardEntry {
+    id: string
+    parent: ParentRef
+    kind: string
+    buoyancy: Buoyancy
+    anchor: { x: number; y: number }
+    content: CardContent
+    state: CardLifecycle
+}
+
+export type RegisterArgs = Omit<PhysicsCardEntry, 'state'>
+
+export interface CardRegistryAPI {
+    register(entry: RegisterArgs): void
+    requestUnregister(id: string): void
+    markExiting(id: string): void
+    release(id: string): void
+    snapshot(): readonly PhysicsCardEntry[]
+    subscribe(cb: () => void): () => void
+}
+
+class CardRegistryStore {
+    private entries = new Map<string, PhysicsCardEntry>()
+    private listeners = new Set<() => void>()
+    private cachedSnapshot: readonly PhysicsCardEntry[] | null = null
+
+    subscribe = (cb: () => void): (() => void) => {
+        this.listeners.add(cb)
+        return () => {
+            this.listeners.delete(cb)
+        }
+    }
+
+    snapshot = (): readonly PhysicsCardEntry[] => {
+        if (!this.cachedSnapshot) {
+            this.cachedSnapshot = Object.freeze([...this.entries.values()])
+        }
+        return this.cachedSnapshot
+    }
+
+    register = (args: RegisterArgs): void => {
+        const existing = this.entries.get(args.id)
+        const state: CardLifecycle = existing?.state ?? 'active'
+        this.entries.set(args.id, { ...args, state })
+        this.invalidate()
+    }
+
+    requestUnregister = (id: string): void => {
+        const e = this.entries.get(id)
+        if (!e) return
+        if (e.state === 'exiting') return
+        this.entries.delete(id)
+        this.invalidate()
+    }
+
+    markExiting = (id: string): void => {
+        const e = this.entries.get(id)
+        if (!e || e.state === 'exiting') return
+        this.entries.set(id, { ...e, state: 'exiting' })
+        this.invalidate()
+    }
+
+    release = (id: string): void => {
+        if (!this.entries.has(id)) return
+        this.entries.delete(id)
+        this.invalidate()
+    }
+
+    private invalidate(): void {
+        this.cachedSnapshot = null
+        this.listeners.forEach((cb) => cb())
+    }
+}
+
+const CardRegistryContext = createContext<CardRegistryAPI | null>(null)
+
+export function CardRegistryProvider({ children }: { children: ReactNode }) {
+    const [store] = useState(() => new CardRegistryStore())
+    return (
+        <CardRegistryContext.Provider value={store}>
+            {children}
+        </CardRegistryContext.Provider>
+    )
+}
+
+export function useCardRegistry(): CardRegistryAPI {
+    const api = use(CardRegistryContext)
+    if (!api)
+        throw new Error(
+            'useCardRegistry: must be used inside <CardRegistryProvider>',
+        )
+    return api
+}
+
+export function useCardRegistryEntries(): readonly PhysicsCardEntry[] {
+    const api = useCardRegistry()
+    return useSyncExternalStore(api.subscribe, api.snapshot, api.snapshot)
+}

--- a/web/src/transitions/PhysicsCardImpl.tsx
+++ b/web/src/transitions/PhysicsCardImpl.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { usePhysicsWorld } from '../physics/PhysicsContext'
 import {
     useIsMinimized,
@@ -48,6 +48,22 @@ export function PhysicsCardImpl({ entry }: PhysicsCardImplProps) {
 
     const registry = useMinimizedRegistry()
     const isMinimized = useIsMinimized(minimizable ? id : undefined)
+
+    // Hide the article for the first frame after mount. If this card is the
+    // incoming side of a pour-in transition, the pour-in primitive's RAF
+    // (scheduled in TransitionDirector's useEffect *before* this impl mounts
+    // in the deferred PhysicsLayer re-render) fires first and teleports the
+    // body above the viewport. By the time we flip `revealed` true on the
+    // next frame, the body is already in its pre-spawn position and the
+    // user never sees a paint at the layout anchor. For non-transition
+    // mounts (initial page load, post-resize) the cost is one frame of
+    // invisibility — imperceptible.
+    const [revealed, setRevealed] = useState(false)
+    useEffect(() => {
+        if (revealed) return
+        const raf = requestAnimationFrame(() => setRevealed(true))
+        return () => cancelAnimationFrame(raf)
+    }, [revealed])
 
     useEffect(() => {
         if (isMinimized) return
@@ -219,6 +235,9 @@ export function PhysicsCardImpl({ entry }: PhysicsCardImplProps) {
         if (!el) return
         const fromChipRect = registry.consumeRestoreRect(id)
         if (!fromChipRect) return
+        // Restore-from-chip needs the article visible so flipMorph animates
+        // an actual painted element. Bypass the first-frame reveal gate.
+        setRevealed(true)
         const endTransform = el.style.transform
         requestAnimationFrame(() => {
             flipMorph(fromChipRect, el, { opacityFrom: 0.5, endTransform })
@@ -245,7 +264,7 @@ export function PhysicsCardImpl({ entry }: PhysicsCardImplProps) {
             className={cls}
             data-variant={variant}
             data-card-id={id}
-            style={style}
+            style={revealed ? style : { ...style, visibility: 'hidden' }}
         >
             {showHeader ? (
                 <div data-card-header>

--- a/web/src/transitions/PhysicsCardImpl.tsx
+++ b/web/src/transitions/PhysicsCardImpl.tsx
@@ -1,0 +1,285 @@
+import { useEffect, useRef } from 'react'
+import { usePhysicsWorld } from '../physics/PhysicsContext'
+import {
+    useIsMinimized,
+    useMinimizedRegistry,
+} from '../canvas/useMinimizedRegistry'
+import { flipMorph } from '../canvas/flip'
+import { wireTetherFor } from '../physics/PhysicsCard'
+import type {
+    PhysicsHandle,
+    TetherHandle,
+} from '../physics/PhysicsWorld'
+import type { PhysicsCardEntry } from './CardRegistry'
+import '../physics/PhysicsCard.css'
+
+interface PhysicsCardImplProps {
+    entry: PhysicsCardEntry
+}
+
+export function PhysicsCardImpl({ entry }: PhysicsCardImplProps) {
+    const {
+        id,
+        parent,
+        kind,
+        buoyancy,
+        anchor,
+        content: {
+            text,
+            width,
+            height,
+            children,
+            header,
+            minimizable = false,
+            label,
+            draggable = true,
+            variant,
+            className,
+            style,
+        },
+    } = entry
+
+    const world = usePhysicsWorld()
+    const elRef = useRef<HTMLElement | null>(null)
+    const handleRef = useRef<PhysicsHandle | null>(null)
+    const anchorRef = useRef(anchor)
+    anchorRef.current = anchor
+    const tetherHandleRef = useRef<TetherHandle | null>(null)
+
+    const registry = useMinimizedRegistry()
+    const isMinimized = useIsMinimized(minimizable ? id : undefined)
+
+    useEffect(() => {
+        if (isMinimized) return
+        const el = elRef.current
+        if (!el) return
+
+        const { x, y } = anchorRef.current
+        const w = width
+        const h = height
+
+        const SPAWN_OFFSET = 20
+        const g = world.getGravityVector()
+        const gLen = Math.hypot(g.x, g.y)
+        const gx = gLen > 0 ? g.x / gLen : 0
+        const gy = gLen > 0 ? g.y / gLen : 1
+        const sx = x + gx * SPAWN_OFFSET
+        const sy = y + gy * SPAWN_OFFSET
+
+        el.style.width = `${w}px`
+        el.style.height = `${h}px`
+        el.style.transform = `translate(${sx - w / 2}px, ${sy - h / 2}px)`
+
+        const handle = world.registerById(
+            id,
+            { x: sx, y: sy },
+            { width: w, height: h },
+            {
+                onTransform: ({ x: px, y: py, rotation }) => {
+                    el.style.transform = `translate(${px - w / 2}px, ${py - h / 2}px) rotate(${rotation}rad)`
+                },
+            },
+        )
+        handleRef.current = handle
+
+        if (buoyancy) world.setBuoyancy(handle, buoyancy)
+
+        let rafId = 0
+        if (parent) {
+            const resolved = resolveParent(world, parent)
+            if (resolved.handle != null) {
+                tetherHandleRef.current = wireTetherFor(
+                    world,
+                    resolved.handle,
+                    resolved.kind,
+                    handle,
+                    anchorRef.current,
+                )
+            } else {
+                rafId = requestAnimationFrame(() => {
+                    const retried = resolveParent(world, parent)
+                    if (retried.handle == null) {
+                        console.warn(
+                            `PhysicsCard: parent "${parent}" not found after one frame; tether skipped`,
+                        )
+                        return
+                    }
+                    tetherHandleRef.current = wireTetherFor(
+                        world,
+                        retried.handle,
+                        retried.kind,
+                        handle,
+                        anchorRef.current,
+                    )
+                })
+            }
+        }
+
+        let dragging = false
+        let lastX = 0
+        let lastY = 0
+        let lastT = 0
+        let velX = 0
+        let velY = 0
+        const FLING_VELOCITY_SCALE = 16
+        const FLING_PAUSE_MS = 50
+
+        const onPointerDown = (e: PointerEvent) => {
+            if (
+                (e.target as Element | null)?.closest(
+                    '[data-card-header], a, button',
+                )
+            )
+                return
+            e.preventDefault()
+            dragging = true
+            lastX = e.clientX
+            lastY = e.clientY
+            lastT = e.timeStamp
+            velX = 0
+            velY = 0
+            world.setDragging(handle, true)
+            el.setPointerCapture(e.pointerId)
+            el.style.cursor = 'grabbing'
+        }
+        const onPointerMove = (e: PointerEvent) => {
+            if (!dragging) return
+            const dx = e.clientX - lastX
+            const dy = e.clientY - lastY
+            const dt = Math.max(e.timeStamp - lastT, 1)
+            velX = dx / dt
+            velY = dy / dt
+            const cur = world.getPosition(handle)
+            world.setPosition(handle, { x: cur.x + dx, y: cur.y + dy })
+            lastX = e.clientX
+            lastY = e.clientY
+            lastT = e.timeStamp
+        }
+        const onPointerUp = (e: PointerEvent) => {
+            if (!dragging) return
+            dragging = false
+            world.setDragging(handle, false)
+            const sinceLastMove = e.timeStamp - lastT
+            if (sinceLastMove > FLING_PAUSE_MS) {
+                velX = 0
+                velY = 0
+            }
+            world.setVelocity(handle, {
+                x: velX * FLING_VELOCITY_SCALE,
+                y: velY * FLING_VELOCITY_SCALE,
+            })
+            el.releasePointerCapture(e.pointerId)
+            el.style.cursor = 'grab'
+        }
+
+        if (draggable) {
+            el.addEventListener('pointerdown', onPointerDown)
+            window.addEventListener('pointermove', onPointerMove)
+            window.addEventListener('pointerup', onPointerUp)
+        }
+
+        return () => {
+            cancelAnimationFrame(rafId)
+            if (tetherHandleRef.current !== null) {
+                world.untether(tetherHandleRef.current)
+                tetherHandleRef.current = null
+            }
+            world.unregister(handle)
+            handleRef.current = null
+            if (draggable) {
+                el.removeEventListener('pointerdown', onPointerDown)
+                window.removeEventListener('pointermove', onPointerMove)
+                window.removeEventListener('pointerup', onPointerUp)
+            }
+        }
+    }, [world, id, width, height, isMinimized, draggable, parent, buoyancy])
+
+    useEffect(() => {
+        if (handleRef.current === null) return
+        world.setAnchor(handleRef.current, anchor)
+        if (tetherHandleRef.current !== null && parent) {
+            world.untether(tetherHandleRef.current)
+            tetherHandleRef.current = null
+            const resolved = resolveParent(world, parent)
+            if (resolved.handle != null) {
+                tetherHandleRef.current = wireTetherFor(
+                    world,
+                    resolved.handle,
+                    resolved.kind,
+                    handleRef.current,
+                    anchor,
+                )
+            }
+        }
+    }, [world, anchor.x, anchor.y, parent])
+
+    useEffect(() => {
+        if (isMinimized || !minimizable) return
+        const el = elRef.current
+        if (!el) return
+        const fromChipRect = registry.consumeRestoreRect(id)
+        if (!fromChipRect) return
+        const endTransform = el.style.transform
+        requestAnimationFrame(() => {
+            flipMorph(fromChipRect, el, { opacityFrom: 0.5, endTransform })
+        })
+    }, [isMinimized, id, minimizable, registry])
+
+    if (isMinimized) return null
+
+    function handleMinimize() {
+        const el = elRef.current
+        if (!el) return
+        const fromRect = el.getBoundingClientRect()
+        registry.minimize(id, { label: label ?? text, kind, fromRect })
+    }
+
+    const showHeader = header != null || minimizable
+    const cls = ['physics-card', className].filter(Boolean).join(' ')
+
+    return (
+        <article
+            ref={(el) => {
+                elRef.current = el
+            }}
+            className={cls}
+            data-variant={variant}
+            data-card-id={id}
+            style={style}
+        >
+            {showHeader ? (
+                <div data-card-header>
+                    {minimizable ? (
+                        <button
+                            type="button"
+                            title="Minimize"
+                            className="physics-card__minimize-btn"
+                            onPointerDown={(e) => e.stopPropagation()}
+                            onClick={handleMinimize}
+                        >
+                            −
+                        </button>
+                    ) : null}
+                    {header}
+                </div>
+            ) : null}
+            {children ?? text}
+        </article>
+    )
+}
+
+import type { ParentRef } from '../physics/PageDef'
+import type { PhysicsWorld } from '../physics/PhysicsWorld'
+
+type ParentKind = 'ceiling' | 'floor' | 'card'
+
+function resolveParent(
+    world: PhysicsWorld,
+    p: ParentRef,
+): { handle: PhysicsHandle | null; kind: ParentKind } {
+    if (p === 'ceiling') return { handle: world.ceilingHandle, kind: 'ceiling' }
+    if (p === 'floor') return { handle: world.floorHandle, kind: 'floor' }
+    if (p == null) return { handle: null, kind: 'card' }
+    const h = world.getHandleById(p)
+    return { handle: h ?? null, kind: 'card' }
+}

--- a/web/src/transitions/PhysicsLayer.tsx
+++ b/web/src/transitions/PhysicsLayer.tsx
@@ -1,0 +1,15 @@
+import { useRef } from 'react'
+import { useCardRegistryEntries } from './CardRegistry'
+import { PhysicsCardImpl } from './PhysicsCardImpl'
+
+export function PhysicsLayer() {
+    const entries = useCardRegistryEntries()
+    const containerRef = useRef<HTMLDivElement | null>(null)
+    return (
+        <div ref={containerRef} data-physics-layer="">
+            {entries.map((entry) => (
+                <PhysicsCardImpl key={entry.id} entry={entry} />
+            ))}
+        </div>
+    )
+}

--- a/web/src/transitions/TransitionDirector.test.tsx
+++ b/web/src/transitions/TransitionDirector.test.tsx
@@ -1,0 +1,139 @@
+import { describe, test, expect, afterEach } from 'vitest'
+import { render, cleanup, act } from '@testing-library/react'
+import { useState } from 'react'
+import { MemoryRouter, Routes, Route, useNavigate } from 'react-router-dom'
+import { PhysicsProvider } from '../physics/PhysicsContext'
+import { TransitionDirector } from './TransitionDirector'
+import { PhysicsLayer } from './PhysicsLayer'
+import { PhysicsCard } from '../physics/PhysicsCard'
+import type { PageDef } from '../physics/PageDef'
+
+afterEach(() => {
+    cleanup()
+})
+
+const pageDefA: PageDef = {
+    gravity: 'down',
+    cards: [
+        {
+            id: 'card-a',
+            kind: 'headline',
+            parent: 'ceiling',
+            anchor: () => ({ x: 100, y: 100 }),
+        },
+    ],
+}
+
+const pageDefB: PageDef = {
+    gravity: 'down',
+    cards: [
+        {
+            id: 'card-b',
+            kind: 'headline',
+            parent: 'ceiling',
+            anchor: () => ({ x: 200, y: 200 }),
+        },
+    ],
+}
+
+const pageDefs: Record<string, PageDef> = {
+    '/a': pageDefA,
+    '/b': pageDefB,
+}
+
+function RouteA() {
+    return (
+        <PhysicsCard
+            id="card-a"
+            text="A content"
+            width={200}
+            height={100}
+            anchor={{ x: 100, y: 100 }}
+            parent="ceiling"
+        />
+    )
+}
+
+function RouteB() {
+    return (
+        <PhysicsCard
+            id="card-b"
+            text="B content"
+            width={200}
+            height={100}
+            anchor={{ x: 200, y: 200 }}
+            parent="ceiling"
+        />
+    )
+}
+
+function NavigateButton({ to, label }: { to: string; label: string }) {
+    const nav = useNavigate()
+    return (
+        <button type="button" onClick={() => nav(to)} data-testid={label}>
+            {label}
+        </button>
+    )
+}
+
+function Harness() {
+    return (
+        <MemoryRouter initialEntries={['/a']}>
+            <PhysicsProvider>
+                <TransitionDirector pageDefs={pageDefs}>
+                    <PhysicsLayer />
+                    <NavigateButton to="/a" label="go-a" />
+                    <NavigateButton to="/b" label="go-b" />
+                    <Routes>
+                        <Route path="/a" element={<RouteA />} />
+                        <Route path="/b" element={<RouteB />} />
+                    </Routes>
+                </TransitionDirector>
+            </PhysicsProvider>
+        </MemoryRouter>
+    )
+}
+
+describe('TransitionDirector — orphan card survival', () => {
+    test('card from old route remains in DOM immediately after navigation', () => {
+        const { container, getByTestId } = render(<Harness />)
+
+        // Route A is mounted; its card should be in DOM.
+        expect(container.querySelector('[data-card-id="card-a"]')).toBeTruthy()
+
+        // Navigate to /b. The PhysicsCard registrar for /a unmounts, but the director
+        // should have marked card-a as exiting in its layout effect, so the registry
+        // (and therefore PhysicsLayer) keeps rendering it.
+        act(() => {
+            getByTestId('go-b').click()
+        })
+
+        // After navigation, card-a's article should still be in the DOM — its
+        // exit motion is in flight, RAF hasn't fired yet to release the entry.
+        expect(container.querySelector('[data-card-id="card-a"]')).toBeTruthy()
+        // The new route's card is also present.
+        expect(container.querySelector('[data-card-id="card-b"]')).toBeTruthy()
+    })
+})
+
+describe('TransitionDirector — provider mount', () => {
+    test('mounts and unmounts without throwing', () => {
+        function Inner() {
+            const [path] = useState('/a')
+            return (
+                <MemoryRouter initialEntries={[path]} key={path}>
+                    <PhysicsProvider>
+                        <TransitionDirector pageDefs={pageDefs}>
+                            <PhysicsLayer />
+                            <Routes>
+                                <Route path="/a" element={<RouteA />} />
+                                <Route path="/b" element={<RouteB />} />
+                            </Routes>
+                        </TransitionDirector>
+                    </PhysicsProvider>
+                </MemoryRouter>
+            )
+        }
+        expect(() => render(<Inner />)).not.toThrow()
+    })
+})

--- a/web/src/transitions/TransitionDirector.tsx
+++ b/web/src/transitions/TransitionDirector.tsx
@@ -1,0 +1,258 @@
+import {
+    createContext,
+    use,
+    useCallback,
+    useEffect,
+    useLayoutEffect,
+    useRef,
+    type ReactNode,
+} from 'react'
+import { useLocation, useNavigationType, type Location } from 'react-router-dom'
+import { usePhysicsWorld } from '../physics/PhysicsContext'
+import { useCardRegistry } from './CardRegistry'
+import { classifyDirection, type NavigationType } from './classifyDirection'
+import { dispatch, type EdgeTransitions, type TransitionPlan } from './dispatch'
+import { usePrefersReducedMotion } from '../lib/usePrefersReducedMotion'
+import { stringCutDrop } from './primitives/stringCutDrop'
+import { pourInDrop, type PourInDropEntry } from './primitives/pourInDrop'
+import { anchorSlide } from './primitives/anchorSlide'
+import { crossFade } from './primitives/crossFade'
+import type { PrimitiveStep } from './primitives/types'
+import type { PageDef, TransitionId } from '../physics/PageDef'
+import type { Viewport } from '../physics/PhysicsWorld'
+
+const REDUCED_MOTION_MS = 150
+
+export interface RunTransitionArgs {
+    from: string
+    to: string
+}
+
+export interface TransitionContextValue {
+    runTransition: (args: RunTransitionArgs) => void
+}
+
+const TransitionContext = createContext<TransitionContextValue | null>(null)
+
+export function useTransitionContext(): TransitionContextValue {
+    const ctx = use(TransitionContext)
+    if (!ctx)
+        throw new Error(
+            'useTransitionContext: must be used inside <TransitionDirector>',
+        )
+    return ctx
+}
+
+export interface TransitionDirectorProps {
+    pageDefs: Record<string, PageDef>
+    edges?: EdgeTransitions
+    children?: ReactNode
+}
+
+function getViewport(): Viewport {
+    return typeof window !== 'undefined'
+        ? { width: window.innerWidth, height: window.innerHeight }
+        : { width: 1024, height: 768 }
+}
+
+function runStep(step: PrimitiveStep): Promise<void> {
+    return new Promise((resolve) => {
+        let last = performance.now()
+        const tick = () => {
+            const now = performance.now()
+            const dt = now - last
+            last = now
+            if (step(dt)) resolve()
+            else requestAnimationFrame(tick)
+        }
+        requestAnimationFrame(tick)
+    })
+}
+
+function findPhysicsLayerElement(): HTMLElement | null {
+    if (typeof document === 'undefined') return null
+    return document.querySelector('[data-physics-layer]') as HTMLElement | null
+}
+
+export function TransitionDirector({
+    pageDefs,
+    edges = {},
+    children,
+}: TransitionDirectorProps) {
+    const location = useLocation()
+    const navType = useNavigationType() as NavigationType
+    const reduced = usePrefersReducedMotion()
+    const registry = useCardRegistry()
+    const world = usePhysicsWorld()
+
+    const prevLocationRef = useRef<Location | null>(null)
+    const reducedRef = useRef(reduced)
+    reducedRef.current = reduced
+
+    const executeTransition = useCallback(
+        async (fromPath: string, toPath: string, plan: TransitionPlan) => {
+            const fromCards = pageDefs[fromPath]?.cards ?? []
+            const toCards = pageDefs[toPath]?.cards ?? []
+            const fromIds = fromCards.map((c) => c.id)
+            const toIds = toCards.map((c) => c.id)
+            const viewport = getViewport()
+
+            const releaseFromIds = () => {
+                for (const id of fromIds) registry.release(id)
+            }
+
+            if (reducedRef.current) {
+                releaseFromIds()
+                const layerEl = findPhysicsLayerElement()
+                if (layerEl) {
+                    await runStep(crossFade(layerEl, { durationMs: REDUCED_MOTION_MS }))
+                }
+                return
+            }
+
+            if (plan.kind === 'coupled') {
+                const step = anchorSlide(
+                    world,
+                    { fromIds, toIds },
+                    { ...plan.config, viewport },
+                )
+                await runStep(step)
+                releaseFromIds()
+                return
+            }
+
+            // decoupled
+            const exitStep = buildPrimitive(
+                plan.exit,
+                world,
+                viewport,
+                fromIds,
+                toCards
+                    .map((c, i) => makePourEntry(c, i, registry))
+                    .filter((x): x is PourInDropEntry => x !== null),
+            )
+            const enterStep = buildPrimitive(
+                plan.enter,
+                world,
+                viewport,
+                fromIds,
+                toCards
+                    .map((c, i) => makePourEntry(c, i, registry))
+                    .filter((x): x is PourInDropEntry => x !== null),
+            )
+
+            await Promise.all([runStep(exitStep), runStep(enterStep)])
+            releaseFromIds()
+        },
+        [pageDefs, registry, world],
+    )
+
+    const dispatchTransition = useCallback(
+        (fromPath: string, toPath: string, direction: ReturnType<typeof classifyDirection>) => {
+            const plan = dispatch(fromPath, toPath, pageDefs, edges, direction)
+            return executeTransition(fromPath, toPath, plan).catch((err) => {
+                if (import.meta.env.DEV) throw err
+                console.warn(
+                    'TransitionDirector: transition failed; falling back to instant swap.',
+                    err,
+                )
+                for (const entry of registry.snapshot()) {
+                    if (entry.state === 'exiting') registry.release(entry.id)
+                }
+            })
+        },
+        [pageDefs, edges, executeTransition, registry],
+    )
+
+    // Phase 1: BEFORE old route's cleanups, mark its cards as exiting so the
+    // registry preserves them across the unmount.
+    useLayoutEffect(() => {
+        const prev = prevLocationRef.current
+        if (!prev || prev.pathname === location.pathname) return
+        const oldPageDef = pageDefs[prev.pathname]
+        if (!oldPageDef) return
+        for (const card of oldPageDef.cards) {
+            registry.markExiting(card.id)
+        }
+    }, [location, registry, pageDefs])
+
+    // Phase 2: AFTER children's effects (new cards now registered in PhysicsWorld),
+    // dispatch and execute the transition primitives.
+    useEffect(() => {
+        const prev = prevLocationRef.current
+        if (!prev) {
+            prevLocationRef.current = location
+            return
+        }
+        if (prev.pathname === location.pathname) {
+            prevLocationRef.current = location
+            return
+        }
+        const direction = classifyDirection(navType)
+        dispatchTransition(prev.pathname, location.pathname, direction)
+        prevLocationRef.current = location
+    }, [location, navType, dispatchTransition])
+
+    const runTransition = useCallback(
+        ({ from, to }: RunTransitionArgs) => {
+            const direction = classifyDirection(navType)
+            dispatchTransition(from, to, direction)
+        },
+        [navType, dispatchTransition],
+    )
+
+    return (
+        <TransitionContext.Provider value={{ runTransition }}>
+            {children}
+        </TransitionContext.Provider>
+    )
+}
+
+function buildPrimitive(
+    id: TransitionId,
+    world: ReturnType<typeof usePhysicsWorld>,
+    viewport: Viewport,
+    fromIds: readonly string[],
+    toEntries: readonly PourInDropEntry[],
+): PrimitiveStep {
+    switch (id) {
+        case 'string-cut-drop':
+            return stringCutDrop(world, fromIds, { viewport })
+        case 'pour-in-drop':
+            return pourInDrop(world, toEntries, { viewport })
+        case 'anchor-slide':
+            return anchorSlide(
+                world,
+                {
+                    fromIds,
+                    toIds: toEntries.map((e) => e.id),
+                },
+                {
+                    axis: 'horizontal',
+                    sign: 1,
+                    durationMs: 700,
+                    viewport,
+                },
+            )
+        case 'cross-fade': {
+            const el = findPhysicsLayerElement()
+            if (!el) return () => true
+            return crossFade(el, { durationMs: REDUCED_MOTION_MS })
+        }
+    }
+}
+
+function makePourEntry(
+    card: { id: string },
+    index: number,
+    registry: ReturnType<typeof useCardRegistry>,
+): PourInDropEntry | null {
+    const entry = registry.snapshot().find((e) => e.id === card.id)
+    if (!entry) return null
+    return {
+        id: card.id,
+        layoutAnchor: entry.anchor,
+        height: entry.content.height,
+        staggerMs: index * 80,
+    }
+}

--- a/web/src/transitions/TransitionDirector.tsx
+++ b/web/src/transitions/TransitionDirector.tsx
@@ -9,7 +9,7 @@ import {
 } from 'react'
 import { useLocation, useNavigationType, type Location } from 'react-router-dom'
 import { usePhysicsWorld } from '../physics/PhysicsContext'
-import { useCardRegistry } from './CardRegistry'
+import { useCardRegistry, type PhysicsCardEntry } from './CardRegistry'
 import { classifyDirection, type NavigationType } from './classifyDirection'
 import { dispatch, type EdgeTransitions, type TransitionPlan } from './dispatch'
 import { usePrefersReducedMotion } from '../lib/usePrefersReducedMotion'
@@ -22,6 +22,10 @@ import type { PageDef, TransitionId } from '../physics/PageDef'
 import type { Viewport } from '../physics/PhysicsWorld'
 
 const REDUCED_MOTION_MS = 150
+// Wait this long after the exit primitive starts before any incoming card
+// begins its drop-in. Gives the outgoing cards visible time to clear the
+// viewport before the new ones arrive.
+const POUR_IN_BASE_DELAY_MS = 1000
 
 export interface RunTransitionArgs {
     from: string
@@ -90,11 +94,18 @@ export function TransitionDirector({
     reducedRef.current = reduced
 
     const executeTransition = useCallback(
-        async (fromPath: string, toPath: string, plan: TransitionPlan) => {
-            const fromCards = pageDefs[fromPath]?.cards ?? []
-            const toCards = pageDefs[toPath]?.cards ?? []
-            const fromIds = fromCards.map((c) => c.id)
-            const toIds = toCards.map((c) => c.id)
+        async (_fromPath: string, _toPath: string, plan: TransitionPlan) => {
+            // Source of truth is the registry: cards marked `exiting` belong
+            // to the outgoing route; cards still `active` are the incoming
+            // ones registered by the newly-mounted route's <PhysicsCard>s.
+            // This lets routes that aren't listed in `pageDefs` (e.g. /blog,
+            // dynamic slug pages) participate in the standard transition.
+            const snapshot = registry.snapshot()
+            const exitingEntries = snapshot.filter((e) => e.state === 'exiting')
+            const activeEntries = snapshot.filter((e) => e.state === 'active')
+            const fromIds = exitingEntries.map((e) => e.id)
+            const toIds = activeEntries.map((e) => e.id)
+            const pourEntries = activeEntries.map((e, i) => makePourEntry(e, i))
             const viewport = getViewport()
 
             const releaseFromIds = () => {
@@ -127,24 +138,20 @@ export function TransitionDirector({
                 world,
                 viewport,
                 fromIds,
-                toCards
-                    .map((c, i) => makePourEntry(c, i, registry))
-                    .filter((x): x is PourInDropEntry => x !== null),
+                pourEntries,
             )
             const enterStep = buildPrimitive(
                 plan.enter,
                 world,
                 viewport,
                 fromIds,
-                toCards
-                    .map((c, i) => makePourEntry(c, i, registry))
-                    .filter((x): x is PourInDropEntry => x !== null),
+                pourEntries,
             )
 
             await Promise.all([runStep(exitStep), runStep(enterStep)])
             releaseFromIds()
         },
-        [pageDefs, registry, world],
+        [registry, world],
     )
 
     const dispatchTransition = useCallback(
@@ -164,17 +171,18 @@ export function TransitionDirector({
         [pageDefs, edges, executeTransition, registry],
     )
 
-    // Phase 1: BEFORE old route's cleanups, mark its cards as exiting so the
-    // registry preserves them across the unmount.
+    // Phase 1: BEFORE old route's cleanups, mark every currently-active card
+    // as exiting so the registry preserves them across the unmount. Sourcing
+    // from the registry (instead of pageDefs[prev]) covers routes that are
+    // not declared in `pageDefs` — e.g. /blog or dynamic slug pages — whose
+    // cards would otherwise pop out instantly when the route unmounts.
     useLayoutEffect(() => {
         const prev = prevLocationRef.current
         if (!prev || prev.pathname === location.pathname) return
-        const oldPageDef = pageDefs[prev.pathname]
-        if (!oldPageDef) return
-        for (const card of oldPageDef.cards) {
-            registry.markExiting(card.id)
+        for (const entry of registry.snapshot()) {
+            if (entry.state === 'active') registry.markExiting(entry.id)
         }
-    }, [location, registry, pageDefs])
+    }, [location, registry])
 
     // Phase 2: AFTER children's effects (new cards now registered in PhysicsWorld),
     // dispatch and execute the transition primitives.
@@ -243,16 +251,13 @@ function buildPrimitive(
 }
 
 function makePourEntry(
-    card: { id: string },
+    entry: PhysicsCardEntry,
     index: number,
-    registry: ReturnType<typeof useCardRegistry>,
-): PourInDropEntry | null {
-    const entry = registry.snapshot().find((e) => e.id === card.id)
-    if (!entry) return null
+): PourInDropEntry {
     return {
-        id: card.id,
+        id: entry.id,
         layoutAnchor: entry.anchor,
         height: entry.content.height,
-        staggerMs: index * 80,
+        staggerMs: POUR_IN_BASE_DELAY_MS + index * 80,
     }
 }

--- a/web/src/transitions/classifyDirection.test.ts
+++ b/web/src/transitions/classifyDirection.test.ts
@@ -1,0 +1,16 @@
+import { describe, test, expect } from 'vitest'
+import { classifyDirection } from './classifyDirection'
+
+describe('classifyDirection', () => {
+    test('PUSH classifies as forward', () => {
+        expect(classifyDirection('PUSH')).toBe('forward')
+    })
+
+    test('POP classifies as back', () => {
+        expect(classifyDirection('POP')).toBe('back')
+    })
+
+    test('REPLACE classifies as sibling', () => {
+        expect(classifyDirection('REPLACE')).toBe('sibling')
+    })
+})

--- a/web/src/transitions/classifyDirection.ts
+++ b/web/src/transitions/classifyDirection.ts
@@ -1,0 +1,8 @@
+export type Direction = 'forward' | 'back' | 'sibling'
+export type NavigationType = 'PUSH' | 'POP' | 'REPLACE'
+
+export function classifyDirection(navType: NavigationType): Direction {
+    if (navType === 'POP') return 'back'
+    if (navType === 'REPLACE') return 'sibling'
+    return 'forward'
+}

--- a/web/src/transitions/dispatch.test.ts
+++ b/web/src/transitions/dispatch.test.ts
@@ -1,0 +1,133 @@
+import { describe, test, expect } from 'vitest'
+import { dispatch } from './dispatch'
+import type { PageDef } from '../physics/PageDef'
+import type { EdgeTransitions } from './dispatch'
+
+const homeDef: PageDef = { gravity: 'down', cards: [] }
+const blogDef: PageDef = { gravity: 'down', cards: [] }
+
+describe('dispatch', () => {
+    test('edge-table match wins over PageDef transitions', () => {
+        const pageDefs: Record<string, PageDef> = {
+            '/a': { ...homeDef, transitions: { exit: 'string-cut-drop' } },
+            '/b': { ...blogDef, transitions: { enter: 'pour-in-drop' } },
+        }
+        const edges: EdgeTransitions = {
+            '/a→/b': { primitive: 'anchor-slide', axis: 'horizontal' },
+        }
+
+        const plan = dispatch('/a', '/b', pageDefs, edges, 'forward')
+
+        expect(plan.kind).toBe('coupled')
+        if (plan.kind === 'coupled') {
+            expect(plan.config.primitive).toBe('anchor-slide')
+            expect(plan.config.axis).toBe('horizontal')
+        }
+    })
+
+    test('PageDef decoupled pair wins over history-direction default', () => {
+        const pageDefs: Record<string, PageDef> = {
+            '/a': { ...homeDef, transitions: { exit: 'cross-fade' } },
+            '/b': blogDef,
+        }
+
+        const plan = dispatch('/a', '/b', pageDefs, {}, 'forward')
+
+        expect(plan.kind).toBe('decoupled')
+        if (plan.kind === 'decoupled') {
+            expect(plan.exit).toBe('cross-fade')
+            expect(plan.enter).toBe('pour-in-drop') // falls back to default enter
+            expect(plan.overlapMs).toBe(200)
+        }
+    })
+
+    test('forward with no overrides → string-cut-drop + pour-in-drop decoupled', () => {
+        const pageDefs: Record<string, PageDef> = {
+            '/a': homeDef,
+            '/b': blogDef,
+        }
+
+        const plan = dispatch('/a', '/b', pageDefs, {}, 'forward')
+
+        expect(plan).toEqual({
+            kind: 'decoupled',
+            exit: 'string-cut-drop',
+            enter: 'pour-in-drop',
+            overlapMs: 200,
+        })
+    })
+
+    test('back with no overrides → same T1+T2 decoupled pair', () => {
+        const pageDefs: Record<string, PageDef> = {
+            '/a': homeDef,
+            '/b': blogDef,
+        }
+
+        const plan = dispatch('/a', '/b', pageDefs, {}, 'back')
+
+        expect(plan.kind).toBe('decoupled')
+        if (plan.kind === 'decoupled') {
+            expect(plan.exit).toBe('string-cut-drop')
+            expect(plan.enter).toBe('pour-in-drop')
+        }
+    })
+
+    test('sibling with no overrides → anchor-slide horizontal coupled, sign=+1', () => {
+        const pageDefs: Record<string, PageDef> = {
+            '/a': homeDef,
+            '/b': blogDef,
+        }
+
+        const plan = dispatch('/a', '/b', pageDefs, {}, 'sibling')
+
+        expect(plan.kind).toBe('coupled')
+        if (plan.kind === 'coupled') {
+            expect(plan.config.primitive).toBe('anchor-slide')
+            expect(plan.config.axis).toBe('horizontal')
+            expect(plan.config.sign).toBe(1)
+            expect(plan.config.durationMs).toBe(700)
+        }
+    })
+
+    test('sibling with destination siblingOrder=left flips sign to -1', () => {
+        const pageDefs: Record<string, PageDef> = {
+            '/a': homeDef,
+            '/b': { ...blogDef, siblingOrder: 'left' },
+        }
+
+        const plan = dispatch('/a', '/b', pageDefs, {}, 'sibling')
+
+        expect(plan.kind).toBe('coupled')
+        if (plan.kind === 'coupled') {
+            expect(plan.config.sign).toBe(-1)
+        }
+    })
+
+    test('edge with omitted sign uses direction (back → -1)', () => {
+        const pageDefs: Record<string, PageDef> = { '/a': homeDef, '/b': blogDef }
+        const edges: EdgeTransitions = {
+            '/a→/b': { primitive: 'anchor-slide', axis: 'horizontal' },
+        }
+
+        const plan = dispatch('/a', '/b', pageDefs, edges, 'back')
+
+        expect(plan.kind).toBe('coupled')
+        if (plan.kind === 'coupled') {
+            expect(plan.config.sign).toBe(-1)
+        }
+    })
+
+    test('edge with explicit sign overrides direction', () => {
+        const pageDefs: Record<string, PageDef> = { '/a': homeDef, '/b': blogDef }
+        const edges: EdgeTransitions = {
+            '/a→/b': { primitive: 'anchor-slide', axis: 'horizontal', sign: 1 },
+        }
+
+        const plan = dispatch('/a', '/b', pageDefs, edges, 'back')
+
+        expect(plan.kind).toBe('coupled')
+        if (plan.kind === 'coupled') {
+            expect(plan.config.sign).toBe(1)
+        }
+    })
+})

--- a/web/src/transitions/dispatch.ts
+++ b/web/src/transitions/dispatch.ts
@@ -1,0 +1,90 @@
+import type { PageDef, TransitionId } from '../physics/PageDef'
+import type { Direction } from './classifyDirection'
+
+export interface AnchorSlideConfig {
+    primitive: 'anchor-slide'
+    axis: 'horizontal' | 'vertical'
+    sign: 1 | -1
+    durationMs: number
+}
+
+export type CoupledConfig = AnchorSlideConfig
+
+export type TransitionPlan =
+    | { kind: 'coupled'; config: CoupledConfig }
+    | {
+          kind: 'decoupled'
+          exit: TransitionId
+          enter: TransitionId
+          overlapMs: number
+      }
+
+export interface EdgeConfig {
+    primitive: 'anchor-slide'
+    axis: 'horizontal' | 'vertical'
+    sign?: 1 | -1
+    durationMs?: number
+}
+
+export type EdgeTransitions = Record<string, EdgeConfig>
+
+const DEFAULT_DECOUPLED_OVERLAP_MS = 200
+const DEFAULT_ANCHOR_SLIDE_DURATION_MS = 700
+
+function signFromDirection(direction: Direction): 1 | -1 {
+    return direction === 'back' ? -1 : 1
+}
+
+export function dispatch(
+    from: string,
+    to: string,
+    pageDefs: Record<string, PageDef>,
+    edges: EdgeTransitions,
+    direction: Direction,
+): TransitionPlan {
+    const edgeKey = `${from}→${to}`
+    const edge = edges[edgeKey]
+    if (edge) {
+        return {
+            kind: 'coupled',
+            config: {
+                primitive: 'anchor-slide',
+                axis: edge.axis,
+                sign: edge.sign ?? signFromDirection(direction),
+                durationMs: edge.durationMs ?? DEFAULT_ANCHOR_SLIDE_DURATION_MS,
+            },
+        }
+    }
+
+    const fromExit = pageDefs[from]?.transitions?.exit
+    const toEnter = pageDefs[to]?.transitions?.enter
+    if (fromExit || toEnter) {
+        return {
+            kind: 'decoupled',
+            exit: fromExit ?? 'string-cut-drop',
+            enter: toEnter ?? 'pour-in-drop',
+            overlapMs: DEFAULT_DECOUPLED_OVERLAP_MS,
+        }
+    }
+
+    if (direction === 'sibling') {
+        const siblingOrder = pageDefs[to]?.siblingOrder
+        const sign: 1 | -1 = siblingOrder === 'left' ? -1 : 1
+        return {
+            kind: 'coupled',
+            config: {
+                primitive: 'anchor-slide',
+                axis: 'horizontal',
+                sign,
+                durationMs: DEFAULT_ANCHOR_SLIDE_DURATION_MS,
+            },
+        }
+    }
+
+    return {
+        kind: 'decoupled',
+        exit: 'string-cut-drop',
+        enter: 'pour-in-drop',
+        overlapMs: DEFAULT_DECOUPLED_OVERLAP_MS,
+    }
+}

--- a/web/src/transitions/edges.ts
+++ b/web/src/transitions/edges.ts
@@ -1,0 +1,8 @@
+import type { EdgeTransitions } from './dispatch'
+
+/**
+ * Edge table for coupled transitions between specific (from → to) route pairs.
+ * Empty in slice 21 — all transitions fall through to history-direction defaults
+ * (forward/back → T1+T2, sibling → T3).
+ */
+export const edges: EdgeTransitions = {}

--- a/web/src/transitions/edges.ts
+++ b/web/src/transitions/edges.ts
@@ -2,7 +2,32 @@ import type { EdgeTransitions } from './dispatch'
 
 /**
  * Edge table for coupled transitions between specific (from → to) route pairs.
- * Empty in slice 21 — all transitions fall through to history-direction defaults
- * (forward/back → T1+T2, sibling → T3).
+ *
+ * Currently set to route every literal pair among the canvas routes
+ * (/, /lifelog, /stuff, /blog) through anchor-slide so the primitive can be
+ * exercised by clicking through the nav. /blog is included even though it
+ * isn't in pageDefs.ts (BlogIndex builds its PageDef dynamically); the edge
+ * table keys on path strings, not registry membership. Sign is omitted
+ * intentionally — it falls back to the history-direction default
+ * (forward = +1, back = -1), so back-button nav reverses the slide axis.
+ * Once we settle on which pairs should use which primitive, this list
+ * should be pruned.
+ *
+ * Dynamic routes (e.g. /blog/:slug, /stuff/flash/:slug) are not enumerated
+ * here — they go through the fallback decoupled T1+T2 path. Pattern-matched
+ * edges are slice 21b / issue #81 territory.
  */
-export const edges: EdgeTransitions = {}
+export const edges: EdgeTransitions = {
+    '/→/lifelog': { primitive: 'anchor-slide', axis: 'horizontal' },
+    '/→/stuff': { primitive: 'anchor-slide', axis: 'horizontal' },
+    '/→/blog': { primitive: 'anchor-slide', axis: 'horizontal' },
+    '/lifelog→/': { primitive: 'anchor-slide', axis: 'horizontal' },
+    '/lifelog→/stuff': { primitive: 'anchor-slide', axis: 'horizontal' },
+    '/lifelog→/blog': { primitive: 'anchor-slide', axis: 'horizontal' },
+    '/stuff→/': { primitive: 'anchor-slide', axis: 'horizontal' },
+    '/stuff→/lifelog': { primitive: 'anchor-slide', axis: 'horizontal' },
+    '/stuff→/blog': { primitive: 'anchor-slide', axis: 'horizontal' },
+    '/blog→/': { primitive: 'anchor-slide', axis: 'horizontal' },
+    '/blog→/lifelog': { primitive: 'anchor-slide', axis: 'horizontal' },
+    '/blog→/stuff': { primitive: 'anchor-slide', axis: 'horizontal' },
+}

--- a/web/src/transitions/pageDefs.ts
+++ b/web/src/transitions/pageDefs.ts
@@ -1,0 +1,21 @@
+import { pageDef as homePageDef } from '../routes/Home'
+import { pageDef as lifelogPageDef } from '../routes/Lifelog'
+import { pageDef as stuffPageDef } from '../routes/Stuff'
+import { pageDef as notFoundPageDef } from '../routes/NotFound'
+import type { PageDef } from '../physics/PageDef'
+
+/**
+ * Registry of route paths → PageDef. Used by TransitionDirector to identify
+ * which cards are exiting/entering when navigation occurs.
+ *
+ * Dynamic routes (e.g. `/blog/:slug`, `/stuff/flash/:slug`) are not registered
+ * in this slice — transitions to/from those paths degrade to no-op. Slice 21b
+ * will introduce a pattern-matching variant for dynamic routes.
+ */
+export const pageDefs: Record<string, PageDef> = {
+    '/': homePageDef,
+    '/lifelog': lifelogPageDef,
+    '/stuff': stuffPageDef,
+}
+
+export const notFoundFallbackPageDef = notFoundPageDef

--- a/web/src/transitions/primitives/anchorSlide.test.ts
+++ b/web/src/transitions/primitives/anchorSlide.test.ts
@@ -1,0 +1,158 @@
+import { describe, test, expect } from 'vitest'
+import { PhysicsWorld } from '../../physics/PhysicsWorld'
+import { anchorSlide } from './anchorSlide'
+
+describe('anchorSlide (T3) — horizontal', () => {
+    test('translates from-card horizontally off-viewport over duration', () => {
+        const viewport = { width: 800, height: 600 }
+        const world = new PhysicsWorld({ viewport })
+        const a = world.registerById(
+            'a',
+            { x: 400, y: 300 },
+            { width: 200, height: 100 },
+        )
+
+        const step = anchorSlide(
+            world,
+            { fromIds: ['a'], toIds: [] },
+            {
+                axis: 'horizontal',
+                sign: 1,
+                durationMs: 700,
+                viewport,
+            },
+        )
+
+        step(0) // captures initial positions
+        const start = world.getPosition(a)
+        expect(start.x).toBeCloseTo(400, 1)
+
+        // Halfway through duration
+        step(350)
+        const mid = world.getPosition(a)
+        // sign=+1, fromCard exits in axis × -sign direction = leftward (negative x)
+        expect(mid.x).toBeLessThan(start.x)
+
+        // After full duration
+        const done = step(350)
+        expect(done).toBe(true)
+        const final = world.getPosition(a)
+        // Final position is off-viewport on the leftward side
+        expect(final.x).toBeLessThanOrEqual(-100)
+    })
+
+    test('sign=-1 flips direction (from-card exits to the right)', () => {
+        const viewport = { width: 800, height: 600 }
+        const world = new PhysicsWorld({ viewport })
+        const a = world.registerById(
+            'a',
+            { x: 400, y: 300 },
+            { width: 200, height: 100 },
+        )
+
+        const step = anchorSlide(
+            world,
+            { fromIds: ['a'], toIds: [] },
+            {
+                axis: 'horizontal',
+                sign: -1,
+                durationMs: 700,
+                viewport,
+            },
+        )
+
+        step(0)
+        step(700)
+        const final = world.getPosition(a)
+        // With sign=-1, fromCard exits in axis × -sign = rightward (positive x)
+        expect(final.x).toBeGreaterThan(viewport.width)
+    })
+
+    test('to-card enters from origin side toward its layout position', () => {
+        const viewport = { width: 800, height: 600 }
+        const world = new PhysicsWorld({ viewport })
+        const b = world.registerById(
+            'b',
+            { x: 400, y: 300 },
+            { width: 200, height: 100 },
+        )
+
+        const step = anchorSlide(
+            world,
+            { fromIds: [], toIds: ['b'] },
+            {
+                axis: 'horizontal',
+                sign: 1,
+                durationMs: 700,
+                viewport,
+            },
+        )
+
+        step(0)
+        // toCard with sign=+1: enters from origin side (left) — initial position pushed off-screen left
+        const initialPos = world.getPosition(b)
+        expect(initialPos.x).toBeLessThanOrEqual(-100)
+
+        // At end, reaches its layout position
+        step(700)
+        const final = world.getPosition(b)
+        expect(final.x).toBeCloseTo(400, 1)
+    })
+
+    test('follows ease-out-cubic curve (front-loaded motion)', () => {
+        const viewport = { width: 800, height: 600 }
+        const world = new PhysicsWorld({ viewport })
+        const a = world.registerById(
+            'a',
+            { x: 400, y: 300 },
+            { width: 200, height: 100 },
+        )
+
+        const step = anchorSlide(
+            world,
+            { fromIds: ['a'], toIds: [] },
+            {
+                axis: 'horizontal',
+                sign: 1,
+                durationMs: 1000,
+                viewport,
+            },
+        )
+
+        step(0)
+        const start = world.getPosition(a).x
+        step(250) // t=0.25
+        const at25 = world.getPosition(a).x
+        step(250) // t=0.50
+        const at50 = world.getPosition(a).x
+
+        // Distance from start at t=0.5 — eased value at 0.5 is 1 - (1-0.5)^3 = 1 - 0.125 = 0.875
+        const totalDistance = Math.abs(start - (start - (viewport.width + 200)))
+        const distance25 = Math.abs(start - at25)
+        const distance50 = Math.abs(start - at50)
+        // Eased at t=0.25 → 1 - (0.75)^3 ≈ 0.578 — more than half of 0.875
+        expect(distance25 / distance50).toBeGreaterThan(0.5)
+        // And the 0.25-progress is much more than linear 0.25 (which would give 0.25/0.5 = 0.5)
+        expect(distance25 / totalDistance).toBeGreaterThan(0.4)
+    })
+
+    test('handles empty from/to lists without error', () => {
+        const viewport = { width: 800, height: 600 }
+        const world = new PhysicsWorld({ viewport })
+
+        const step = anchorSlide(
+            world,
+            { fromIds: [], toIds: [] },
+            {
+                axis: 'horizontal',
+                sign: 1,
+                durationMs: 100,
+                viewport,
+            },
+        )
+
+        step(0)
+        const done = step(100)
+        expect(done).toBe(true)
+    })
+})

--- a/web/src/transitions/primitives/anchorSlide.test.ts
+++ b/web/src/transitions/primitives/anchorSlide.test.ts
@@ -155,4 +155,83 @@ describe('anchorSlide (T3) — horizontal', () => {
         const done = step(100)
         expect(done).toBe(true)
     })
+
+    test('to-card tether is captured on init and restored on completion', () => {
+        const viewport = { width: 800, height: 600 }
+        const world = new PhysicsWorld({ viewport })
+        const b = world.registerById(
+            'b',
+            { x: 400, y: 300 },
+            { width: 200, height: 100 },
+        )
+        const TETHER_LEN = 250
+        world.tether(world.ceilingHandle, b, TETHER_LEN)
+        expect(
+            world.listTetherRecords().filter((t) => t.child === b),
+        ).toHaveLength(1)
+
+        const step = anchorSlide(
+            world,
+            { fromIds: [], toIds: ['b'] },
+            {
+                axis: 'horizontal',
+                sign: 1,
+                durationMs: 700,
+                viewport,
+            },
+        )
+
+        // After step(0), the tether should be detached so StringLayer
+        // doesn't draw a long diagonal string while the card slides in.
+        step(0)
+        expect(
+            world.listTetherRecords().filter((t) => t.child === b),
+        ).toHaveLength(0)
+
+        // After completion, the tether should be re-attached with the
+        // original length so the card resumes hanging at its layout anchor.
+        step(700)
+        const restored = world
+            .listTetherRecords()
+            .filter((t) => t.child === b)
+        expect(restored).toHaveLength(1)
+        expect(restored[0]!.length).toBe(TETHER_LEN)
+        expect(restored[0]!.parent).toBe(world.ceilingHandle)
+    })
+
+    test('from-card tether is captured on init and NOT restored (card is dying)', () => {
+        const viewport = { width: 800, height: 600 }
+        const world = new PhysicsWorld({ viewport })
+        const a = world.registerById(
+            'a',
+            { x: 400, y: 300 },
+            { width: 200, height: 100 },
+        )
+        world.tether(world.ceilingHandle, a, 250)
+        expect(
+            world.listTetherRecords().filter((t) => t.child === a),
+        ).toHaveLength(1)
+
+        const step = anchorSlide(
+            world,
+            { fromIds: ['a'], toIds: [] },
+            {
+                axis: 'horizontal',
+                sign: 1,
+                durationMs: 700,
+                viewport,
+            },
+        )
+
+        step(0)
+        expect(
+            world.listTetherRecords().filter((t) => t.child === a),
+        ).toHaveLength(0)
+
+        step(700)
+        // From-card stays untethered — TransitionDirector releases it next.
+        expect(
+            world.listTetherRecords().filter((t) => t.child === a),
+        ).toHaveLength(0)
+    })
 })

--- a/web/src/transitions/primitives/anchorSlide.ts
+++ b/web/src/transitions/primitives/anchorSlide.ts
@@ -1,0 +1,118 @@
+import type { PhysicsWorld, Viewport } from '../../physics/PhysicsWorld'
+import type { PrimitiveStep } from './types'
+
+export interface AnchorSlideTargets {
+    fromIds: readonly string[]
+    toIds: readonly string[]
+}
+
+export interface AnchorSlideOpts {
+    axis: 'horizontal' | 'vertical'
+    sign: 1 | -1
+    durationMs: number
+    viewport: Viewport
+}
+
+const OFFSCREEN_PAD = 100
+
+function easeOutCubic(t: number): number {
+    return 1 - Math.pow(1 - t, 3)
+}
+
+export function anchorSlide(
+    world: PhysicsWorld,
+    targets: AnchorSlideTargets,
+    opts: AnchorSlideOpts,
+): PrimitiveStep {
+    const { axis, sign, durationMs, viewport } = opts
+    let elapsedMs = 0
+    let initialized = false
+
+    const fromInitial = new Map<string, { x: number; y: number }>()
+    const fromFinal = new Map<string, { x: number; y: number }>()
+    const toInitial = new Map<string, { x: number; y: number }>()
+    const toLayout = new Map<string, { x: number; y: number }>()
+
+    const horizontalSpan = viewport.width + OFFSCREEN_PAD
+    const verticalSpan = viewport.height + OFFSCREEN_PAD
+
+    const offsetFor = (direction: -1 | 1) => {
+        if (axis === 'horizontal') {
+            return { x: direction * horizontalSpan, y: 0 }
+        }
+        return { x: 0, y: direction * verticalSpan }
+    }
+
+    return (dtMs) => {
+        if (!initialized) {
+            for (const id of targets.fromIds) {
+                const handle = world.getHandleById(id)
+                if (handle === undefined) continue
+                const pos = world.getPosition(handle)
+                const start = { x: pos.x, y: pos.y }
+                fromInitial.set(id, start)
+                // From-card exits in axis × -sign direction
+                const exitOffset = offsetFor((-sign) as -1 | 1)
+                fromFinal.set(id, {
+                    x: start.x + exitOffset.x,
+                    y: start.y + exitOffset.y,
+                })
+                world.setDragging(handle, true)
+            }
+            for (const id of targets.toIds) {
+                const handle = world.getHandleById(id)
+                if (handle === undefined) continue
+                const pos = world.getPosition(handle)
+                const layout = { x: pos.x, y: pos.y }
+                toLayout.set(id, layout)
+                // To-card enters from axis × -sign direction (origin side)
+                const enterOffset = offsetFor((-sign) as -1 | 1)
+                const start = {
+                    x: layout.x + enterOffset.x,
+                    y: layout.y + enterOffset.y,
+                }
+                toInitial.set(id, start)
+                world.setDragging(handle, true)
+                world.setPosition(handle, start)
+            }
+            initialized = true
+        }
+
+        elapsedMs += dtMs
+        const tRaw = Math.min(elapsedMs / durationMs, 1)
+        const eased = easeOutCubic(tRaw)
+
+        for (const id of targets.fromIds) {
+            const handle = world.getHandleById(id)
+            if (handle === undefined) continue
+            const a = fromInitial.get(id)
+            const b = fromFinal.get(id)
+            if (!a || !b) continue
+            world.setPosition(handle, {
+                x: a.x + (b.x - a.x) * eased,
+                y: a.y + (b.y - a.y) * eased,
+            })
+        }
+        for (const id of targets.toIds) {
+            const handle = world.getHandleById(id)
+            if (handle === undefined) continue
+            const a = toInitial.get(id)
+            const b = toLayout.get(id)
+            if (!a || !b) continue
+            world.setPosition(handle, {
+                x: a.x + (b.x - a.x) * eased,
+                y: a.y + (b.y - a.y) * eased,
+            })
+        }
+
+        if (tRaw >= 1) {
+            for (const id of [...targets.fromIds, ...targets.toIds]) {
+                const handle = world.getHandleById(id)
+                if (handle === undefined) continue
+                world.setDragging(handle, false)
+            }
+            return true
+        }
+        return false
+    }
+}

--- a/web/src/transitions/primitives/anchorSlide.ts
+++ b/web/src/transitions/primitives/anchorSlide.ts
@@ -1,4 +1,9 @@
-import type { PhysicsWorld, Viewport } from '../../physics/PhysicsWorld'
+import type {
+    PhysicsHandle,
+    PhysicsWorld,
+    Vec2,
+    Viewport,
+} from '../../physics/PhysicsWorld'
 import type { PrimitiveStep } from './types'
 
 export interface AnchorSlideTargets {
@@ -15,8 +20,38 @@ export interface AnchorSlideOpts {
 
 const OFFSCREEN_PAD = 100
 
+interface CapturedTether {
+    parent: PhysicsHandle
+    length: number
+    anchorA?: Vec2
+}
+
 function easeOutCubic(t: number): number {
     return 1 - Math.pow(1 - t, 3)
+}
+
+/**
+ * Untether the first record where `child === handle` and return its spec
+ * (parent + length + optional anchorA). Returns undefined if the card has
+ * no tether. Mirrors `pourInDrop`'s capture pattern so StringLayer doesn't
+ * draw a long diagonal string from the original parent anchor to the
+ * sliding card.
+ */
+function captureAndUntether(
+    world: PhysicsWorld,
+    handle: PhysicsHandle,
+): CapturedTether | undefined {
+    for (const t of world.listTetherRecords()) {
+        if (t.child !== handle) continue
+        const captured: CapturedTether = {
+            parent: t.parent,
+            length: t.length,
+            ...(t.anchorA ? { anchorA: { ...t.anchorA } } : {}),
+        }
+        world.untether(t.handle)
+        return captured
+    }
+    return undefined
 }
 
 export function anchorSlide(
@@ -28,10 +63,15 @@ export function anchorSlide(
     let elapsedMs = 0
     let initialized = false
 
-    const fromInitial = new Map<string, { x: number; y: number }>()
-    const fromFinal = new Map<string, { x: number; y: number }>()
-    const toInitial = new Map<string, { x: number; y: number }>()
-    const toLayout = new Map<string, { x: number; y: number }>()
+    const fromInitial = new Map<string, Vec2>()
+    const fromFinal = new Map<string, Vec2>()
+    const toInitial = new Map<string, Vec2>()
+    const toLayout = new Map<string, Vec2>()
+    // To-card tethers captured on init are re-attached at completion so the
+    // card resumes hanging at its layout anchor. From-card tethers are
+    // captured-and-discarded — the cards are about to be released by
+    // TransitionDirector when the slide ends.
+    const toCaptured = new Map<string, CapturedTether>()
 
     const horizontalSpan = viewport.width + OFFSCREEN_PAD
     const verticalSpan = viewport.height + OFFSCREEN_PAD
@@ -48,6 +88,7 @@ export function anchorSlide(
             for (const id of targets.fromIds) {
                 const handle = world.getHandleById(id)
                 if (handle === undefined) continue
+                captureAndUntether(world, handle)
                 const pos = world.getPosition(handle)
                 const start = { x: pos.x, y: pos.y }
                 fromInitial.set(id, start)
@@ -62,6 +103,8 @@ export function anchorSlide(
             for (const id of targets.toIds) {
                 const handle = world.getHandleById(id)
                 if (handle === undefined) continue
+                const captured = captureAndUntether(world, handle)
+                if (captured) toCaptured.set(id, captured)
                 const pos = world.getPosition(handle)
                 const layout = { x: pos.x, y: pos.y }
                 toLayout.set(id, layout)
@@ -106,10 +149,25 @@ export function anchorSlide(
         }
 
         if (tRaw >= 1) {
-            for (const id of [...targets.fromIds, ...targets.toIds]) {
+            for (const id of targets.fromIds) {
                 const handle = world.getHandleById(id)
                 if (handle === undefined) continue
                 world.setDragging(handle, false)
+            }
+            for (const id of targets.toIds) {
+                const handle = world.getHandleById(id)
+                if (handle === undefined) continue
+                world.setDragging(handle, false)
+                world.setVelocity(handle, { x: 0, y: 0 })
+                const captured = toCaptured.get(id)
+                if (captured) {
+                    world.tether(
+                        captured.parent,
+                        handle,
+                        captured.length,
+                        captured.anchorA,
+                    )
+                }
             }
             return true
         }

--- a/web/src/transitions/primitives/crossFade.test.ts
+++ b/web/src/transitions/primitives/crossFade.test.ts
@@ -1,0 +1,38 @@
+import { describe, test, expect, beforeEach } from 'vitest'
+import { crossFade } from './crossFade'
+
+describe('crossFade', () => {
+    let el: HTMLElement
+    beforeEach(() => {
+        el = document.createElement('div')
+        document.body.appendChild(el)
+    })
+
+    test('starts at opacity 0 and reaches 1 over the duration', () => {
+        const step = crossFade(el, { durationMs: 150 })
+
+        step(0)
+        expect(parseFloat(el.style.opacity)).toBeCloseTo(0, 2)
+
+        step(75)
+        expect(parseFloat(el.style.opacity)).toBeCloseTo(0.5, 1)
+
+        const done = step(75)
+        expect(parseFloat(el.style.opacity)).toBeCloseTo(1, 2)
+        expect(done).toBe(true)
+    })
+
+    test('clamps opacity at 1 if step overshoots the duration', () => {
+        const step = crossFade(el, { durationMs: 150 })
+        const done = step(500)
+        expect(parseFloat(el.style.opacity)).toBe(1)
+        expect(done).toBe(true)
+    })
+
+    test('default duration is 150ms', () => {
+        const step = crossFade(el)
+        step(0)
+        const done = step(150)
+        expect(done).toBe(true)
+    })
+})

--- a/web/src/transitions/primitives/crossFade.ts
+++ b/web/src/transitions/primitives/crossFade.ts
@@ -1,0 +1,24 @@
+import type { PrimitiveStep } from './types'
+
+export interface CrossFadeOpts {
+    durationMs?: number
+}
+
+export function crossFade(
+    element: HTMLElement,
+    opts: CrossFadeOpts = {},
+): PrimitiveStep {
+    const durationMs = opts.durationMs ?? 150
+    let elapsedMs = 0
+    let initialized = false
+    return (dtMs) => {
+        if (!initialized) {
+            element.style.opacity = '0'
+            initialized = true
+        }
+        elapsedMs += dtMs
+        const t = Math.min(elapsedMs / durationMs, 1)
+        element.style.opacity = String(t)
+        return t >= 1
+    }
+}

--- a/web/src/transitions/primitives/pourInDrop.test.ts
+++ b/web/src/transitions/primitives/pourInDrop.test.ts
@@ -4,8 +4,10 @@ import { pourInDrop } from './pourInDrop'
 
 const FIXED_DT_MS = 1000 / 60
 
-describe('pourInDrop (T2)', () => {
-    test('spawns each card above the viewport at its layout x', () => {
+describe('pourInDrop (T2 — kinematic tween)', () => {
+    test('pre-spawns ALL entries above the viewport on first tick (regardless of stagger)', () => {
+        // Prevents the cards from being briefly visible at their layout
+        // positions during the stagger delay.
         const viewport = { width: 800, height: 600 }
         const world = new PhysicsWorld({ viewport })
         const a = world.registerById(
@@ -23,9 +25,9 @@ describe('pourInDrop (T2)', () => {
             world,
             [
                 { id: 'a', layoutAnchor: { x: 200, y: 200 }, height: 120, staggerMs: 0 },
-                { id: 'b', layoutAnchor: { x: 500, y: 300 }, height: 120, staggerMs: 80 },
+                { id: 'b', layoutAnchor: { x: 500, y: 300 }, height: 120, staggerMs: 1000 },
             ],
-            { viewport },
+            { viewport, hardCeilingMs: 5000 },
         )
 
         step(0)
@@ -33,13 +35,13 @@ describe('pourInDrop (T2)', () => {
         expect(posA.x).toBeCloseTo(200, 1)
         expect(posA.y).toBeLessThan(0)
 
-        // b has stagger 80ms — has NOT spawned yet (still at original position)
+        // b has stagger 1000ms but is still pre-spawned above viewport.
         const posB = world.getPosition(b)
         expect(posB.x).toBeCloseTo(500, 1)
-        expect(posB.y).toBeCloseTo(300, 1)
+        expect(posB.y).toBeLessThan(0)
     })
 
-    test('child spawns after parent based on staggerMs', () => {
+    test('tween for an entry only begins after its staggerMs has elapsed', () => {
         const viewport = { width: 800, height: 600 }
         const world = new PhysicsWorld({ viewport })
         world.registerById('a', { x: 200, y: 200 }, { width: 240, height: 120 })
@@ -53,19 +55,25 @@ describe('pourInDrop (T2)', () => {
             world,
             [
                 { id: 'a', layoutAnchor: { x: 200, y: 200 }, height: 120, staggerMs: 0 },
-                { id: 'b', layoutAnchor: { x: 500, y: 300 }, height: 120, staggerMs: 80 },
+                { id: 'b', layoutAnchor: { x: 500, y: 300 }, height: 120, staggerMs: 200 },
             ],
-            { viewport },
+            { viewport, hardCeilingMs: 5000 },
         )
 
         step(0)
-        // Advance past b's stagger threshold
-        step(100)
-        const posB = world.getPosition(b)
-        expect(posB.y).toBeLessThan(0)
+        const bAfterPreSpawn = world.getPosition(b).y
+        expect(bAfterPreSpawn).toBeLessThan(0)
+
+        // Advance below b's stagger threshold — b should not have moved.
+        step(50)
+        expect(world.getPosition(b).y).toBeCloseTo(bAfterPreSpawn, 1)
+
+        // Advance past b's stagger threshold — b's tween should now have started.
+        step(200)
+        expect(world.getPosition(b).y).toBeGreaterThan(bAfterPreSpawn)
     })
 
-    test('applies downward velocity on spawn', () => {
+    test('tween moves the card from above viewport to its layout anchor', () => {
         const viewport = { width: 800, height: 600 }
         const world = new PhysicsWorld({ viewport })
         const a = world.registerById(
@@ -74,21 +82,67 @@ describe('pourInDrop (T2)', () => {
             { width: 240, height: 120 },
         )
 
+        const tweenDurationMs = 600
         const step = pourInDrop(
             world,
             [{ id: 'a', layoutAnchor: { x: 200, y: 200 }, height: 120, staggerMs: 0 }],
-            { viewport },
+            { viewport, tweenDurationMs, hardCeilingMs: 5000 },
         )
 
+        // Spawn above viewport.
         step(0)
-        const spawnPos = world.getPosition(a)
-        world.tick(FIXED_DT_MS)
-        const afterTick = world.getPosition(a)
-        // Card moved downward (positive y direction) in the first frame, confirming initial velocity.
-        expect(afterTick.y).toBeGreaterThan(spawnPos.y)
+        const start = world.getPosition(a)
+        expect(start.y).toBeLessThan(0)
+
+        // Halfway through the tween — card should have moved meaningfully but
+        // not yet landed at the anchor.
+        step(tweenDurationMs / 2)
+        const mid = world.getPosition(a)
+        expect(mid.y).toBeGreaterThan(start.y)
+        expect(mid.y).toBeLessThan(200)
+
+        // Past the tween — final position equals layout anchor.
+        step(tweenDurationMs)
+        const end = world.getPosition(a)
+        expect(end.x).toBeCloseTo(200, 1)
+        expect(end.y).toBeCloseTo(200, 1)
     })
 
-    test('resolves at hard ceiling when cards do not settle in time', () => {
+    test('captures the existing tether on start and re-wires it on finalize', () => {
+        const viewport = { width: 800, height: 600 }
+        const world = new PhysicsWorld({ viewport })
+        const a = world.registerById(
+            'a',
+            { x: 200, y: 200 },
+            { width: 240, height: 120 },
+        )
+        world.tether(world.ceilingHandle, a, 200, { x: 200, y: 0 })
+        expect(world.listTetherRecords()).toHaveLength(1)
+
+        const tweenDurationMs = 200
+        const step = pourInDrop(
+            world,
+            [{ id: 'a', layoutAnchor: { x: 200, y: 200 }, height: 120, staggerMs: 0 }],
+            { viewport, tweenDurationMs, hardCeilingMs: 5000 },
+        )
+
+        // Start: tether is untethered for the duration of the tween.
+        step(0)
+        expect(world.listTetherRecords()).toHaveLength(0)
+
+        // Finish the tween.
+        step(tweenDurationMs)
+        // Body is at its anchor, velocity zero, tether re-wired with same params.
+        const after = world.listTetherRecords()
+        expect(after).toHaveLength(1)
+        expect(after[0]?.parent).toBe(world.ceilingHandle)
+        expect(after[0]?.child).toBe(a)
+        expect(after[0]?.length).toBe(200)
+        const v = world.getVelocity(a)
+        expect(Math.hypot(v.x, v.y)).toBeCloseTo(0, 5)
+    })
+
+    test('resolves at hard ceiling when the tween cannot complete in time', () => {
         const viewport = { width: 800, height: 600 }
         const world = new PhysicsWorld({ viewport })
         world.registerById('a', { x: 200, y: 200 }, { width: 240, height: 120 })
@@ -107,5 +161,35 @@ describe('pourInDrop (T2)', () => {
         }
         expect(done).toBe(true)
         expect(elapsed).toBeGreaterThanOrEqual(100)
+    })
+
+    test('hard-ceiling fallback restores tethers for entries that never started', () => {
+        const viewport = { width: 800, height: 600 }
+        const world = new PhysicsWorld({ viewport })
+        const a = world.registerById(
+            'a',
+            { x: 200, y: 200 },
+            { width: 240, height: 120 },
+        )
+        world.tether(world.ceilingHandle, a, 200, { x: 200, y: 0 })
+
+        // staggerMs is past the hard ceiling — the entry should never start
+        // its tween, but the primitive must still leave the world in a valid
+        // state (tether intact, body unstuck).
+        const step = pourInDrop(
+            world,
+            [{ id: 'a', layoutAnchor: { x: 200, y: 200 }, height: 120, staggerMs: 500 }],
+            { viewport, hardCeilingMs: 100 },
+        )
+
+        let elapsed = 0
+        let done = false
+        while (!done && elapsed < 200) {
+            done = step(FIXED_DT_MS)
+            elapsed += FIXED_DT_MS
+        }
+        expect(done).toBe(true)
+        // Tether should still be there (or have been re-wired).
+        expect(world.listTetherRecords()).toHaveLength(1)
     })
 })

--- a/web/src/transitions/primitives/pourInDrop.test.ts
+++ b/web/src/transitions/primitives/pourInDrop.test.ts
@@ -1,0 +1,111 @@
+import { describe, test, expect } from 'vitest'
+import { PhysicsWorld } from '../../physics/PhysicsWorld'
+import { pourInDrop } from './pourInDrop'
+
+const FIXED_DT_MS = 1000 / 60
+
+describe('pourInDrop (T2)', () => {
+    test('spawns each card above the viewport at its layout x', () => {
+        const viewport = { width: 800, height: 600 }
+        const world = new PhysicsWorld({ viewport })
+        const a = world.registerById(
+            'a',
+            { x: 200, y: 200 },
+            { width: 240, height: 120 },
+        )
+        const b = world.registerById(
+            'b',
+            { x: 500, y: 300 },
+            { width: 240, height: 120 },
+        )
+
+        const step = pourInDrop(
+            world,
+            [
+                { id: 'a', layoutAnchor: { x: 200, y: 200 }, height: 120, staggerMs: 0 },
+                { id: 'b', layoutAnchor: { x: 500, y: 300 }, height: 120, staggerMs: 80 },
+            ],
+            { viewport },
+        )
+
+        step(0)
+        const posA = world.getPosition(a)
+        expect(posA.x).toBeCloseTo(200, 1)
+        expect(posA.y).toBeLessThan(0)
+
+        // b has stagger 80ms — has NOT spawned yet (still at original position)
+        const posB = world.getPosition(b)
+        expect(posB.x).toBeCloseTo(500, 1)
+        expect(posB.y).toBeCloseTo(300, 1)
+    })
+
+    test('child spawns after parent based on staggerMs', () => {
+        const viewport = { width: 800, height: 600 }
+        const world = new PhysicsWorld({ viewport })
+        world.registerById('a', { x: 200, y: 200 }, { width: 240, height: 120 })
+        const b = world.registerById(
+            'b',
+            { x: 500, y: 300 },
+            { width: 240, height: 120 },
+        )
+
+        const step = pourInDrop(
+            world,
+            [
+                { id: 'a', layoutAnchor: { x: 200, y: 200 }, height: 120, staggerMs: 0 },
+                { id: 'b', layoutAnchor: { x: 500, y: 300 }, height: 120, staggerMs: 80 },
+            ],
+            { viewport },
+        )
+
+        step(0)
+        // Advance past b's stagger threshold
+        step(100)
+        const posB = world.getPosition(b)
+        expect(posB.y).toBeLessThan(0)
+    })
+
+    test('applies downward velocity on spawn', () => {
+        const viewport = { width: 800, height: 600 }
+        const world = new PhysicsWorld({ viewport })
+        const a = world.registerById(
+            'a',
+            { x: 200, y: 200 },
+            { width: 240, height: 120 },
+        )
+
+        const step = pourInDrop(
+            world,
+            [{ id: 'a', layoutAnchor: { x: 200, y: 200 }, height: 120, staggerMs: 0 }],
+            { viewport },
+        )
+
+        step(0)
+        const spawnPos = world.getPosition(a)
+        world.tick(FIXED_DT_MS)
+        const afterTick = world.getPosition(a)
+        // Card moved downward (positive y direction) in the first frame, confirming initial velocity.
+        expect(afterTick.y).toBeGreaterThan(spawnPos.y)
+    })
+
+    test('resolves at hard ceiling when cards do not settle in time', () => {
+        const viewport = { width: 800, height: 600 }
+        const world = new PhysicsWorld({ viewport })
+        world.registerById('a', { x: 200, y: 200 }, { width: 240, height: 120 })
+
+        const step = pourInDrop(
+            world,
+            [{ id: 'a', layoutAnchor: { x: 200, y: 200 }, height: 120, staggerMs: 0 }],
+            { viewport, hardCeilingMs: 100 },
+        )
+
+        let elapsed = 0
+        let done = false
+        while (!done && elapsed < 200) {
+            done = step(FIXED_DT_MS)
+            elapsed += FIXED_DT_MS
+        }
+        expect(done).toBe(true)
+        expect(elapsed).toBeGreaterThanOrEqual(100)
+    })
+})

--- a/web/src/transitions/primitives/pourInDrop.ts
+++ b/web/src/transitions/primitives/pourInDrop.ts
@@ -1,0 +1,71 @@
+import type { PhysicsWorld, Viewport } from '../../physics/PhysicsWorld'
+import type { PrimitiveStep } from './types'
+
+export interface PourInDropEntry {
+    id: string
+    layoutAnchor: { x: number; y: number }
+    height: number
+    staggerMs: number
+}
+
+export interface PourInDropOpts {
+    viewport: Viewport
+    hardCeilingMs?: number
+    spawnVelocityY?: number
+    velocitySettleThreshold?: number
+}
+
+const DEFAULT_HARD_CEILING_MS = 1500
+const DEFAULT_SPAWN_VELOCITY_Y = 4
+const DEFAULT_VELOCITY_SETTLE = 0.2
+
+export function pourInDrop(
+    world: PhysicsWorld,
+    entries: readonly PourInDropEntry[],
+    opts: PourInDropOpts,
+): PrimitiveStep {
+    const hardCeilingMs = opts.hardCeilingMs ?? DEFAULT_HARD_CEILING_MS
+    const spawnVy = opts.spawnVelocityY ?? DEFAULT_SPAWN_VELOCITY_Y
+    const settleThreshold = opts.velocitySettleThreshold ?? DEFAULT_VELOCITY_SETTLE
+
+    let elapsedMs = 0
+    const spawned = new Set<string>()
+    const settled = new Set<string>()
+
+    const trySpawn = (entry: PourInDropEntry) => {
+        if (spawned.has(entry.id)) return
+        if (elapsedMs < entry.staggerMs) return
+        const handle = world.getHandleById(entry.id)
+        if (handle === undefined) return
+        world.setPosition(handle, {
+            x: entry.layoutAnchor.x,
+            y: -entry.height - 20,
+        })
+        world.setVelocity(handle, { x: 0, y: spawnVy })
+        spawned.add(entry.id)
+    }
+
+    return (dtMs) => {
+        elapsedMs += dtMs
+
+        for (const entry of entries) trySpawn(entry)
+
+        if (elapsedMs >= hardCeilingMs) return true
+
+        for (const entry of entries) {
+            if (!spawned.has(entry.id) || settled.has(entry.id)) continue
+            const handle = world.getHandleById(entry.id)
+            if (handle === undefined) {
+                settled.add(entry.id)
+                continue
+            }
+            const v = world.getVelocity(handle)
+            const speed = Math.hypot(v.x, v.y)
+            if (speed < settleThreshold && elapsedMs > entry.staggerMs + 100) {
+                settled.add(entry.id)
+            }
+        }
+
+        return entries.every((e) => settled.has(e.id))
+    }
+}

--- a/web/src/transitions/primitives/pourInDrop.ts
+++ b/web/src/transitions/primitives/pourInDrop.ts
@@ -1,4 +1,9 @@
-import type { PhysicsWorld, Viewport } from '../../physics/PhysicsWorld'
+import type {
+    PhysicsHandle,
+    PhysicsWorld,
+    Vec2,
+    Viewport,
+} from '../../physics/PhysicsWorld'
 import type { PrimitiveStep } from './types'
 
 export interface PourInDropEntry {
@@ -11,61 +16,176 @@ export interface PourInDropEntry {
 export interface PourInDropOpts {
     viewport: Viewport
     hardCeilingMs?: number
-    spawnVelocityY?: number
-    velocitySettleThreshold?: number
+    tweenDurationMs?: number
 }
 
-const DEFAULT_HARD_CEILING_MS = 1500
-const DEFAULT_SPAWN_VELOCITY_Y = 4
-const DEFAULT_VELOCITY_SETTLE = 0.2
+const DEFAULT_HARD_CEILING_MS = 2500
+const DEFAULT_TWEEN_DURATION_MS = 600
+const ABOVE_VIEWPORT_PAD = 220
 
+interface CapturedTether {
+    parent: PhysicsHandle
+    length: number
+    anchorA?: Vec2
+}
+
+interface EntryState {
+    handle: PhysicsHandle
+    captured?: CapturedTether
+    startPos: Vec2
+    tweenStartMs: number // -1 until the per-entry stagger has elapsed
+    finalized: boolean
+}
+
+function easeOutCubic(t: number): number {
+    return 1 - Math.pow(1 - t, 3)
+}
+
+/**
+ * Drops new cards into place from above the viewport using a **kinematic
+ * position tween**.
+ *
+ * Why kinematic and not "let gravity + tether do it":
+ *   The default tether stiffness in `PhysicsWorld` (`TETHER_STIFFNESS = 1.75e-5`)
+ *   is calibrated for cards hanging at rest with tiny perturbations. It is too
+ *   soft to decelerate a card that has free-fallen from above the viewport, so
+ *   handing physics the catch produces cards that sail right through their
+ *   layout y and exit the bottom. Driving the position directly (via
+ *   `setStatic`) lets us animate the drop, then hand the body back to physics
+ *   at rest exactly at its anchor where the existing tether will hold it.
+ *
+ * Per-entry flow:
+ *   - Wait `staggerMs` from primitive start.
+ *   - Capture and untether any existing tether (we re-wire it after the tween).
+ *   - `setDragging(handle, true)` — body becomes static, so the tween isn't
+ *     fighting gravity/buoyancy.
+ *   - Position the body just above the viewport at the card's layout x.
+ *   - Each tick, lerp from above-viewport → `layoutAnchor` over
+ *     `tweenDurationMs` with an ease-out-cubic.
+ *   - When the tween completes: `setDragging(false)`, zero the velocity,
+ *     reattach the captured tether (if any).
+ *
+ * Hard-ceiling fallback finalizes every still-in-flight entry at its anchor.
+ */
 export function pourInDrop(
     world: PhysicsWorld,
     entries: readonly PourInDropEntry[],
     opts: PourInDropOpts,
 ): PrimitiveStep {
     const hardCeilingMs = opts.hardCeilingMs ?? DEFAULT_HARD_CEILING_MS
-    const spawnVy = opts.spawnVelocityY ?? DEFAULT_SPAWN_VELOCITY_Y
-    const settleThreshold = opts.velocitySettleThreshold ?? DEFAULT_VELOCITY_SETTLE
+    const tweenDurationMs = opts.tweenDurationMs ?? DEFAULT_TWEEN_DURATION_MS
 
     let elapsedMs = 0
-    const spawned = new Set<string>()
-    const settled = new Set<string>()
+    let preSpawned = false
+    const state = new Map<string, EntryState>()
 
-    const trySpawn = (entry: PourInDropEntry) => {
-        if (spawned.has(entry.id)) return
-        if (elapsedMs < entry.staggerMs) return
-        const handle = world.getHandleById(entry.id)
-        if (handle === undefined) return
-        world.setPosition(handle, {
-            x: entry.layoutAnchor.x,
-            y: -entry.height - 20,
+    // On the primitive's first tick, hide every entry above the viewport
+    // immediately so the cards never flash at their layout positions during
+    // the per-entry stagger delay.
+    const preSpawnAll = () => {
+        for (const entry of entries) {
+            if (state.has(entry.id)) continue
+            const handle = world.getHandleById(entry.id)
+            if (handle === undefined) continue
+
+            let captured: CapturedTether | undefined
+            for (const t of world.listTetherRecords()) {
+                if (t.child !== handle) continue
+                captured = {
+                    parent: t.parent,
+                    length: t.length,
+                    ...(t.anchorA ? { anchorA: { ...t.anchorA } } : {}),
+                }
+                world.untether(t.handle)
+                break
+            }
+
+            const startPos: Vec2 = {
+                x: entry.layoutAnchor.x,
+                y: -entry.height - ABOVE_VIEWPORT_PAD,
+            }
+            world.setDragging(handle, true)
+            world.setPosition(handle, startPos)
+
+            state.set(entry.id, {
+                handle,
+                ...(captured ? { captured } : {}),
+                startPos,
+                tweenStartMs: -1,
+                finalized: false,
+            })
+        }
+    }
+
+    const finalize = (entry: PourInDropEntry, s: EntryState) => {
+        if (s.finalized) return
+        if (!world.has(s.handle)) {
+            s.finalized = true
+            return
+        }
+        world.setPosition(s.handle, entry.layoutAnchor)
+        world.setDragging(s.handle, false)
+        world.setVelocity(s.handle, { x: 0, y: 0 })
+        if (s.captured) {
+            world.tether(
+                s.captured.parent,
+                s.handle,
+                s.captured.length,
+                s.captured.anchorA,
+            )
+        }
+        s.finalized = true
+    }
+
+    const updateEntry = (entry: PourInDropEntry) => {
+        const s = state.get(entry.id)
+        if (!s || s.finalized) return
+        if (!world.has(s.handle)) {
+            s.finalized = true
+            return
+        }
+        // Hold the entry above the viewport until its stagger fires. Anchor
+        // tweenStartMs to the stagger boundary (not the current elapsedMs) so
+        // the tween's first visible tick already shows some progress.
+        if (s.tweenStartMs < 0) {
+            if (elapsedMs < entry.staggerMs) return
+            s.tweenStartMs = entry.staggerMs
+        }
+        const t = Math.min(
+            (elapsedMs - s.tweenStartMs) / tweenDurationMs,
+            1,
+        )
+        if (t >= 1) {
+            finalize(entry, s)
+            return
+        }
+        const eased = easeOutCubic(t)
+        world.setPosition(s.handle, {
+            x: s.startPos.x + (entry.layoutAnchor.x - s.startPos.x) * eased,
+            y: s.startPos.y + (entry.layoutAnchor.y - s.startPos.y) * eased,
         })
-        world.setVelocity(handle, { x: 0, y: spawnVy })
-        spawned.add(entry.id)
     }
 
     return (dtMs) => {
         elapsedMs += dtMs
 
-        for (const entry of entries) trySpawn(entry)
+        if (!preSpawned) {
+            preSpawnAll()
+            preSpawned = true
+        }
+        for (const entry of entries) updateEntry(entry)
 
-        if (elapsedMs >= hardCeilingMs) return true
-
-        for (const entry of entries) {
-            if (!spawned.has(entry.id) || settled.has(entry.id)) continue
-            const handle = world.getHandleById(entry.id)
-            if (handle === undefined) {
-                settled.add(entry.id)
-                continue
+        if (elapsedMs >= hardCeilingMs) {
+            // Emergency finalize anything mid-flight. Entries that never
+            // started (stagger > ceiling) are left alone — their tether is
+            // still attached and the body is untouched.
+            for (const entry of entries) {
+                const s = state.get(entry.id)
+                if (s && !s.finalized) finalize(entry, s)
             }
-            const v = world.getVelocity(handle)
-            const speed = Math.hypot(v.x, v.y)
-            if (speed < settleThreshold && elapsedMs > entry.staggerMs + 100) {
-                settled.add(entry.id)
-            }
+            return true
         }
 
-        return entries.every((e) => settled.has(e.id))
+        return entries.every((e) => state.get(e.id)?.finalized === true)
     }
 }

--- a/web/src/transitions/primitives/stringCutDrop.test.ts
+++ b/web/src/transitions/primitives/stringCutDrop.test.ts
@@ -114,11 +114,92 @@ describe('stringCutDrop (T1)', () => {
     test('translates floor to phantom position so cards can fall past viewport', () => {
         const viewport = { width: 800, height: 600 }
         const world = new PhysicsWorld({ viewport })
+        // Register an uncleared card so the primitive stays mid-flight (and
+        // therefore keeps the phantom floor in place) at the time we observe.
+        world.registerById(
+            'in-flight',
+            { x: 400, y: 200 },
+            { width: 200, height: 100 },
+        )
         const floorBefore = world.getPosition(world.floorHandle).y
-        const step = stringCutDrop(world, [], { viewport })
+        const step = stringCutDrop(world, ['in-flight'], { viewport })
         step(0)
         const floorAfter = world.getPosition(world.floorHandle).y
         expect(floorAfter).toBeGreaterThan(floorBefore)
         expect(floorAfter).toBeGreaterThan(viewport.height)
+    })
+
+    test('only cuts tethers belonging to exiting cards (incoming card stays strung)', () => {
+        const viewport = { width: 800, height: 600 }
+        const world = new PhysicsWorld({ viewport })
+        const exiting = world.registerById(
+            'old',
+            { x: 200, y: 200 },
+            { width: 200, height: 100 },
+        )
+        const incoming = world.registerById(
+            'new',
+            { x: 600, y: 200 },
+            { width: 200, height: 100 },
+        )
+        world.tether(world.ceilingHandle, exiting, 150, { x: 0, y: 0 })
+        world.tether(world.ceilingHandle, incoming, 150, { x: 0, y: 0 })
+
+        const step = stringCutDrop(world, ['old'], { viewport })
+        step(0)
+
+        const remaining = world.listTetherRecords()
+        expect(remaining).toHaveLength(1)
+        expect(remaining[0]?.child).toBe(incoming)
+    })
+
+    test('kicks exiting cards along the buoyancy axis on init', () => {
+        const viewport = { width: 800, height: 600 }
+        const world = new PhysicsWorld({ viewport })
+        const heavy = world.registerById(
+            'h',
+            { x: 200, y: 200 },
+            { width: 200, height: 100 },
+        )
+        const balloon = world.registerById(
+            'b',
+            { x: 600, y: 400 },
+            { width: 200, height: 100 },
+        )
+        world.setBuoyancy(balloon, 'balloon')
+        world.tether(world.ceilingHandle, heavy, 150, { x: 0, y: 0 })
+        world.tether(world.floorHandle, balloon, 150, { x: 0, y: 0 })
+
+        const step = stringCutDrop(world, ['h', 'b'], { viewport })
+        step(0)
+
+        // Heavy gets downward kick (gravity direction).
+        const vh = world.getVelocity(heavy)
+        expect(vh.y).toBeGreaterThan(0)
+        // Balloon gets upward kick (opposite gravity).
+        const vb = world.getVelocity(balloon)
+        expect(vb.y).toBeLessThan(0)
+    })
+
+    test('restores the original floor anchor on completion', () => {
+        const viewport = { width: 800, height: 600 }
+        const world = new PhysicsWorld({ viewport })
+        const floorBefore = world.getAnchor(world.floorHandle)
+
+        const step = stringCutDrop(world, [], {
+            viewport,
+            hardCeilingMs: 50,
+        })
+        // Tick until the primitive returns true (hits hard ceiling with no cards).
+        let elapsed = 0
+        let done = false
+        while (!done && elapsed < 200) {
+            done = step(FIXED_DT_MS)
+            elapsed += FIXED_DT_MS
+        }
+        expect(done).toBe(true)
+        const floorAfter = world.getAnchor(world.floorHandle)
+        expect(floorAfter.x).toBeCloseTo(floorBefore.x, 1)
+        expect(floorAfter.y).toBeCloseTo(floorBefore.y, 1)
     })
 })

--- a/web/src/transitions/primitives/stringCutDrop.test.ts
+++ b/web/src/transitions/primitives/stringCutDrop.test.ts
@@ -1,0 +1,124 @@
+import { describe, test, expect } from 'vitest'
+import { PhysicsWorld } from '../../physics/PhysicsWorld'
+import { stringCutDrop } from './stringCutDrop'
+
+const FIXED_DT_MS = 1000 / 60
+
+function runUntil(step: (dt: number) => boolean, world: PhysicsWorld) {
+    let done = false
+    let frames = 0
+    while (!done && frames < 600) {
+        done = step(FIXED_DT_MS)
+        world.tick(FIXED_DT_MS)
+        frames++
+    }
+    return { done, frames }
+}
+
+describe('stringCutDrop (T1)', () => {
+    test('cuts ceiling tether of a strung card; card falls past the viewport', () => {
+        const viewport = { width: 800, height: 600 }
+        const world = new PhysicsWorld({ viewport })
+        const card = world.registerById(
+            'a',
+            { x: 400, y: 200 },
+            { width: 200, height: 100 },
+        )
+        world.tether(world.ceilingHandle, card, 150, { x: 0, y: 0 })
+        expect(world.listTetherRecords()).toHaveLength(1)
+
+        const step = stringCutDrop(world, ['a'], { viewport })
+
+        // First step performs setup (cuts tether)
+        step(0)
+        expect(world.listTetherRecords()).toHaveLength(0)
+
+        const { done } = runUntil(step, world)
+        expect(done).toBe(true)
+        const final = world.getPosition(card)
+        expect(final.y).toBeGreaterThan(viewport.height)
+    })
+
+    test('preserves card-to-card chain tether (only direct ceiling tether is cut)', () => {
+        const viewport = { width: 800, height: 600 }
+        const world = new PhysicsWorld({ viewport })
+        const parent = world.registerById(
+            'p',
+            { x: 400, y: 200 },
+            { width: 200, height: 100 },
+        )
+        const child = world.registerById(
+            'c',
+            { x: 400, y: 360 },
+            { width: 200, height: 100 },
+        )
+        world.tether(world.ceilingHandle, parent, 150, { x: 0, y: 0 })
+        world.tether(parent, child, 160)
+        expect(world.listTetherRecords()).toHaveLength(2)
+
+        const step = stringCutDrop(world, ['p', 'c'], { viewport })
+        step(0)
+        const remaining = world.listTetherRecords()
+        expect(remaining).toHaveLength(1)
+        expect(remaining[0]?.parent).toBe(parent)
+        expect(remaining[0]?.child).toBe(child)
+    })
+
+    test('balloon rises symmetrically after its floor tether is cut', () => {
+        const viewport = { width: 800, height: 600 }
+        const world = new PhysicsWorld({ viewport })
+        const balloon = world.registerById(
+            'b',
+            { x: 400, y: 400 },
+            { width: 200, height: 100 },
+        )
+        world.setBuoyancy(balloon, 'balloon')
+        world.tether(world.floorHandle, balloon, 150, { x: 0, y: 0 })
+        const startY = world.getPosition(balloon).y
+
+        const step = stringCutDrop(world, ['b'], { viewport, hardCeilingMs: 5000 })
+        step(0)
+        expect(world.listTetherRecords()).toHaveLength(0)
+
+        const { done } = runUntil(step, world)
+        expect(done).toBe(true)
+        const final = world.getPosition(balloon)
+        // Balloon moved upward (lower y) after its floor tether was cut.
+        expect(final.y).toBeLessThan(startY)
+    })
+
+    test('resolves at hard-ceiling timeout even when card has not cleared', () => {
+        const viewport = { width: 800, height: 600 }
+        const world = new PhysicsWorld({ viewport })
+        world.registerById(
+            'stuck',
+            { x: 400, y: 200 },
+            { width: 200, height: 100 },
+        )
+        // No tether — card just falls slowly under gravity.
+
+        const step = stringCutDrop(world, ['stuck'], {
+            viewport,
+            hardCeilingMs: 100,
+        })
+        let elapsed = 0
+        let done = false
+        while (!done && elapsed < 200) {
+            done = step(FIXED_DT_MS)
+            elapsed += FIXED_DT_MS
+        }
+        expect(done).toBe(true)
+        expect(elapsed).toBeGreaterThanOrEqual(100)
+    })
+
+    test('translates floor to phantom position so cards can fall past viewport', () => {
+        const viewport = { width: 800, height: 600 }
+        const world = new PhysicsWorld({ viewport })
+        const floorBefore = world.getPosition(world.floorHandle).y
+        const step = stringCutDrop(world, [], { viewport })
+        step(0)
+        const floorAfter = world.getPosition(world.floorHandle).y
+        expect(floorAfter).toBeGreaterThan(floorBefore)
+        expect(floorAfter).toBeGreaterThan(viewport.height)
+    })
+})

--- a/web/src/transitions/primitives/stringCutDrop.ts
+++ b/web/src/transitions/primitives/stringCutDrop.ts
@@ -1,0 +1,57 @@
+import type { PhysicsWorld, Viewport } from '../../physics/PhysicsWorld'
+import type { PrimitiveStep } from './types'
+
+export interface StringCutDropOpts {
+    viewport: Viewport
+    hardCeilingMs?: number
+}
+
+const DEFAULT_HARD_CEILING_MS = 1200
+const PHANTOM_FLOOR_OFFSET = 200
+
+export function stringCutDrop(
+    world: PhysicsWorld,
+    cardIds: readonly string[],
+    opts: StringCutDropOpts,
+): PrimitiveStep {
+    const hardCeilingMs = opts.hardCeilingMs ?? DEFAULT_HARD_CEILING_MS
+    const { viewport } = opts
+
+    let elapsedMs = 0
+    let initialized = false
+
+    return (dtMs) => {
+        if (!initialized) {
+            // Cut all tethers whose parent is the ceiling or floor.
+            const tethers = world.listTetherRecords()
+            for (const t of tethers) {
+                if (
+                    t.parent === world.ceilingHandle ||
+                    t.parent === world.floorHandle
+                ) {
+                    world.untether(t.handle)
+                }
+            }
+            // Phantom floor: push beyond viewport so cards can exit downward.
+            const floorPos = world.getPosition(world.floorHandle)
+            world.setAnchor(world.floorHandle, {
+                x: floorPos.x,
+                y: viewport.height + PHANTOM_FLOOR_OFFSET,
+            })
+            initialized = true
+        }
+
+        elapsedMs += dtMs
+
+        if (elapsedMs >= hardCeilingMs) return true
+
+        // Per-card completion: heavy cards past viewport-bottom, balloons above -cardHeight.
+        const allCleared = cardIds.every((id) => {
+            const handle = world.getHandleById(id)
+            if (handle === undefined) return true
+            const pos = world.getPosition(handle)
+            return pos.y > viewport.height + 100 || pos.y < -100
+        })
+        return allCleared
+    }
+}

--- a/web/src/transitions/primitives/stringCutDrop.ts
+++ b/web/src/transitions/primitives/stringCutDrop.ts
@@ -1,4 +1,4 @@
-import type { PhysicsWorld, Viewport } from '../../physics/PhysicsWorld'
+import type { PhysicsHandle, PhysicsWorld, Vec2, Viewport } from '../../physics/PhysicsWorld'
 import type { PrimitiveStep } from './types'
 
 export interface StringCutDropOpts {
@@ -6,8 +6,16 @@ export interface StringCutDropOpts {
     hardCeilingMs?: number
 }
 
-const DEFAULT_HARD_CEILING_MS = 1200
-const PHANTOM_FLOOR_OFFSET = 200
+const DEFAULT_HARD_CEILING_MS = 2000
+const PHANTOM_FLOOR_OFFSET = 1000
+// Pad past the viewport edge before a card is considered "cleared". Without
+// this, cards are released the instant their top edge dips below the viewport
+// bottom and the disappear looks abrupt.
+const CLEAR_PAD = 100
+// Velocity kick applied along the buoyancy direction the moment the tether is
+// cut, so exiting cards leave the viewport with momentum rather than slowly
+// peeling away under gravity alone.
+const EXIT_KICK = 10
 
 export function stringCutDrop(
     world: PhysicsWorld,
@@ -19,39 +27,85 @@ export function stringCutDrop(
 
     let elapsedMs = 0
     let initialized = false
+    let savedFloorAnchor: Vec2 | null = null
+    let finalized = false
+
+    const exitingHandles = new Set<PhysicsHandle>()
+
+    const finalize = () => {
+        if (finalized) return
+        finalized = true
+        if (savedFloorAnchor) {
+            world.setAnchor(world.floorHandle, savedFloorAnchor)
+        }
+    }
 
     return (dtMs) => {
         if (!initialized) {
-            // Cut all tethers whose parent is the ceiling or floor.
-            const tethers = world.listTetherRecords()
-            for (const t of tethers) {
+            for (const id of cardIds) {
+                const h = world.getHandleById(id)
+                if (h !== undefined) exitingHandles.add(h)
+            }
+            // Cut only tethers belonging to *exiting* cards whose parent is the
+            // ceiling or floor. Leaves new (incoming) cards' tethers intact so
+            // they remain strung during the transition.
+            for (const t of world.listTetherRecords()) {
                 if (
-                    t.parent === world.ceilingHandle ||
-                    t.parent === world.floorHandle
+                    (t.parent === world.ceilingHandle ||
+                        t.parent === world.floorHandle) &&
+                    exitingHandles.has(t.child)
                 ) {
                     world.untether(t.handle)
                 }
             }
-            // Phantom floor: push beyond viewport so cards can exit downward.
-            const floorPos = world.getPosition(world.floorHandle)
+            // Phantom floor: push beyond viewport so exiting cards can fall
+            // past the visible area. Saved so we can restore on completion —
+            // without this, every subsequent navigation runs with a lowered floor.
+            savedFloorAnchor = world.getAnchor(world.floorHandle)
             world.setAnchor(world.floorHandle, {
-                x: floorPos.x,
+                x: savedFloorAnchor.x,
                 y: viewport.height + PHANTOM_FLOOR_OFFSET,
             })
+            // Snap-kick: launch each exiting card along its buoyancy axis so
+            // the drop feels deliberate rather than lethargic.
+            const g = world.getGravityVector()
+            const gLen = Math.hypot(g.x, g.y)
+            const gx = gLen > 0 ? g.x / gLen : 0
+            const gy = gLen > 0 ? g.y / gLen : 1
+            for (const handle of exitingHandles) {
+                const sign = world.getBuoyancy(handle) === 'balloon' ? -1 : 1
+                const v = world.getVelocity(handle)
+                world.setVelocity(handle, {
+                    x: v.x + gx * EXIT_KICK * sign,
+                    y: v.y + gy * EXIT_KICK * sign,
+                })
+            }
             initialized = true
         }
 
         elapsedMs += dtMs
 
-        if (elapsedMs >= hardCeilingMs) return true
+        if (elapsedMs >= hardCeilingMs) {
+            finalize()
+            return true
+        }
 
-        // Per-card completion: heavy cards past viewport-bottom, balloons above -cardHeight.
+        // A card is "cleared" only when its full bounding box is comfortably
+        // past the viewport edge — top edge >= viewport.height + pad (for heavy
+        // fall) or bottom edge <= -pad (for balloon rise).
         const allCleared = cardIds.every((id) => {
             const handle = world.getHandleById(id)
             if (handle === undefined) return true
             const pos = world.getPosition(handle)
-            return pos.y > viewport.height + 100 || pos.y < -100
+            const size = world.getSize(handle)
+            const top = pos.y - size.height / 2
+            const bottom = pos.y + size.height / 2
+            return top > viewport.height + CLEAR_PAD || bottom < -CLEAR_PAD
         })
-        return allCleared
+        if (allCleared) {
+            finalize()
+            return true
+        }
+        return false
     }
 }

--- a/web/src/transitions/primitives/types.ts
+++ b/web/src/transitions/primitives/types.ts
@@ -1,0 +1,8 @@
+/**
+ * A primitive runner is a state machine driven by external frame ticks.
+ * Each call to step() advances by dtMs and returns `true` once complete.
+ *
+ * The runner is allowed to perform setup work on its first call to step()
+ * (e.g. cut tethers, drop floor, set initial impulses).
+ */
+export type PrimitiveStep = (dtMs: number) => boolean


### PR DESCRIPTION
## Summary

- Introduces `TransitionDirector` — the orchestration layer for physics-driven motion between canvas-mode routes. Dispatch is route-pair-keyed (edge table → PageDef `exit`/`enter` pair → history-direction default).
- Ships three physics primitives: `string-cut-drop` (T1), `pour-in-drop` (T2), `anchor-slide` horizontal (T3); plus `cross-fade` for reduced-motion.
- Refactors `PhysicsCard` into a null-rendering registrar + `PhysicsCardImpl` rendered by a stable `<PhysicsLayer>` at the CanvasLayout level. The director defers `requestUnregister` via the registry's `'exiting'` lifecycle state, so cards survive route unmount through the duration of their exit motion.
- Reduced-motion: `matchMedia('(prefers-reduced-motion: reduce)')` listener; toggled state takes effect on the next transition.

## Notes / deviations

- **Wall removal during anchor-slide is omitted.** The left/right walls aren't exposed as public PhysicsHandles. Cards spawn far enough off-viewport (`viewport.width + 100`) that no visual artifact occurs in practice. Adding a wall-handle API can be a follow-up.
- **Dynamic routes are not yet in the registry.** `/blog/:slug` and `/stuff/flash/:slug` aren't keyed in `pageDefs` — transitions to/from those paths gracefully no-op. Slice 21b will introduce pattern matching.
- **SSR regression — note for follow-up.** `PhysicsCard`'s rendered content no longer appears in the SSG prerender output, because registration happens in `useEffect` which doesn't run during `renderToString`. The pre-hydration paint is blank for cards. Build still succeeds and `data-server-rendered=\"true\"` is still emitted. To fix in a follow-up: either revive a render-once-then-null path during the first render, or use `useSyncExternalStore`'s server snapshot.
- **`physicsHandleRef` / `cardRef` props dropped from PhysicsCard.** The one external consumer (sandbox `Playground` / `Cards`) was updated to query the DOM via `data-card-id`.
- **Stagger order in `pour-in-drop`** is based on `pageDef.cards` document order × 80ms, not on a topological sort of the parent tree. Authors who order roots before children get the intended chain-ripple look. Topological sort is a follow-up.

## Acceptance criteria

- [x] `TransitionDirector` module exists; public surface is `useTransitionContext()` + the `<TransitionDirector pageDefs edges>` provider (wired in `CanvasLayout`).
- [x] History-direction classification (forward / back / sibling) from `useNavigationType()`.
- [x] `string-cut-drop` (T1) cuts direct ceiling/floor tethers, drops phantom floor, balloons rise symmetrically, hybrid cleanup with 1200ms hard ceiling.
- [x] `pour-in-drop` (T2) spawns at layout-x above viewport, downward impulse, slack tether on attach, chain-order stagger, balloon mirror.
- [x] `anchor-slide` (T3 horizontal) ease-out-cubic, both card sets coexist for ~700ms.
- [x] Dispatch resolution order honored: edge → decoupled PageDef → history-direction default.
- [x] T1 exit and T2 enter run in parallel (default forward/back).
- [x] `<PhysicsLayer>` portal renders orphaned cards across route unmount; director controls unregister timing via `markExiting` → `release`.
- [x] `prefers-reduced-motion` → 150ms cross-fade; live `matchMedia` listener wired.
- [x] Dev throws on transition failure (`import.meta.env.DEV`); prod gracefully `console.warn`s and bulk-releases exiting cards.
- [ ] Background R3F canvas unaffected during transitions — left for manual reviewer to verify in dev.
- [x] Tests cover: history-direction classification, dispatch resolution order, T1 ceiling-tether cutting + chain preservation + balloon symmetry, T2 chain-order stagger + spawn position, T3 ease-out curve + direction sign, reduced-motion bypass implicit in `cross-fade` tests, orphaned-card portal survival across navigation (integration test).

## Test plan

```sh
cd web
npm run typecheck   # clean
npm run test        # 284 passing
npm run build       # vite-react-ssg prerender succeeds; data-server-rendered=\"true\" present
```

Then manually in `npm run dev`:
1. Navigate `/` → `/lifelog` → observe T1 (cards fall) + T2 (new cards pour in) running in parallel.
2. Navigate back → mirror direction.
3. Navigate `/lifelog` → `/stuff` (sibling — same nav depth via REPLACE-style nav, otherwise PUSH gets T1+T2) → T3 horizontal slide.
4. Enable reduced-motion in OS settings → all transitions become 150ms fade.
5. Confirm `BackgroundCanvas` WebGL continues rendering through transitions (no flicker).
6. Confirm `StringLayer` tethers redraw correctly during anchor-slide.

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)