### PR TITLE
Slice 21 fix: anchor-slide via tether-anchor tweening (#86)

### DIFF
--- a/web/src/physics/PhysicsWorld.test.ts
+++ b/web/src/physics/PhysicsWorld.test.ts
@@ -631,6 +631,91 @@ describe('PhysicsWorld setSensor', () => {
     })
 })
 
+describe('PhysicsWorld setWallSensor', () => {
+    test('isWallSensor defaults to false for both walls', () => {
+        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
+        expect(world.isWallSensor('left')).toBe(false)
+        expect(world.isWallSensor('right')).toBe(false)
+    })
+
+    test('setWallSensor("left", true) flips only the left wall', () => {
+        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
+        world.setWallSensor('left', true)
+        expect(world.isWallSensor('left')).toBe(true)
+        expect(world.isWallSensor('right')).toBe(false)
+    })
+
+    test('setWallSensor("right", true) flips only the right wall', () => {
+        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
+        world.setWallSensor('right', true)
+        expect(world.isWallSensor('left')).toBe(false)
+        expect(world.isWallSensor('right')).toBe(true)
+    })
+
+    test('setWallSensor restores collision when toggled back to false', () => {
+        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
+        world.setWallSensor('left', true)
+        world.setWallSensor('left', false)
+        expect(world.isWallSensor('left')).toBe(false)
+    })
+})
+
+describe('PhysicsWorld setTetherAnchorA', () => {
+    test('updates the stored anchorA in listTetherRecords', () => {
+        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
+        const ceilingPos = world.getPosition(world.ceilingHandle)
+        const child = world.register({ x: 200, y: 150 }, { width: 80, height: 40 })
+        const th = world.tether(world.ceilingHandle, child, 150, {
+            x: 200 - ceilingPos.x,
+            y: 0 - ceilingPos.y,
+        })
+        const newAnchor = { x: -300 - ceilingPos.x, y: 0 - ceilingPos.y }
+        world.setTetherAnchorA(th, newAnchor)
+        const rec = world.listTetherRecords().find((r) => r.handle === th)
+        expect(rec).toBeDefined()
+        expect(rec!.anchorA).toEqual(newAnchor)
+    })
+
+    test('shifts the rope origin reported by getTethers', () => {
+        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
+        const ceilingPos = world.getPosition(world.ceilingHandle)
+        const child = world.register({ x: 200, y: 150 }, { width: 80, height: 40 })
+        const th = world.tether(world.ceilingHandle, child, 150, {
+            x: 200 - ceilingPos.x,
+            y: 0 - ceilingPos.y,
+        })
+        // Move rope origin to x=600 in world space (relative to ceiling centre)
+        world.setTetherAnchorA(th, { x: 600 - ceilingPos.x, y: 0 - ceilingPos.y })
+        const view = world.getTethers()[0]!
+        expect(view.parentPos.x).toBeCloseTo(600, 5)
+        expect(view.parentPos.y).toBeCloseTo(0, 5)
+    })
+
+    test('rope force pulls the child toward the new origin after a tick', () => {
+        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
+        const ceilingPos = world.getPosition(world.ceilingHandle)
+        const child = world.register({ x: 200, y: 200 }, { width: 80, height: 40 })
+        const th = world.tether(world.ceilingHandle, child, 50, {
+            x: 200 - ceilingPos.x,
+            y: 0 - ceilingPos.y,
+        })
+        // Settle near (200, ~50 below 0)
+        for (let i = 0; i < 200; i++) world.tick(FIXED_DT_MS)
+        const before = world.getPosition(child)
+        expect(Math.abs(before.x - 200)).toBeLessThan(20)
+        // Now move the rope origin to x=600. Child should drift rightward over time.
+        world.setTetherAnchorA(th, { x: 600 - ceilingPos.x, y: 0 - ceilingPos.y })
+        for (let i = 0; i < 200; i++) world.tick(FIXED_DT_MS)
+        const after = world.getPosition(child)
+        expect(after.x).toBeGreaterThan(before.x + 100)
+    })
+
+    test('throws for an unknown tether handle', () => {
+        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
+        expect(() => world.setTetherAnchorA(999, { x: 0, y: 0 })).toThrow()
+    })
+})
+
 describe('PhysicsWorld setStatic', () => {
     test('setStatic throws for an unknown handle', () => {
         const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })

--- a/web/src/physics/PhysicsWorld.ts
+++ b/web/src/physics/PhysicsWorld.ts
@@ -511,6 +511,26 @@ export class PhysicsWorld {
         Matter.Body.set(reg.body, 'isSensor', isSensor)
     }
 
+    setWallSensor(side: 'left' | 'right', sensor: boolean): void {
+        const body = side === 'left' ? this._leftWall : this._rightWall
+        Matter.Body.set(body, 'isSensor', sensor)
+    }
+
+    isWallSensor(side: 'left' | 'right'): boolean {
+        const body = side === 'left' ? this._leftWall : this._rightWall
+        return body.isSensor === true
+    }
+
+    setTetherAnchorA(th: TetherHandle, anchorA: Vec2): void {
+        const rec = this.tethers.get(th)
+        if (!rec) throw new Error(`PhysicsWorld: unknown tether handle ${th}`)
+        const constraint = this.links.get(rec.linkHandle)
+        if (!constraint) throw new Error(`PhysicsWorld: tether ${th} has no constraint`)
+        const next = { x: anchorA.x, y: anchorA.y }
+        rec.anchorA = next
+        constraint.pointA = { x: next.x, y: next.y }
+    }
+
     setStatic(handle: PhysicsHandle, isStatic: boolean): void {
         const reg = this.registrations.get(handle)
         if (!reg) throw new Error(`PhysicsWorld: unknown handle ${handle}`)

--- a/web/src/transitions/primitives/anchorSlide.test.ts
+++ b/web/src/transitions/primitives/anchorSlide.test.ts
@@ -1,139 +1,133 @@
 import { describe, test, expect } from 'vitest'
-import { PhysicsWorld } from '../../physics/PhysicsWorld'
+import { PhysicsWorld, type PhysicsHandle } from '../../physics/PhysicsWorld'
 import { anchorSlide } from './anchorSlide'
 
-describe('anchorSlide (T3) — horizontal', () => {
-    test('translates from-card horizontally off-viewport over duration', () => {
+const FIXED_DT_MS = 1000 / 60
+const DURATION_MS = 700
+
+/**
+ * Drive the slide step to completion using fixed-dt physics ticks between
+ * frames. Real TransitionDirector uses requestAnimationFrame, but for the
+ * test we step both the primitive and the world at a constant cadence so
+ * the physics body has a chance to respond to tether-origin tweens.
+ */
+function runToCompletion(
+    world: PhysicsWorld,
+    step: ReturnType<typeof anchorSlide>,
+    durationMs = DURATION_MS,
+) {
+    const frames = Math.ceil((durationMs * 1.05) / FIXED_DT_MS)
+    let done = false
+    for (let i = 0; i < frames; i++) {
+        done = step(FIXED_DT_MS)
+        world.tick(FIXED_DT_MS)
+        if (done) break
+    }
+    return done
+}
+
+function stringCard(
+    world: PhysicsWorld,
+    id: string,
+    layoutAnchor: { x: number; y: number },
+    tetherLen = 150,
+): PhysicsHandle {
+    const ceilingPos = world.getPosition(world.ceilingHandle)
+    const handle = world.registerById(id, layoutAnchor, {
+        width: 200,
+        height: 100,
+    })
+    world.tether(world.ceilingHandle, handle, tetherLen, {
+        x: layoutAnchor.x - ceilingPos.x,
+        y: layoutAnchor.y - tetherLen - ceilingPos.y,
+    })
+    return handle
+}
+
+describe('anchorSlide (T3) — horizontal, tether-driven', () => {
+    test('from-card with stiff tether translates toward off-viewport on -sign side', () => {
         const viewport = { width: 800, height: 600 }
         const world = new PhysicsWorld({ viewport })
-        const a = world.registerById(
-            'a',
-            { x: 400, y: 300 },
-            { width: 200, height: 100 },
-        )
+        const handle = stringCard(world, 'a', { x: 400, y: 200 })
+        const start = world.getPosition(handle)
 
         const step = anchorSlide(
             world,
             { fromIds: ['a'], toIds: [] },
-            {
-                axis: 'horizontal',
-                sign: 1,
-                durationMs: 700,
-                viewport,
-            },
+            { axis: 'horizontal', sign: 1, durationMs: DURATION_MS, viewport },
         )
 
-        step(0) // captures initial positions
-        const start = world.getPosition(a)
-        expect(start.x).toBeCloseTo(400, 1)
-
-        // Halfway through duration
-        step(350)
-        const mid = world.getPosition(a)
-        // sign=+1, fromCard exits in axis × -sign direction = leftward (negative x)
-        expect(mid.x).toBeLessThan(start.x)
-
-        // After full duration
-        const done = step(350)
+        const done = runToCompletion(world, step)
         expect(done).toBe(true)
-        const final = world.getPosition(a)
-        // Final position is off-viewport on the leftward side
-        expect(final.x).toBeLessThanOrEqual(-100)
+        const final = world.getPosition(handle)
+        // sign=+1, from-card exits in -sign direction (leftward) — should clear viewport
+        expect(final.x).toBeLessThan(0)
+        expect(final.x).toBeLessThan(start.x)
     })
 
     test('sign=-1 flips direction (from-card exits to the right)', () => {
         const viewport = { width: 800, height: 600 }
         const world = new PhysicsWorld({ viewport })
-        const a = world.registerById(
-            'a',
-            { x: 400, y: 300 },
-            { width: 200, height: 100 },
-        )
+        const handle = stringCard(world, 'a', { x: 400, y: 200 })
 
         const step = anchorSlide(
             world,
             { fromIds: ['a'], toIds: [] },
-            {
-                axis: 'horizontal',
-                sign: -1,
-                durationMs: 700,
-                viewport,
-            },
+            { axis: 'horizontal', sign: -1, durationMs: DURATION_MS, viewport },
         )
 
-        step(0)
-        step(700)
-        const final = world.getPosition(a)
-        // With sign=-1, fromCard exits in axis × -sign = rightward (positive x)
+        runToCompletion(world, step)
+        const final = world.getPosition(handle)
         expect(final.x).toBeGreaterThan(viewport.width)
     })
 
-    test('to-card enters from origin side toward its layout position', () => {
+    test('to-card enters from origin side and arrives near layout', () => {
         const viewport = { width: 800, height: 600 }
         const world = new PhysicsWorld({ viewport })
-        const b = world.registerById(
-            'b',
-            { x: 400, y: 300 },
-            { width: 200, height: 100 },
-        )
+        const handle = stringCard(world, 'b', { x: 400, y: 200 })
 
         const step = anchorSlide(
             world,
             { fromIds: [], toIds: ['b'] },
-            {
-                axis: 'horizontal',
-                sign: 1,
-                durationMs: 700,
-                viewport,
-            },
+            { axis: 'horizontal', sign: 1, durationMs: DURATION_MS, viewport },
         )
 
+        // After init, the tether origin should be off-screen on the origin
+        // side (left), so the card gets yanked leftward immediately.
         step(0)
-        // toCard with sign=+1: enters from origin side (left) — initial position pushed off-screen left
-        const initialPos = world.getPosition(b)
-        expect(initialPos.x).toBeLessThanOrEqual(-100)
+        world.tick(FIXED_DT_MS)
+        expect(world.getPosition(handle).x).toBeLessThan(400)
 
-        // At end, reaches its layout position
-        step(700)
-        const final = world.getPosition(b)
-        expect(final.x).toBeCloseTo(400, 1)
+        runToCompletion(world, step)
+        // After the slide ends, the body keeps pendulum-settling toward
+        // the rope origin under continued physics. Real app behaviour —
+        // TransitionDirector returns, but the physics loop ticks on.
+        for (let i = 0; i < 600; i++) world.tick(FIXED_DT_MS)
+        const final = world.getPosition(handle)
+        // Pendulum landing — within a tether length of the layout anchor x
+        expect(Math.abs(final.x - 400)).toBeLessThan(150)
     })
 
-    test('follows ease-out-cubic curve (front-loaded motion)', () => {
+    test('detached (untethered) cards are skipped without throwing', () => {
         const viewport = { width: 800, height: 600 }
         const world = new PhysicsWorld({ viewport })
-        const a = world.registerById(
+        const handle = world.registerById(
             'a',
             { x: 400, y: 300 },
             { width: 200, height: 100 },
         )
+        const start = world.getPosition(handle)
 
         const step = anchorSlide(
             world,
             { fromIds: ['a'], toIds: [] },
-            {
-                axis: 'horizontal',
-                sign: 1,
-                durationMs: 1000,
-                viewport,
-            },
+            { axis: 'horizontal', sign: 1, durationMs: DURATION_MS, viewport },
         )
 
-        step(0)
-        const start = world.getPosition(a).x
-        step(250) // t=0.25
-        const at25 = world.getPosition(a).x
-        step(250) // t=0.50
-        const at50 = world.getPosition(a).x
-
-        // Distance from start at t=0.5 — eased value at 0.5 is 1 - (1-0.5)^3 = 1 - 0.125 = 0.875
-        const totalDistance = Math.abs(start - (start - (viewport.width + 200)))
-        const distance25 = Math.abs(start - at25)
-        const distance50 = Math.abs(start - at50)
-        // Eased at t=0.25 → 1 - (0.75)^3 ≈ 0.578 — more than half of 0.875
-        expect(distance25 / distance50).toBeGreaterThan(0.5)
-        // And the 0.25-progress is much more than linear 0.25 (which would give 0.25/0.5 = 0.5)
-        expect(distance25 / totalDistance).toBeGreaterThan(0.4)
+        expect(() => runToCompletion(world, step)).not.toThrow()
+        // Untethered card is left to gravity; horizontal position roughly unchanged
+        const final = world.getPosition(handle)
+        expect(Math.abs(final.x - start.x)).toBeLessThan(50)
     })
 
     test('handles empty from/to lists without error', () => {
@@ -143,12 +137,7 @@ describe('anchorSlide (T3) — horizontal', () => {
         const step = anchorSlide(
             world,
             { fromIds: [], toIds: [] },
-            {
-                axis: 'horizontal',
-                sign: 1,
-                durationMs: 100,
-                viewport,
-            },
+            { axis: 'horizontal', sign: 1, durationMs: 100, viewport },
         )
 
         step(0)
@@ -156,82 +145,138 @@ describe('anchorSlide (T3) — horizontal', () => {
         expect(done).toBe(true)
     })
 
-    test('to-card tether is captured on init and restored on completion', () => {
+    test('pendulum signature: from-card swings on the y-axis as it slides', () => {
         const viewport = { width: 800, height: 600 }
         const world = new PhysicsWorld({ viewport })
-        const b = world.registerById(
-            'b',
-            { x: 400, y: 300 },
-            { width: 200, height: 100 },
+        const handle = stringCard(world, 'a', { x: 400, y: 250 }, 150)
+        // Let the rope settle to its hanging equilibrium before the slide.
+        for (let i = 0; i < 60; i++) world.tick(FIXED_DT_MS)
+        const y0 = world.getPosition(handle).y
+
+        const step = anchorSlide(
+            world,
+            { fromIds: ['a'], toIds: [] },
+            { axis: 'horizontal', sign: 1, durationMs: DURATION_MS, viewport },
         )
-        const TETHER_LEN = 250
-        world.tether(world.ceilingHandle, b, TETHER_LEN)
-        expect(
-            world.listTetherRecords().filter((t) => t.child === b),
-        ).toHaveLength(1)
+
+        let maxYDelta = 0
+        const frames = Math.ceil((DURATION_MS * 1.05) / FIXED_DT_MS)
+        for (let i = 0; i < frames; i++) {
+            const done = step(FIXED_DT_MS)
+            world.tick(FIXED_DT_MS)
+            const y = world.getPosition(handle).y
+            maxYDelta = Math.max(maxYDelta, Math.abs(y - y0))
+            if (done) break
+        }
+        // A dynamic body lagging behind a fast-moving rope origin does not
+        // travel in a perfectly straight horizontal line; it pendulums.
+        // Threshold is conservative; observed deltas in practice are larger.
+        expect(maxYDelta).toBeGreaterThan(2)
+    })
+
+    test('destination-side wall is sensor during the slide and restored after', () => {
+        const viewport = { width: 800, height: 600 }
+        const world = new PhysicsWorld({ viewport })
+        stringCard(world, 'a', { x: 400, y: 200 })
+
+        expect(world.isWallSensor('left')).toBe(false)
+        expect(world.isWallSensor('right')).toBe(false)
+
+        const step = anchorSlide(
+            world,
+            { fromIds: ['a'], toIds: [] },
+            { axis: 'horizontal', sign: 1, durationMs: DURATION_MS, viewport },
+        )
+
+        step(0)
+        // sign=+1 → from-card exits leftward → left wall becomes sensor
+        expect(world.isWallSensor('left')).toBe(true)
+        expect(world.isWallSensor('right')).toBe(false)
+
+        runToCompletion(world, step)
+        expect(world.isWallSensor('left')).toBe(false)
+        expect(world.isWallSensor('right')).toBe(false)
+    })
+
+    test('sign=-1 makes the right wall the sensor', () => {
+        const viewport = { width: 800, height: 600 }
+        const world = new PhysicsWorld({ viewport })
+        stringCard(world, 'a', { x: 400, y: 200 })
+
+        const step = anchorSlide(
+            world,
+            { fromIds: ['a'], toIds: [] },
+            { axis: 'horizontal', sign: -1, durationMs: DURATION_MS, viewport },
+        )
+
+        step(0)
+        expect(world.isWallSensor('right')).toBe(true)
+        expect(world.isWallSensor('left')).toBe(false)
+
+        runToCompletion(world, step)
+        expect(world.isWallSensor('right')).toBe(false)
+    })
+
+    test("to-card's tether stays continuously attached and ends at original anchor", () => {
+        const viewport = { width: 800, height: 600 }
+        const world = new PhysicsWorld({ viewport })
+        const handle = stringCard(world, 'b', { x: 400, y: 200 }, 150)
+        const ceilingPos = world.getPosition(world.ceilingHandle)
+        const originalAnchor = { x: 400 - ceilingPos.x, y: 50 - ceilingPos.y }
+
+        // Sanity: anchorA recorded matches what we wired
+        const recBefore = world
+            .listTetherRecords()
+            .find((r) => r.child === handle)!
+        expect(recBefore.anchorA?.x).toBeCloseTo(originalAnchor.x, 5)
+        expect(recBefore.anchorA?.y).toBeCloseTo(originalAnchor.y, 5)
 
         const step = anchorSlide(
             world,
             { fromIds: [], toIds: ['b'] },
-            {
-                axis: 'horizontal',
-                sign: 1,
-                durationMs: 700,
-                viewport,
-            },
+            { axis: 'horizontal', sign: 1, durationMs: DURATION_MS, viewport },
         )
 
-        // After step(0), the tether should be detached so StringLayer
-        // doesn't draw a long diagonal string while the card slides in.
-        step(0)
-        expect(
-            world.listTetherRecords().filter((t) => t.child === b),
-        ).toHaveLength(0)
+        // Walk through the slide and confirm the tether is never removed.
+        const frames = Math.ceil((DURATION_MS * 1.05) / FIXED_DT_MS)
+        for (let i = 0; i < frames; i++) {
+            const done = step(FIXED_DT_MS)
+            world.tick(FIXED_DT_MS)
+            expect(
+                world
+                    .listTetherRecords()
+                    .filter((r) => r.child === handle).length,
+            ).toBe(1)
+            if (done) break
+        }
 
-        // After completion, the tether should be re-attached with the
-        // original length so the card resumes hanging at its layout anchor.
-        step(700)
-        const restored = world
+        // At completion, anchorA is restored exactly.
+        const recAfter = world
             .listTetherRecords()
-            .filter((t) => t.child === b)
-        expect(restored).toHaveLength(1)
-        expect(restored[0]!.length).toBe(TETHER_LEN)
-        expect(restored[0]!.parent).toBe(world.ceilingHandle)
+            .find((r) => r.child === handle)!
+        expect(recAfter.anchorA?.x).toBeCloseTo(originalAnchor.x, 5)
+        expect(recAfter.anchorA?.y).toBeCloseTo(originalAnchor.y, 5)
     })
 
-    test('from-card tether is captured on init and NOT restored (card is dying)', () => {
+    test('from-card tether is left intact for TransitionDirector to release', () => {
         const viewport = { width: 800, height: 600 }
         const world = new PhysicsWorld({ viewport })
-        const a = world.registerById(
-            'a',
-            { x: 400, y: 300 },
-            { width: 200, height: 100 },
-        )
-        world.tether(world.ceilingHandle, a, 250)
+        const handle = stringCard(world, 'a', { x: 400, y: 200 })
         expect(
-            world.listTetherRecords().filter((t) => t.child === a),
+            world.listTetherRecords().filter((r) => r.child === handle),
         ).toHaveLength(1)
 
         const step = anchorSlide(
             world,
             { fromIds: ['a'], toIds: [] },
-            {
-                axis: 'horizontal',
-                sign: 1,
-                durationMs: 700,
-                viewport,
-            },
+            { axis: 'horizontal', sign: 1, durationMs: DURATION_MS, viewport },
         )
 
-        step(0)
+        runToCompletion(world, step)
+        // Tether is NOT cut by anchorSlide; TransitionDirector calls
+        // registry.release next, which unregisters the body (tether goes with it).
         expect(
-            world.listTetherRecords().filter((t) => t.child === a),
-        ).toHaveLength(0)
-
-        step(700)
-        // From-card stays untethered — TransitionDirector releases it next.
-        expect(
-            world.listTetherRecords().filter((t) => t.child === a),
-        ).toHaveLength(0)
+            world.listTetherRecords().filter((r) => r.child === handle),
+        ).toHaveLength(1)
     })
 })

--- a/web/src/transitions/primitives/anchorSlide.ts
+++ b/web/src/transitions/primitives/anchorSlide.ts
@@ -1,6 +1,7 @@
 import type {
     PhysicsHandle,
     PhysicsWorld,
+    TetherHandle,
     Vec2,
     Viewport,
 } from '../../physics/PhysicsWorld'
@@ -20,40 +21,49 @@ export interface AnchorSlideOpts {
 
 const OFFSCREEN_PAD = 100
 
-interface CapturedTether {
-    parent: PhysicsHandle
-    length: number
-    anchorA?: Vec2
+interface TweenSpec {
+    th: TetherHandle
+    start: Vec2
+    end: Vec2
 }
 
 function easeOutCubic(t: number): number {
     return 1 - Math.pow(1 - t, 3)
 }
 
-/**
- * Untether the first record where `child === handle` and return its spec
- * (parent + length + optional anchorA). Returns undefined if the card has
- * no tether. Mirrors `pourInDrop`'s capture pattern so StringLayer doesn't
- * draw a long diagonal string from the original parent anchor to the
- * sliding card.
- */
-function captureAndUntether(
+function findTetherByChild(
     world: PhysicsWorld,
     handle: PhysicsHandle,
-): CapturedTether | undefined {
+):
+    | {
+          handle: TetherHandle
+          anchorA: Vec2
+      }
+    | undefined {
     for (const t of world.listTetherRecords()) {
         if (t.child !== handle) continue
-        const captured: CapturedTether = {
-            parent: t.parent,
-            length: t.length,
-            ...(t.anchorA ? { anchorA: { ...t.anchorA } } : {}),
-        }
-        world.untether(t.handle)
-        return captured
+        const anchorA: Vec2 = t.anchorA ? { ...t.anchorA } : { x: 0, y: 0 }
+        return { handle: t.handle, anchorA }
     }
     return undefined
 }
 
+/**
+ * Coupled cross-route transition (T3 horizontal / T4 vertical).
+ *
+ * Cards remain *dynamic* throughout the slide. Each strung card's tether
+ * origin (body-local `anchorA` on the rope's parent body) is tween'd along
+ * `axis × -sign`, and the existing pull-only rope force drags the card
+ * naturally. This preserves a slight pendulum swing that the previous
+ * kinematic implementation flattened.
+ *
+ * Wall on the side motion crosses is put in sensor mode for the duration,
+ * so dynamic cards pass through without collision-resolution impulses.
+ *
+ * Cards without a tether (detached / free cards) are skipped — anchorSlide
+ * is for *strung* cards per the PRD. From-card tethers are left intact;
+ * TransitionDirector unregisters those bodies next via `registry.release`.
+ */
 export function anchorSlide(
     world: PhysicsWorld,
     targets: AnchorSlideTargets,
@@ -63,61 +73,54 @@ export function anchorSlide(
     let elapsedMs = 0
     let initialized = false
 
-    const fromInitial = new Map<string, Vec2>()
-    const fromFinal = new Map<string, Vec2>()
-    const toInitial = new Map<string, Vec2>()
-    const toLayout = new Map<string, Vec2>()
-    // To-card tethers captured on init are re-attached at completion so the
-    // card resumes hanging at its layout anchor. From-card tethers are
-    // captured-and-discarded — the cards are about to be released by
-    // TransitionDirector when the slide ends.
-    const toCaptured = new Map<string, CapturedTether>()
+    const tweens: TweenSpec[] = []
+    let destinationSide: 'left' | 'right' | null = null
 
     const horizontalSpan = viewport.width + OFFSCREEN_PAD
     const verticalSpan = viewport.height + OFFSCREEN_PAD
 
-    const offsetFor = (direction: -1 | 1) => {
-        if (axis === 'horizontal') {
-            return { x: direction * horizontalSpan, y: 0 }
-        }
-        return { x: 0, y: direction * verticalSpan }
-    }
+    // Motion direction in world-space (axis × -sign)
+    const offset: Vec2 =
+        axis === 'horizontal'
+            ? { x: -sign * horizontalSpan, y: 0 }
+            : { x: 0, y: -sign * verticalSpan }
 
     return (dtMs) => {
         if (!initialized) {
+            if (axis === 'horizontal') {
+                destinationSide = sign === 1 ? 'left' : 'right'
+                world.setWallSensor(destinationSide, true)
+            }
+
             for (const id of targets.fromIds) {
                 const handle = world.getHandleById(id)
                 if (handle === undefined) continue
-                captureAndUntether(world, handle)
-                const pos = world.getPosition(handle)
-                const start = { x: pos.x, y: pos.y }
-                fromInitial.set(id, start)
-                // From-card exits in axis × -sign direction
-                const exitOffset = offsetFor((-sign) as -1 | 1)
-                fromFinal.set(id, {
-                    x: start.x + exitOffset.x,
-                    y: start.y + exitOffset.y,
+                const t = findTetherByChild(world, handle)
+                if (!t) continue
+                tweens.push({
+                    th: t.handle,
+                    start: { ...t.anchorA },
+                    end: { x: t.anchorA.x + offset.x, y: t.anchorA.y + offset.y },
                 })
-                world.setDragging(handle, true)
             }
+
             for (const id of targets.toIds) {
                 const handle = world.getHandleById(id)
                 if (handle === undefined) continue
-                const captured = captureAndUntether(world, handle)
-                if (captured) toCaptured.set(id, captured)
-                const pos = world.getPosition(handle)
-                const layout = { x: pos.x, y: pos.y }
-                toLayout.set(id, layout)
-                // To-card enters from axis × -sign direction (origin side)
-                const enterOffset = offsetFor((-sign) as -1 | 1)
-                const start = {
-                    x: layout.x + enterOffset.x,
-                    y: layout.y + enterOffset.y,
+                const t = findTetherByChild(world, handle)
+                if (!t) continue
+                const startAnchor: Vec2 = {
+                    x: t.anchorA.x + offset.x,
+                    y: t.anchorA.y + offset.y,
                 }
-                toInitial.set(id, start)
-                world.setDragging(handle, true)
-                world.setPosition(handle, start)
+                world.setTetherAnchorA(t.handle, startAnchor)
+                tweens.push({
+                    th: t.handle,
+                    start: startAnchor,
+                    end: { ...t.anchorA },
+                })
             }
+
             initialized = true
         }
 
@@ -125,50 +128,21 @@ export function anchorSlide(
         const tRaw = Math.min(elapsedMs / durationMs, 1)
         const eased = easeOutCubic(tRaw)
 
-        for (const id of targets.fromIds) {
-            const handle = world.getHandleById(id)
-            if (handle === undefined) continue
-            const a = fromInitial.get(id)
-            const b = fromFinal.get(id)
-            if (!a || !b) continue
-            world.setPosition(handle, {
-                x: a.x + (b.x - a.x) * eased,
-                y: a.y + (b.y - a.y) * eased,
-            })
-        }
-        for (const id of targets.toIds) {
-            const handle = world.getHandleById(id)
-            if (handle === undefined) continue
-            const a = toInitial.get(id)
-            const b = toLayout.get(id)
-            if (!a || !b) continue
-            world.setPosition(handle, {
-                x: a.x + (b.x - a.x) * eased,
-                y: a.y + (b.y - a.y) * eased,
+        for (const tw of tweens) {
+            world.setTetherAnchorA(tw.th, {
+                x: tw.start.x + (tw.end.x - tw.start.x) * eased,
+                y: tw.start.y + (tw.end.y - tw.start.y) * eased,
             })
         }
 
         if (tRaw >= 1) {
-            for (const id of targets.fromIds) {
-                const handle = world.getHandleById(id)
-                if (handle === undefined) continue
-                world.setDragging(handle, false)
+            // Snap exactly to the end values so to-cards land on their
+            // original anchor and from-cards' rope origins finish off-screen
+            // (purely cosmetic since those bodies are released next tick).
+            for (const tw of tweens) {
+                world.setTetherAnchorA(tw.th, { x: tw.end.x, y: tw.end.y })
             }
-            for (const id of targets.toIds) {
-                const handle = world.getHandleById(id)
-                if (handle === undefined) continue
-                world.setDragging(handle, false)
-                world.setVelocity(handle, { x: 0, y: 0 })
-                const captured = toCaptured.get(id)
-                if (captured) {
-                    world.tether(
-                        captured.parent,
-                        handle,
-                        captured.length,
-                        captured.anchorA,
-                    )
-                }
-            }
+            if (destinationSide) world.setWallSensor(destinationSide, false)
             return true
         }
         return false


### PR DESCRIPTION
## Summary

- Replace slice 21's kinematic anchor-slide (`setDragging` + per-frame `setPosition`) with the PRD-spec mechanism: cards remain *dynamic* bodies and their **tether origin** is tween'd, so the existing pull-only rope force drags them naturally.
- Add `PhysicsWorld.setTetherAnchorA(th, anchorA)` so each card's rope origin can move independently — necessary because `fromIds` and `toIds` share the ceiling/floor body but need to slide in opposite directions.
- Add `PhysicsWorld.setWallSensor(side, sensor)` (+ `isWallSensor` for tests) — destination-side wall becomes a sensor for the slide duration so dynamic cards pass through without collision-resolution impulses; restored to solid on completion.

## Notes / deviations

- Picked **per-tether anchorA** over the issue's "move the ceiling body itself" alternative. The latter is simpler but cannot satisfy the cross-route case where `fromIds` and `toIds` are both strung to the same ceiling and need to move opposite ways — moving the ceiling would lock both groups to the same motion.
- Picked **`setWallSensor(side, sensor)`** over exposing `leftWallHandle` / `rightWallHandle`. Smaller public surface; walls stay internal.
- The to-card's tether is **no longer captured-and-rebuilt** mid-slide; it stays continuously attached, and its `anchorA` is restored exactly on completion. The old per-frame `setPosition` path is fully removed from this file (still used elsewhere for pointer drag).
- Detached (untethered) cards are now **skipped** by `anchorSlide` — per the PRD, this primitive is for strung cards. Previously they were teleported kinematically. In real routes (CardChain layouts) every card is strung, so this is a no-op in practice.

## Acceptance criteria (from #86)

- [x] `PhysicsWorld` exposes a `setWallSensor` method (Option 2 in the issue). `isWallSensor(side)` getter added for test introspection.
- [x] `anchorSlide.ts` no longer calls `setDragging` for kinematic motion (`grep -c setDragging web/src/transitions/primitives/anchorSlide.ts` → 0); uses `setTetherAnchorA` + tether enforcement.
- [x] Destination-side wall is sensor for the slide duration; origin-side stays solid; both restored on complete. Covered by two unit tests.
- [x] `anchorSlide.test.ts` updated — assertions are now physics-tolerant (final positions verified by side-of-viewport, not exact pixels) and use real `world.tick`s between primitive steps.
- [x] New test: from-card with a stiff tether shows non-zero **y-axis** displacement at mid-slide (pendulum signature).
- [ ] Manual verification in `npm run dev` — left for the human reviewer. I confirmed the dev server starts and `/` returns 200 with the expected HTML, but I can't visually verify the pendulum swing or wall-crossing from a CLI session.
- [x] `setDragging` usage removed from `anchorSlide.ts`.

## Test plan

```sh
cd web
npm run typecheck      # clean
npm run test           # 302 tests pass
npm run build          # SSG prerender intact
```

Then manually:

1. `npm run dev` and open the local URL.
2. Navigate between sibling routes (e.g. `/about` ↔ `/blog` ↔ `/portfolio` per the edge table; whichever pair currently dispatches `anchor-slide` horizontally).
3. Watch the strung cards as they slide off / on. Expected:
   - Slight **y-axis swing** during the motion — the card lags the rope origin, the rope yanks it back, pendulum-settle.
   - **No snag** at the viewport edge — the destination-side wall is sensor mode for the duration; cards pass through cleanly.
   - Cards **land near their layout anchors** after the slide; small overshoot is expected (pendulum damping), but no spring-back from a hard target.
4. Enable `prefers-reduced-motion: reduce` in DevTools and re-navigate — should fall back to the reduced-motion cross-fade unchanged.

Closes #86