### PR TITLE
Slice 21b: within-page section pagination + T4 (#81)

### DIFF
--- a/content/blog/2026-05-10-draft-second-card/index.mdx
+++ b/content/blog/2026-05-10-draft-second-card/index.mdx
@@ -1,0 +1,11 @@
+---
+title: On notation
+description: A short reflection on why naming things — files, functions, axes — is half the work of doing them.
+date: "2026-05-10"
+tags: [craft, writing]
+draft: true
+---
+
+Naming things is half the work of doing them. The other half is doing them, which is easier once they're named.
+
+The discipline is to delay the name only long enough to know what it should be — not so long that you forget what you were doing while you were waiting.

--- a/content/blog/2026-05-11-draft-third-card/index.mdx
+++ b/content/blog/2026-05-11-draft-third-card/index.mdx
@@ -1,0 +1,11 @@
+---
+title: Reading the room
+description: Why interaction design is fundamentally about predicting the next thing someone wants to do, and how that's harder than it sounds.
+date: "2026-05-11"
+tags: [design, ux]
+draft: true
+---
+
+Most interfaces fail not because they're ugly but because they don't predict the next thing the user wants to do.
+
+That prediction is the design. Everything else — typography, color, animation — supports it.

--- a/content/blog/2026-05-12-draft-fourth-card/index.mdx
+++ b/content/blog/2026-05-12-draft-fourth-card/index.mdx
@@ -1,0 +1,9 @@
+---
+title: A small theory of margins
+description: Whitespace isn't decoration — it's the load-bearing element that lets the rest of the page mean something.
+date: "2026-05-12"
+tags: [design, typography]
+draft: true
+---
+
+The most underrated css property is `padding`. The second most underrated is `margin`. The third is the absence of both, used confidently.

--- a/content/blog/2026-05-13-draft-fifth-card/index.mdx
+++ b/content/blog/2026-05-13-draft-fifth-card/index.mdx
@@ -1,0 +1,11 @@
+---
+title: The cost of generality
+description: Building for "any case" is more expensive than building for "this case" — and the cost is usually paid by the next person.
+date: "2026-05-13"
+tags: [engineering, abstractions]
+draft: true
+---
+
+Generality is a tax you pay on day one and your successor pays every day after. Sometimes it's worth it. Often it isn't.
+
+The honest move is usually: build for this case, and refactor toward generality when a second concrete case shows up.

--- a/web/src/layout/sectionLayout.test.ts
+++ b/web/src/layout/sectionLayout.test.ts
@@ -52,8 +52,10 @@ describe('partitionChain', () => {
     })
 
     test('two cards that overflow split into two sections with nav', () => {
-        // Each card 400 tall, viewport 700 tall, NAV_RESERVE ~140 → usable ~560.
-        // Card 1 at y≈80..480 fits; card 2 would need y≈540..940 → overflow → split.
+        // Each card 400 tall, viewport 700 tall, with the inline nav reserve
+        // (~232px for two NAV_CARD_H + 2 CHAIN_GAP + 24 breathing room),
+        // usable shrinks below ~400 → first card alone already overflows after
+        // the gap, so each section gets one content card.
         const sections = partitionChain({
             viewport: DESKTOP,
             cards: items([
@@ -158,7 +160,7 @@ describe('partitionChain', () => {
         expect(sections[1]!.cards.map((c) => c.id)).toEqual(['b', 'c'])
     })
 
-    test('narrow viewport uses a single centered nav card', () => {
+    test('narrow viewport still emits a single next-nav at section 1', () => {
         const sections = partitionChain({
             viewport: NARROW,
             cards: items([
@@ -168,15 +170,31 @@ describe('partitionChain', () => {
             routeKey: '/blog',
         })
 
-        // Section 1 should have exactly one nav card (next), centered.
+        // Section 1 should have exactly one nav card (next).
         expect(sections[0]!.navCards).toHaveLength(1)
-        const nav = sections[0]!.navCards[0]!
-        const anchor = nav.anchor(NARROW)
-        expect(anchor.x).toBeCloseTo(NARROW.width / 2, 0)
-        expect(nav.id).toBe('/blog-nav-next-s1')
+        expect(sections[0]!.navCards[0]!.id).toBe('/blog-nav-next-s1')
     })
 
-    test('desktop nav cards are bottom-corners', () => {
+    test('non-first section without back-nav: head card inherits chain edge', () => {
+        // Author mode with single-card sections — no nav cards emitted
+        // when sectionCount > 1 actually... wait, paginated chains always
+        // emit nav cards. Use unpaginated single section to verify edge
+        // inheritance baseline.
+        const sections = partitionChain({
+            viewport: DESKTOP,
+            cards: items([{ id: 'a', height: 50 }]),
+            routeKey: '/blog',
+        })
+
+        // Single section, no back-nav, head card retains its 'ceiling' parent.
+        expect(sections[0]!.cards[0]!.parent).toBe('ceiling')
+        expect(sections[0]!.navCards).toEqual([])
+    })
+
+    test('paginated: back-nav becomes chain head, first content reattaches to back-nav', () => {
+        // Three cards forced into 3 sections via overflow. Each non-first
+        // section gets a back-nav at the head; the first content card
+        // re-attaches to that back-nav, not to the ceiling directly.
         const sections = partitionChain({
             viewport: DESKTOP,
             cards: items([
@@ -187,21 +205,111 @@ describe('partitionChain', () => {
             routeKey: '/blog',
         })
 
-        const middleNav = sections[1]!.navCards
-        const back = middleNav.find((c) => c.id.includes('back'))!
-        const next = middleNav.find((c) => c.id.includes('next'))!
-        const backA = back.anchor(DESKTOP)
-        const nextA = next.anchor(DESKTOP)
+        expect(sections).toHaveLength(3)
 
-        expect(backA.x).toBeLessThan(DESKTOP.width / 2)
-        expect(nextA.x).toBeGreaterThan(DESKTOP.width / 2)
-        // Same y (bottom inset)
-        expect(backA.y).toBeCloseTo(nextA.y, 0)
-        // Near the bottom
-        expect(backA.y).toBeGreaterThan(DESKTOP.height / 2)
+        // Section 1 (first, no back-nav): a hangs from ceiling.
+        expect(sections[0]!.cards[0]!.parent).toBe('ceiling')
+
+        // Section 2 (middle, has back-nav): back-nav hangs from ceiling,
+        // and b hangs from the back-nav.
+        const s2Back = sections[1]!.navCards.find((c) => c.id.includes('back'))!
+        expect(s2Back.parent).toBe('ceiling')
+        expect(sections[1]!.cards[0]!.parent).toBe(s2Back.id)
+
+        // Section 3 (last, has back-nav): same pattern, c hangs from back-nav.
+        const s3Back = sections[2]!.navCards.find((c) => c.id.includes('back'))!
+        expect(s3Back.parent).toBe('ceiling')
+        expect(sections[2]!.cards[0]!.parent).toBe(s3Back.id)
     })
 
-    test('nav cards are floor-strung with kind=nav', () => {
+    test('paginated: next-nav hangs from last content card and trails to floor', () => {
+        const sections = partitionChain({
+            viewport: DESKTOP,
+            cards: items([
+                { id: 'a', height: 400 },
+                { id: 'b', height: 400 },
+                { id: 'c', height: 400 },
+            ]),
+            routeKey: '/blog',
+        })
+
+        // Section 1 has a next-nav; it hangs from card a and trails to floor.
+        const s1Next = sections[0]!.navCards.find((c) => c.id.includes('next'))!
+        expect(s1Next.parent).toBe('a')
+        expect(s1Next.trail).toBe('floor')
+
+        // Section 2 (middle) also has a next-nav hanging from b with floor trail.
+        const s2Next = sections[1]!.navCards.find((c) => c.id.includes('next'))!
+        expect(s2Next.parent).toBe('b')
+        expect(s2Next.trail).toBe('floor')
+
+        // Section 3 (last) has no next-nav → no floor trail anywhere.
+        const s3Next = sections[2]!.navCards.find((c) => c.id.includes('next'))
+        expect(s3Next).toBeUndefined()
+    })
+
+    test('chain field is the inline ordered render list: [back?, ...content, next?]', () => {
+        const sections = partitionChain({
+            viewport: DESKTOP,
+            cards: items([
+                { id: 'a', height: 400 },
+                { id: 'b', height: 400 },
+                { id: 'c', height: 400 },
+            ]),
+            routeKey: '/blog',
+        })
+
+        // Section 1: no back, content [a], next → chain = [a, next]
+        expect(sections[0]!.chain.map((c) => c.id)).toEqual([
+            'a',
+            '/blog-nav-next-s1',
+        ])
+
+        // Section 2: back, content [b], next → chain = [back, b, next]
+        expect(sections[1]!.chain.map((c) => c.id)).toEqual([
+            '/blog-nav-back-s2',
+            'b',
+            '/blog-nav-next-s2',
+        ])
+
+        // Section 3: back, content [c], no next → chain = [back, c]
+        expect(sections[2]!.chain.map((c) => c.id)).toEqual([
+            '/blog-nav-back-s3',
+            'c',
+        ])
+    })
+
+    test('chain on unpaginated section is just the content cards', () => {
+        const sections = partitionChain({
+            viewport: DESKTOP,
+            cards: items([{ id: 'a', height: 50 }]),
+            routeKey: '/blog',
+        })
+
+        expect(sections[0]!.chain.map((c) => c.id)).toEqual(['a'])
+    })
+
+    test('head-rewrite uses the original chain head parent (gravity-up routes)', () => {
+        // Floor-strung chain: section heads should re-attach to 'floor'
+        // (via back-nav, when present, or directly for section 1).
+        const sections = partitionChain({
+            viewport: DESKTOP,
+            cards: [
+                { card: makeCard('a', { parent: 'floor' }), height: 400 },
+                { card: makeCard('b', { parent: 'a' }), height: 400 },
+            ],
+            routeKey: '/lifelog',
+        })
+
+        expect(sections).toHaveLength(2)
+        // Section 1: no back-nav, a still hangs from floor.
+        expect(sections[0]!.cards[0]!.parent).toBe('floor')
+        // Section 2: back-nav itself hangs from floor.
+        const s2Back = sections[1]!.navCards.find((c) => c.id.includes('back'))!
+        expect(s2Back.parent).toBe('floor')
+    })
+
+    test('nav cards have kind=nav', () => {
         const sections = partitionChain({
             viewport: DESKTOP,
             cards: items([
@@ -213,7 +321,6 @@ describe('partitionChain', () => {
 
         for (const nav of sections.flatMap((s) => s.navCards)) {
             expect(nav.kind).toBe('nav')
-            expect(nav.parent).toBe('floor')
         }
     })
 })

--- a/web/src/layout/sectionLayout.test.ts
+++ b/web/src/layout/sectionLayout.test.ts
@@ -1,0 +1,219 @@
+import { describe, test, expect } from 'vitest'
+import { partitionChain, type ChainItem, type PartitionOptions } from './sectionLayout'
+import type { CardSpec } from '../physics/PageDef'
+
+function makeCard(id: string, overrides: Partial<CardSpec> = {}): CardSpec {
+    return {
+        id,
+        kind: 'blog',
+        parent: 'ceiling',
+        anchor: () => ({ x: 0, y: 0 }),
+        ...overrides,
+    }
+}
+
+function items(specs: { id: string; height: number; spec?: Partial<CardSpec> }[]): ChainItem[] {
+    return specs.map((s, i) => ({
+        card: makeCard(s.id, {
+            // chain: first card's parent is ceiling, subsequent point at previous id
+            parent: i === 0 ? 'ceiling' : specs[i - 1]!.id,
+            ...s.spec,
+        }),
+        height: s.height,
+    }))
+}
+
+const DESKTOP: PartitionOptions['viewport'] = { width: 1024, height: 700 }
+const NARROW: PartitionOptions['viewport'] = { width: 400, height: 800 }
+
+describe('partitionChain', () => {
+    test('empty chain yields a single section with no cards or nav', () => {
+        const sections = partitionChain({
+            viewport: DESKTOP,
+            cards: [],
+            routeKey: '/blog',
+        })
+
+        expect(sections).toHaveLength(1)
+        expect(sections[0]!.cards).toEqual([])
+        expect(sections[0]!.navCards).toEqual([])
+    })
+
+    test('single card under viewport yields one section, no nav', () => {
+        const sections = partitionChain({
+            viewport: DESKTOP,
+            cards: items([{ id: 'a', height: 200 }]),
+            routeKey: '/blog',
+        })
+
+        expect(sections).toHaveLength(1)
+        expect(sections[0]!.cards.map((c) => c.id)).toEqual(['a'])
+        expect(sections[0]!.navCards).toEqual([])
+    })
+
+    test('two cards that overflow split into two sections with nav', () => {
+        // Each card 400 tall, viewport 700 tall, NAV_RESERVE ~140 → usable ~560.
+        // Card 1 at y≈80..480 fits; card 2 would need y≈540..940 → overflow → split.
+        const sections = partitionChain({
+            viewport: DESKTOP,
+            cards: items([
+                { id: 'a', height: 400 },
+                { id: 'b', height: 400 },
+            ]),
+            routeKey: '/blog',
+        })
+
+        expect(sections).toHaveLength(2)
+        expect(sections[0]!.cards.map((c) => c.id)).toEqual(['a'])
+        expect(sections[1]!.cards.map((c) => c.id)).toEqual(['b'])
+        // Section 1 → next only
+        expect(sections[0]!.navCards.map((c) => c.id)).toEqual(['/blog-nav-next-s1'])
+        // Section 2 (last) → back only
+        expect(sections[1]!.navCards.map((c) => c.id)).toEqual(['/blog-nav-back-s2'])
+    })
+
+    test('middle section has both back and next nav cards', () => {
+        const sections = partitionChain({
+            viewport: DESKTOP,
+            cards: items([
+                { id: 'a', height: 400 },
+                { id: 'b', height: 400 },
+                { id: 'c', height: 400 },
+            ]),
+            routeKey: '/blog',
+        })
+
+        expect(sections).toHaveLength(3)
+        expect(sections[1]!.navCards.map((c) => c.id).sort()).toEqual([
+            '/blog-nav-back-s2',
+            '/blog-nav-next-s2',
+        ])
+    })
+
+    test('sectionBreak: after forces split after the marked card', () => {
+        const sections = partitionChain({
+            viewport: DESKTOP,
+            cards: items([
+                { id: 'a', height: 100, spec: { sectionBreak: 'after' } },
+                { id: 'b', height: 100 },
+            ]),
+            routeKey: '/blog',
+        })
+
+        expect(sections).toHaveLength(2)
+        expect(sections[0]!.cards.map((c) => c.id)).toEqual(['a'])
+        expect(sections[1]!.cards.map((c) => c.id)).toEqual(['b'])
+    })
+
+    test('sectionBreak: before forces split before the marked card', () => {
+        const sections = partitionChain({
+            viewport: DESKTOP,
+            cards: items([
+                { id: 'a', height: 100 },
+                { id: 'b', height: 100, spec: { sectionBreak: 'before' } },
+            ]),
+            routeKey: '/blog',
+        })
+
+        expect(sections).toHaveLength(2)
+        expect(sections[0]!.cards.map((c) => c.id)).toEqual(['a'])
+        expect(sections[1]!.cards.map((c) => c.id)).toEqual(['b'])
+    })
+
+    test('maxPerSection caps section length', () => {
+        const sections = partitionChain({
+            viewport: DESKTOP,
+            cards: items([
+                { id: 'a', height: 50 },
+                { id: 'b', height: 50 },
+                { id: 'c', height: 50 },
+                { id: 'd', height: 50 },
+            ]),
+            routeKey: '/blog',
+            maxPerSection: 2,
+        })
+
+        expect(sections).toHaveLength(2)
+        expect(sections[0]!.cards.map((c) => c.id)).toEqual(['a', 'b'])
+        expect(sections[1]!.cards.map((c) => c.id)).toEqual(['c', 'd'])
+    })
+
+    test('author mode bypasses auto-chain heuristic', () => {
+        const sections = partitionChain({
+            viewport: DESKTOP,
+            cards: items([
+                { id: 'a', height: 100 },
+                { id: 'b', height: 100 },
+                { id: 'c', height: 100 },
+            ]),
+            routeKey: '/lifelog',
+            explicitSections: [
+                { cardIds: ['a'] },
+                { cardIds: ['b', 'c'] },
+            ],
+        })
+
+        expect(sections).toHaveLength(2)
+        expect(sections[0]!.cards.map((c) => c.id)).toEqual(['a'])
+        expect(sections[1]!.cards.map((c) => c.id)).toEqual(['b', 'c'])
+    })
+
+    test('narrow viewport uses a single centered nav card', () => {
+        const sections = partitionChain({
+            viewport: NARROW,
+            cards: items([
+                { id: 'a', height: 400 },
+                { id: 'b', height: 400 },
+            ]),
+            routeKey: '/blog',
+        })
+
+        // Section 1 should have exactly one nav card (next), centered.
+        expect(sections[0]!.navCards).toHaveLength(1)
+        const nav = sections[0]!.navCards[0]!
+        const anchor = nav.anchor(NARROW)
+        expect(anchor.x).toBeCloseTo(NARROW.width / 2, 0)
+        expect(nav.id).toBe('/blog-nav-next-s1')
+    })
+
+    test('desktop nav cards are bottom-corners', () => {
+        const sections = partitionChain({
+            viewport: DESKTOP,
+            cards: items([
+                { id: 'a', height: 400 },
+                { id: 'b', height: 400 },
+                { id: 'c', height: 400 },
+            ]),
+            routeKey: '/blog',
+        })
+
+        const middleNav = sections[1]!.navCards
+        const back = middleNav.find((c) => c.id.includes('back'))!
+        const next = middleNav.find((c) => c.id.includes('next'))!
+        const backA = back.anchor(DESKTOP)
+        const nextA = next.anchor(DESKTOP)
+
+        expect(backA.x).toBeLessThan(DESKTOP.width / 2)
+        expect(nextA.x).toBeGreaterThan(DESKTOP.width / 2)
+        // Same y (bottom inset)
+        expect(backA.y).toBeCloseTo(nextA.y, 0)
+        // Near the bottom
+        expect(backA.y).toBeGreaterThan(DESKTOP.height / 2)
+    })
+
+    test('nav cards are floor-strung with kind=nav', () => {
+        const sections = partitionChain({
+            viewport: DESKTOP,
+            cards: items([
+                { id: 'a', height: 400 },
+                { id: 'b', height: 400 },
+            ]),
+            routeKey: '/blog',
+        })
+
+        for (const nav of sections.flatMap((s) => s.navCards)) {
+            expect(nav.kind).toBe('nav')
+            expect(nav.parent).toBe('floor')
+        }
+    })
+})

--- a/web/src/layout/sectionLayout.ts
+++ b/web/src/layout/sectionLayout.ts
@@ -1,6 +1,7 @@
 import type {
     AuthorSectionDef,
     CardSpec,
+    ParentRef,
     PageDef,
 } from '../physics/PageDef'
 import type { Vec2, Viewport } from '../physics/PhysicsWorld'
@@ -8,12 +9,26 @@ import type { Vec2, Viewport } from '../physics/PhysicsWorld'
 export const NAV_CARD_W = 180
 export const NAV_CARD_H = 56
 export const NAV_BREAKPOINT = 600
-export const NAV_BOTTOM_INSET = 80
-export const NAV_TETHER_LEN = 24
 export const CHAIN_TOP = 80
 export const CHAIN_GAP = 60
 
-const NAV_RESERVE = NAV_CARD_H + NAV_BOTTOM_INSET + 24 // small breathing room
+// Fixed insets for inline nav cards — back-nav top edge sits NAV_TOP_INSET
+// below the ceiling, next-nav bottom edge sits NAV_BOTTOM_INSET above the
+// floor. Content fills the middle.
+export const NAV_TOP_INSET = 40
+export const NAV_BOTTOM_INSET = 40
+
+// Reserve vertical budget for inline nav cards (back + next) plus their
+// chain gaps. Slight over-reservation is fine — partitioning never knows
+// up front whether a section will end up at the head or tail of the
+// chain (no back-nav / no next-nav respectively).
+const NAV_RESERVE =
+    NAV_TOP_INSET +
+    NAV_CARD_H +
+    CHAIN_GAP +
+    NAV_CARD_H +
+    NAV_BOTTOM_INSET +
+    24
 
 export interface ChainItem {
     card: CardSpec
@@ -23,8 +38,12 @@ export interface ChainItem {
 export interface SectionLayout {
     sectionIndex: number
     sectionCount: number
+    /** Content cards only — first card's parent rewritten to back-nav id when one exists, else inherits the chain head parent. */
     cards: CardSpec[]
+    /** Nav cards for this section (kind: 'nav'), in chain order: back (if any) then next (if any). */
     navCards: CardSpec[]
+    /** Full inline chain: optional back-nav, content cards, optional next-nav. Parent/trail topology pre-wired. */
+    chain: CardSpec[]
 }
 
 export interface PartitionOptions {
@@ -35,69 +54,80 @@ export interface PartitionOptions {
     explicitSections?: readonly AuthorSectionDef[]
 }
 
-/**
- * Returns the y-coordinate (top edge in physics space) where the nav card row
- * sits — bottom-of-viewport minus the inset.
- */
-function navRowY(viewport: Viewport): number {
-    return viewport.height - NAV_BOTTOM_INSET
-}
-
 function makeNavCard(
     routeKey: string,
     target: 'prev' | 'next',
     sectionIndex: number,
-    layout: 'narrow' | 'desktop-back' | 'desktop-next',
+    parent: ParentRef,
+    trail?: ParentRef,
 ): CardSpec {
     const targetLabel = target === 'prev' ? 'back' : 'next'
     const id = `${routeKey}-nav-${targetLabel}-s${sectionIndex + 1}`
 
-    const anchor = (vp: Viewport): Vec2 => {
-        const y = navRowY(vp)
-        if (layout === 'narrow') {
-            return { x: vp.width / 2, y }
-        }
-        if (layout === 'desktop-back') {
-            return { x: NAV_CARD_W / 2 + 24, y }
-        }
-        return { x: vp.width - NAV_CARD_W / 2 - 24, y }
-    }
+    // Anchor is chain-centered. Routes that lay out a section (e.g.
+    // BlogIndex's layoutSection) override these anchors to position
+    // each card within the section's vertical chain; this default
+    // is the fallback for unsynthesised consumers.
+    const anchor = (vp: Viewport): Vec2 => ({ x: vp.width / 2, y: 0 })
 
-    return { id, kind: 'nav', parent: 'floor', anchor }
+    return trail !== undefined
+        ? { id, kind: 'nav', parent, anchor, trail }
+        : { id, kind: 'nav', parent, anchor }
 }
 
-function navCardsForSection(
+/**
+ * Builds the inline chain for a section: optional back-nav at the head,
+ * the content cards (with parent topology rewired so the head re-attaches
+ * correctly), and optional next-nav at the tail.
+ *
+ * Parent topology:
+ *   - back-nav (if present) → chain head parent (e.g. 'ceiling')
+ *   - first content card → back-nav id if present, else chain head parent
+ *   - subsequent content cards → preserve their original predecessor
+ *   - next-nav (if present) → last content card id, with trail: 'floor'
+ */
+function buildSectionChain(
     routeKey: string,
     sectionIndex: number,
     sectionCount: number,
-    viewport: Viewport,
-): CardSpec[] {
-    if (sectionCount <= 1) return []
+    contentCards: CardSpec[],
+    chainHeadParent: ParentRef,
+): { cards: CardSpec[]; navCards: CardSpec[]; chain: CardSpec[] } {
+    const paginated = sectionCount > 1
+    const showBack = paginated && sectionIndex > 0
+    const showNext = paginated && sectionIndex < sectionCount - 1
 
-    const showBack = sectionIndex > 0
-    const showNext = sectionIndex < sectionCount - 1
-    if (!showBack && !showNext) return []
+    const backNav: CardSpec | null = showBack
+        ? makeNavCard(routeKey, 'prev', sectionIndex, chainHeadParent)
+        : null
 
-    const narrow = viewport.width < NAV_BREAKPOINT
-    const cards: CardSpec[] = []
+    // Content card parent rewiring: head re-attaches to back-nav or chain edge.
+    const headParent: ParentRef = backNav ? backNav.id : chainHeadParent
+    const rewrittenContent: CardSpec[] = contentCards.map((card, i) =>
+        i === 0 ? { ...card, parent: headParent } : card,
+    )
 
-    if (narrow) {
-        // Single nav card centered. If both directions are valid, the partitioner
-        // emits the forward control (the dominant action); back is reachable via
-        // the browser back button. This matches the spec note "single full-width
-        // nav card on narrow viewport".
-        const target: 'prev' | 'next' = showNext ? 'next' : 'prev'
-        cards.push(makeNavCard(routeKey, target, sectionIndex, 'narrow'))
-        return cards
-    }
+    const lastContent = rewrittenContent[rewrittenContent.length - 1]
+    const nextNav: CardSpec | null = showNext && lastContent
+        ? makeNavCard(
+              routeKey,
+              'next',
+              sectionIndex,
+              lastContent.id,
+              'floor',
+          )
+        : null
 
-    if (showBack) {
-        cards.push(makeNavCard(routeKey, 'prev', sectionIndex, 'desktop-back'))
-    }
-    if (showNext) {
-        cards.push(makeNavCard(routeKey, 'next', sectionIndex, 'desktop-next'))
-    }
-    return cards
+    const navCards = [
+        ...(backNav ? [backNav] : []),
+        ...(nextNav ? [nextNav] : []),
+    ]
+    const chain = [
+        ...(backNav ? [backNav] : []),
+        ...rewrittenContent,
+        ...(nextNav ? [nextNav] : []),
+    ]
+    return { cards: rewrittenContent, navCards, chain }
 }
 
 function partitionByOverflow(
@@ -167,17 +197,26 @@ export function partitionChain(opts: PartitionOptions): SectionLayout[] {
         ? partitionByAuthor(cards, explicitSections)
         : partitionByOverflow(cards, viewport, maxPerSection)
 
-    return partitioned.map((sectionCards, sectionIndex) => ({
-        sectionIndex,
-        sectionCount: partitioned.length,
-        cards: sectionCards,
-        navCards: navCardsForSection(
+    // The original chain head's parent declares which edge the chain is
+    // strung from (ceiling for gravity:down routes, floor for gravity:up).
+    // Section heads inherit this so paginated sections stay anchored to
+    // the same edge as the full chain.
+    const chainHeadParent: ParentRef = cards[0]?.card.parent ?? 'ceiling'
+
+    return partitioned.map((sectionCards, sectionIndex) => {
+        const built = buildSectionChain(
             routeKey,
             sectionIndex,
             partitioned.length,
-            viewport,
-        ),
-    }))
+            sectionCards,
+            chainHeadParent,
+        )
+        return {
+            sectionIndex,
+            sectionCount: partitioned.length,
+            ...built,
+        }
+    })
 }
 
 /**

--- a/web/src/layout/sectionLayout.ts
+++ b/web/src/layout/sectionLayout.ts
@@ -1,0 +1,215 @@
+import type {
+    AuthorSectionDef,
+    CardSpec,
+    PageDef,
+} from '../physics/PageDef'
+import type { Vec2, Viewport } from '../physics/PhysicsWorld'
+
+export const NAV_CARD_W = 180
+export const NAV_CARD_H = 56
+export const NAV_BREAKPOINT = 600
+export const NAV_BOTTOM_INSET = 80
+export const NAV_TETHER_LEN = 24
+export const CHAIN_TOP = 80
+export const CHAIN_GAP = 60
+
+const NAV_RESERVE = NAV_CARD_H + NAV_BOTTOM_INSET + 24 // small breathing room
+
+export interface ChainItem {
+    card: CardSpec
+    height: number
+}
+
+export interface SectionLayout {
+    sectionIndex: number
+    sectionCount: number
+    cards: CardSpec[]
+    navCards: CardSpec[]
+}
+
+export interface PartitionOptions {
+    viewport: Viewport
+    cards: readonly ChainItem[]
+    routeKey: string
+    maxPerSection?: number
+    explicitSections?: readonly AuthorSectionDef[]
+}
+
+/**
+ * Returns the y-coordinate (top edge in physics space) where the nav card row
+ * sits — bottom-of-viewport minus the inset.
+ */
+function navRowY(viewport: Viewport): number {
+    return viewport.height - NAV_BOTTOM_INSET
+}
+
+function makeNavCard(
+    routeKey: string,
+    target: 'prev' | 'next',
+    sectionIndex: number,
+    layout: 'narrow' | 'desktop-back' | 'desktop-next',
+): CardSpec {
+    const targetLabel = target === 'prev' ? 'back' : 'next'
+    const id = `${routeKey}-nav-${targetLabel}-s${sectionIndex + 1}`
+
+    const anchor = (vp: Viewport): Vec2 => {
+        const y = navRowY(vp)
+        if (layout === 'narrow') {
+            return { x: vp.width / 2, y }
+        }
+        if (layout === 'desktop-back') {
+            return { x: NAV_CARD_W / 2 + 24, y }
+        }
+        return { x: vp.width - NAV_CARD_W / 2 - 24, y }
+    }
+
+    return { id, kind: 'nav', parent: 'floor', anchor }
+}
+
+function navCardsForSection(
+    routeKey: string,
+    sectionIndex: number,
+    sectionCount: number,
+    viewport: Viewport,
+): CardSpec[] {
+    if (sectionCount <= 1) return []
+
+    const showBack = sectionIndex > 0
+    const showNext = sectionIndex < sectionCount - 1
+    if (!showBack && !showNext) return []
+
+    const narrow = viewport.width < NAV_BREAKPOINT
+    const cards: CardSpec[] = []
+
+    if (narrow) {
+        // Single nav card centered. If both directions are valid, the partitioner
+        // emits the forward control (the dominant action); back is reachable via
+        // the browser back button. This matches the spec note "single full-width
+        // nav card on narrow viewport".
+        const target: 'prev' | 'next' = showNext ? 'next' : 'prev'
+        cards.push(makeNavCard(routeKey, target, sectionIndex, 'narrow'))
+        return cards
+    }
+
+    if (showBack) {
+        cards.push(makeNavCard(routeKey, 'prev', sectionIndex, 'desktop-back'))
+    }
+    if (showNext) {
+        cards.push(makeNavCard(routeKey, 'next', sectionIndex, 'desktop-next'))
+    }
+    return cards
+}
+
+function partitionByOverflow(
+    items: readonly ChainItem[],
+    viewport: Viewport,
+    maxPerSection?: number,
+): CardSpec[][] {
+    const usable = viewport.height - CHAIN_TOP - NAV_RESERVE
+
+    const sections: CardSpec[][] = []
+    let current: CardSpec[] = []
+    let cursorY = 0
+
+    const flush = () => {
+        if (current.length > 0) {
+            sections.push(current)
+            current = []
+            cursorY = 0
+        }
+    }
+
+    for (const item of items) {
+        const sb = item.card.sectionBreak
+
+        if (sb === 'before' && current.length > 0) {
+            flush()
+        }
+
+        const projected = cursorY + (current.length > 0 ? CHAIN_GAP : 0) + item.height
+        const overflows = current.length > 0 && projected > usable
+        const overMax = maxPerSection !== undefined && current.length >= maxPerSection
+
+        if (overflows || overMax) {
+            flush()
+        }
+
+        // Place card in current section
+        cursorY += (current.length > 0 ? CHAIN_GAP : 0) + item.height
+        current.push(item.card)
+
+        if (sb === 'after') {
+            flush()
+        }
+    }
+
+    flush()
+    if (sections.length === 0) sections.push([])
+    return sections
+}
+
+function partitionByAuthor(
+    items: readonly ChainItem[],
+    explicit: readonly AuthorSectionDef[],
+): CardSpec[][] {
+    const byId = new Map(items.map((i) => [i.card.id, i.card]))
+    return explicit.map((section) =>
+        section.cardIds
+            .map((id) => byId.get(id))
+            .filter((c): c is CardSpec => c !== undefined),
+    )
+}
+
+export function partitionChain(opts: PartitionOptions): SectionLayout[] {
+    const { viewport, cards, routeKey, maxPerSection, explicitSections } = opts
+
+    const partitioned: CardSpec[][] = explicitSections
+        ? partitionByAuthor(cards, explicitSections)
+        : partitionByOverflow(cards, viewport, maxPerSection)
+
+    return partitioned.map((sectionCards, sectionIndex) => ({
+        sectionIndex,
+        sectionCount: partitioned.length,
+        cards: sectionCards,
+        navCards: navCardsForSection(
+            routeKey,
+            sectionIndex,
+            partitioned.length,
+            viewport,
+        ),
+    }))
+}
+
+/**
+ * Convenience: produce the layout for a PageDef whose `cards` form a chain.
+ * Pulls heights from the supplied `heights` map (route is responsible for
+ * measuring its own card content; we don't re-implement measurement here).
+ */
+export function partitionPageDef(
+    pageDef: PageDef,
+    viewport: Viewport,
+    routeKey: string,
+    heights: Record<string, number>,
+): SectionLayout[] {
+    const items: ChainItem[] = pageDef.cards.map((card) => ({
+        card,
+        height: heights[card.id] ?? 0,
+    }))
+
+    const explicit =
+        pageDef.sections?.mode === 'author'
+            ? pageDef.sections.sections
+            : undefined
+    const maxPerSection =
+        pageDef.sections?.mode === 'auto-chain'
+            ? pageDef.sections.maxPerSection
+            : undefined
+
+    return partitionChain({
+        viewport,
+        cards: items,
+        routeKey,
+        ...(explicit ? { explicitSections: explicit } : {}),
+        ...(maxPerSection !== undefined ? { maxPerSection } : {}),
+    })
+}

--- a/web/src/layouts/CanvasLayout.tsx
+++ b/web/src/layouts/CanvasLayout.tsx
@@ -8,6 +8,7 @@ import { StringLayer } from '../canvas/StringLayer'
 import { useFrameEdge } from '../canvas/useFrameEdge'
 import { TransitionDirector } from '../transitions/TransitionDirector'
 import { PhysicsLayer } from '../transitions/PhysicsLayer'
+import { PageDefRegistryProvider } from '../transitions/PageDefRegistry'
 import { pageDefs } from '../transitions/pageDefs'
 import { edges } from '../transitions/edges'
 import './CanvasLayout.css'
@@ -23,19 +24,21 @@ export default function CanvasLayout() {
 
     return (
         <PhysicsProvider>
-            <TransitionDirector pageDefs={pageDefs} edges={edges}>
-                <div
-                    data-layout="canvas"
-                    data-canvas-marker={CANVAS_ONLY_BUNDLE_MARKER}
-                    data-frame-edge={edge}
-                >
-                    <BackgroundCanvas />
-                    <PhysicsLayer />
-                    <StringLayer />
-                    <FrameBar />
-                    <Outlet />
-                </div>
-            </TransitionDirector>
+            <PageDefRegistryProvider>
+                <TransitionDirector pageDefs={pageDefs} edges={edges}>
+                    <div
+                        data-layout="canvas"
+                        data-canvas-marker={CANVAS_ONLY_BUNDLE_MARKER}
+                        data-frame-edge={edge}
+                    >
+                        <BackgroundCanvas />
+                        <PhysicsLayer />
+                        <StringLayer />
+                        <FrameBar />
+                        <Outlet />
+                    </div>
+                </TransitionDirector>
+            </PageDefRegistryProvider>
         </PhysicsProvider>
     )
 }

--- a/web/src/physics/PageDef.ts
+++ b/web/src/physics/PageDef.ts
@@ -3,7 +3,14 @@ import type { Vec2, Viewport } from './PhysicsWorld'
 export type Cardinal = 'down' | 'up' | 'left' | 'right'
 export type Buoyancy = 'heavy' | 'balloon'
 export type ParentRef = 'ceiling' | 'floor' | string | null
-export type CardKind = 'lifelog' | 'blog' | 'portfolio' | 'note' | 'link' | 'headline'
+export type CardKind =
+    | 'lifelog'
+    | 'blog'
+    | 'portfolio'
+    | 'note'
+    | 'link'
+    | 'headline'
+    | 'nav'
 
 export type TransitionId =
     | 'string-cut-drop'
@@ -11,12 +18,23 @@ export type TransitionId =
     | 'anchor-slide'
     | 'cross-fade'
 
+export type ChainNavTarget = 'prev' | 'next'
+
 export interface CardSpec {
     id: string
     kind: CardKind
     parent: ParentRef
     anchor: (viewport: Viewport) => Vec2
+    sectionBreak?: 'before' | 'after'
 }
+
+export interface AuthorSectionDef {
+    cardIds: readonly string[]
+}
+
+export type SectionsConfig =
+    | { mode: 'author'; sections: readonly AuthorSectionDef[] }
+    | { mode: 'auto-chain'; chainRoot?: string; maxPerSection?: number }
 
 export interface PageDef {
     gravity: Cardinal
@@ -26,6 +44,8 @@ export interface PageDef {
         enter?: TransitionId
     }
     siblingOrder?: 'left' | 'right'
+    sections?: SectionsConfig
+    sectionsPushHistory?: boolean
 }
 
 export function buoyancyForKind(kind: CardKind): Buoyancy {

--- a/web/src/physics/PageDef.ts
+++ b/web/src/physics/PageDef.ts
@@ -26,6 +26,10 @@ export interface CardSpec {
     parent: ParentRef
     anchor: (viewport: Viewport) => Vec2
     sectionBreak?: 'before' | 'after'
+    // Secondary tether — e.g. a paginated section's terminal nav card uses
+    // `trail: 'floor'` so a string visibly continues from the card to the
+    // floor, implying the chain extends below the screen.
+    trail?: ParentRef
 }
 
 export interface AuthorSectionDef {

--- a/web/src/physics/PhysicsCard.test.tsx
+++ b/web/src/physics/PhysicsCard.test.tsx
@@ -1,9 +1,10 @@
 import { describe, test, expect, afterEach } from 'vitest'
-import { render, cleanup } from '@testing-library/react'
-import { PhysicsProvider } from './PhysicsContext'
+import { act, render, cleanup } from '@testing-library/react'
+import { PhysicsProvider, usePhysicsWorld } from './PhysicsContext'
 import { PhysicsCard } from './PhysicsCard'
 import { CardRegistryProvider } from '../transitions/CardRegistry'
 import { PhysicsLayer } from '../transitions/PhysicsLayer'
+import type { PhysicsWorld } from './PhysicsWorld'
 
 afterEach(() => {
     cleanup()
@@ -45,6 +46,44 @@ describe('PhysicsCard — draggable prop', () => {
         article.setPointerCapture = () => {}
         fireRealPointerDown(article)
         expect(article.style.cursor).toBe('grabbing')
+    })
+
+    test('trail prop wires a second tether (e.g. ceiling-strung card also tethered to floor)', async () => {
+        let captured: PhysicsWorld | null = null
+        function Probe() {
+            captured = usePhysicsWorld()
+            return null
+        }
+        await act(async () => {
+            render(
+                <PhysicsProvider>
+                    <CardRegistryProvider>
+                        <PhysicsLayer />
+                        <Probe />
+                        <PhysicsCard
+                            id="dual-tether"
+                            text="dual"
+                            width={120}
+                            height={80}
+                            anchor={{ x: 200, y: 200 }}
+                            parent="ceiling"
+                            trail="floor"
+                        />
+                    </CardRegistryProvider>
+                </PhysicsProvider>,
+            )
+            // Give the registry/PhysicsLayer pipeline a frame to wire tethers.
+            await new Promise((r) => requestAnimationFrame(() => r(null)))
+        })
+        const world = captured! as PhysicsWorld
+        const records = world.listTetherRecords()
+        // One tether to ceiling, one to floor — both share the same child
+        // body but use different parents.
+        expect(records).toHaveLength(2)
+        const parents = records.map((r) => r.parent).sort()
+        expect(parents).toEqual(
+            [world.ceilingHandle, world.floorHandle].sort(),
+        )
     })
 
     test('draggable={false} does NOT set cursor to grabbing on pointerdown', () => {

--- a/web/src/physics/PhysicsCard.tsx
+++ b/web/src/physics/PhysicsCard.tsx
@@ -49,6 +49,7 @@ export interface PhysicsCardProps {
     label?: string
     kind?: string
     parent?: ParentRef
+    trail?: ParentRef
     buoyancy?: Buoyancy
     draggable?: boolean
 }
@@ -62,6 +63,7 @@ export function PhysicsCard(props: PhysicsCardProps) {
         () => ({
             id,
             parent: props.parent ?? null,
+            trail: props.trail,
             kind: props.kind ?? 'card',
             buoyancy: props.buoyancy ?? 'heavy',
             anchor: props.anchor,
@@ -82,6 +84,7 @@ export function PhysicsCard(props: PhysicsCardProps) {
         [
             id,
             props.parent,
+            props.trail,
             props.kind,
             props.buoyancy,
             props.anchor.x,

--- a/web/src/physics/PhysicsContext.tsx
+++ b/web/src/physics/PhysicsContext.tsx
@@ -10,9 +10,9 @@ import { useFrameEdge, getFrameEdgeController } from '../canvas/useFrameEdge'
 import { CardRegistryProvider } from '../transitions/CardRegistry'
 import type { FrameEdge } from '../canvas/useFrameEdge'
 
-const FRAME_BAR_HEIGHT = 40
+export const FRAME_BAR_HEIGHT = 40
 
-function edgeToInsets(edge: FrameEdge) {
+export function edgeToInsets(edge: FrameEdge) {
     return edge === 'top'
         ? { top: FRAME_BAR_HEIGHT, bottom: 0 }
         : { top: 0, bottom: FRAME_BAR_HEIGHT }

--- a/web/src/physics/PhysicsPage.tsx
+++ b/web/src/physics/PhysicsPage.tsx
@@ -59,6 +59,7 @@ export function PhysicsPage({
                         height={c?.height ?? 160}
                         anchor={{ x, y }}
                         parent={spec.parent}
+                        trail={spec.trail}
                         buoyancy={buoyancyForKind(spec.kind)}
                         minimizable={c?.minimizable ?? false}
                         label={c?.label}

--- a/web/src/physics/PhysicsWorld.ts
+++ b/web/src/physics/PhysicsWorld.ts
@@ -511,6 +511,12 @@ export class PhysicsWorld {
         Matter.Body.set(reg.body, 'isSensor', isSensor)
     }
 
+    isSensor(handle: PhysicsHandle): boolean {
+        const reg = this.registrations.get(handle)
+        if (!reg) throw new Error(`PhysicsWorld: unknown handle ${handle}`)
+        return reg.body.isSensor
+    }
+
     setStatic(handle: PhysicsHandle, isStatic: boolean): void {
         const reg = this.registrations.get(handle)
         if (!reg) throw new Error(`PhysicsWorld: unknown handle ${handle}`)

--- a/web/src/routes/blog/BlogIndex.chain.test.ts
+++ b/web/src/routes/blog/BlogIndex.chain.test.ts
@@ -1,5 +1,13 @@
 import { describe, test, expect } from 'vitest'
-import { buildChain, CHAIN_GAP, CHAIN_X_FRACTION, CHAIN_TOP } from './BlogIndex'
+import {
+    buildChain,
+    layoutSection,
+    CHAIN_GAP,
+    CHAIN_X_FRACTION,
+    CHAIN_TOP,
+} from './BlogIndex'
+import { NAV_CARD_H, NAV_TOP_INSET } from '../../layout/sectionLayout'
+import type { CardSpec } from '../../physics/PageDef'
 import { measureBlogCard, CARD_PADDING } from './BlogIndex.measure'
 import type { Post } from '../../blog/types'
 
@@ -87,5 +95,184 @@ describe('BlogIndex chain topology', () => {
         for (let i = 1; i < ys.length; i++) {
             expect(ys[i]! - ys[i - 1]!).toBe(height + CHAIN_GAP)
         }
+    })
+})
+
+describe('layoutSection', () => {
+    // A non-first section's cards still carry the original full-chain
+    // anchor closures (which place them where they would sit if the full
+    // chain were rendered). layoutSection must rewrite their y so the
+    // section's chain starts at CHAIN_TOP again — otherwise section 2's
+    // head card hangs from the ceiling with a tether that runs the full
+    // height of the would-be earlier chain.
+    function makeCard(id: string, capturedY: number): CardSpec {
+        return {
+            id,
+            kind: 'blog',
+            parent: 'ceiling',
+            anchor: (vp) => ({ x: vp.width * CHAIN_X_FRACTION, y: capturedY }),
+        }
+    }
+
+    test('first card in section anchors at CHAIN_TOP + height/2', () => {
+        const card = makeCard('blog-x', 999) // would-be full-chain y, irrelevant
+        const out = layoutSection([card], { 'blog-x': 80 }, viewport)
+        expect(out).toHaveLength(1)
+        expect(out[0]!.anchor(viewport).y).toBe(CHAIN_TOP + 80 / 2)
+    })
+
+    test('subsequent cards stack with height + CHAIN_GAP from the previous', () => {
+        const cards = [
+            makeCard('blog-a', 999),
+            makeCard('blog-b', 1500),
+        ]
+        const heights = { 'blog-a': 100, 'blog-b': 120 }
+        const out = layoutSection(cards, heights, viewport)
+        const yA = out[0]!.anchor(viewport).y
+        const yB = out[1]!.anchor(viewport).y
+        expect(yA).toBe(CHAIN_TOP + 100 / 2)
+        // top of B = top of A + 100 + CHAIN_GAP → centre yB = yA + 100/2 + CHAIN_GAP + 120/2
+        expect(yB).toBe(yA + 100 / 2 + CHAIN_GAP + 120 / 2)
+    })
+
+    test('x position still tracks viewport width', () => {
+        const card = makeCard('blog-x', 999)
+        const wide = { width: 1600, height: 900 }
+        const out = layoutSection([card], { 'blog-x': 80 }, viewport)
+        expect(out[0]!.anchor(wide).x).toBe(wide.width * CHAIN_X_FRACTION)
+    })
+
+    test('preserves card identity fields (id, kind, parent)', () => {
+        const card = makeCard('blog-x', 999)
+        const out = layoutSection([card], { 'blog-x': 80 }, viewport)
+        expect(out[0]!.id).toBe('blog-x')
+        expect(out[0]!.kind).toBe('blog')
+        expect(out[0]!.parent).toBe('ceiling')
+    })
+
+    test('back-nav is pinned at NAV_TOP_INSET below ceiling (fixed)', () => {
+        const back: CardSpec = {
+            id: 'nav-back',
+            kind: 'nav',
+            parent: 'ceiling',
+            anchor: () => ({ x: 0, y: 0 }),
+        }
+        const content: CardSpec = {
+            id: 'blog-x',
+            kind: 'blog',
+            parent: 'nav-back',
+            anchor: () => ({ x: 0, y: 0 }),
+        }
+        const out = layoutSection([back, content], { 'blog-x': 100 }, viewport)
+        const yBack = out[0]!.anchor(viewport).y
+        // Back-nav top edge = NAV_TOP_INSET = 40 → centre = 40 + NAV_CARD_H/2
+        expect(yBack).toBe(NAV_TOP_INSET + NAV_CARD_H / 2)
+    })
+
+    test('next-nav stacks just below last content card with CHAIN_GAP', () => {
+        const content: CardSpec = {
+            id: 'blog-x',
+            kind: 'blog',
+            parent: 'ceiling',
+            anchor: () => ({ x: 0, y: 0 }),
+        }
+        const next: CardSpec = {
+            id: 'nav-next',
+            kind: 'nav',
+            parent: 'blog-x',
+            anchor: () => ({ x: 0, y: 0 }),
+            trail: 'floor',
+        }
+        const out = layoutSection([content, next], { 'blog-x': 100 }, viewport)
+        const yContent = out[0]!.anchor(viewport).y
+        const yNext = out[1]!.anchor(viewport).y
+        // Next-nav top = content bottom + CHAIN_GAP → centre = yContent + h/2 + CHAIN_GAP + NAV_CARD_H/2
+        expect(yNext).toBe(yContent + 100 / 2 + CHAIN_GAP + NAV_CARD_H / 2)
+    })
+
+    test('content card after back-nav starts below it with CHAIN_GAP', () => {
+        const back: CardSpec = {
+            id: 'nav-back',
+            kind: 'nav',
+            parent: 'ceiling',
+            anchor: () => ({ x: 0, y: 0 }),
+        }
+        const content: CardSpec = {
+            id: 'blog-x',
+            kind: 'blog',
+            parent: 'nav-back',
+            anchor: () => ({ x: 0, y: 0 }),
+        }
+        const out = layoutSection([back, content], { 'blog-x': 100 }, viewport)
+        const yBack = out[0]!.anchor(viewport).y
+        const yContent = out[1]!.anchor(viewport).y
+        // Content top = back-nav bottom + CHAIN_GAP
+        expect(yContent).toBe(yBack + NAV_CARD_H / 2 + CHAIN_GAP + 100 / 2)
+    })
+
+    test('without back-nav, content starts at CHAIN_TOP (unchanged)', () => {
+        const content: CardSpec = {
+            id: 'blog-x',
+            kind: 'blog',
+            parent: 'ceiling',
+            anchor: () => ({ x: 0, y: 0 }),
+        }
+        const out = layoutSection([content], { 'blog-x': 100 }, viewport)
+        expect(out[0]!.anchor(viewport).y).toBe(CHAIN_TOP + 100 / 2)
+    })
+
+    test('back-nav respects top inset (e.g. top-edge frame bar)', () => {
+        const back: CardSpec = {
+            id: 'nav-back',
+            kind: 'nav',
+            parent: 'ceiling',
+            anchor: () => ({ x: 0, y: 0 }),
+        }
+        const content: CardSpec = {
+            id: 'blog-x',
+            kind: 'blog',
+            parent: 'nav-back',
+            anchor: () => ({ x: 0, y: 0 }),
+        }
+        const insets = { top: 40, bottom: 0 }
+        const out = layoutSection(
+            [back, content],
+            { 'blog-x': 100 },
+            viewport,
+            insets,
+        )
+        const yBack = out[0]!.anchor(viewport).y
+        // Ceiling y = 40 → back-nav centre = ceiling + inset + h/2
+        expect(yBack).toBe(insets.top + NAV_TOP_INSET + NAV_CARD_H / 2)
+    })
+
+    test('next-nav follows content height (chain-stacked, not fixed)', () => {
+        // Next-nav floats with the chain. Tall content pushes next-nav
+        // lower; the trail string to floor grows or shrinks accordingly.
+        const back: CardSpec = {
+            id: 'nav-back',
+            kind: 'nav',
+            parent: 'ceiling',
+            anchor: () => ({ x: 0, y: 0 }),
+        }
+        const content: CardSpec = {
+            id: 'blog-x',
+            kind: 'blog',
+            parent: 'nav-back',
+            anchor: () => ({ x: 0, y: 0 }),
+        }
+        const next: CardSpec = {
+            id: 'nav-next',
+            kind: 'nav',
+            parent: 'blog-x',
+            anchor: () => ({ x: 0, y: 0 }),
+            trail: 'floor',
+        }
+        const outSmall = layoutSection([back, content, next], { 'blog-x': 80 }, viewport)
+        const outTall = layoutSection([back, content, next], { 'blog-x': 300 }, viewport)
+        const yNextSmall = outSmall[2]!.anchor(viewport).y
+        const yNextTall = outTall[2]!.anchor(viewport).y
+        // Tall content pushes next-nav down by 220px (300 - 80).
+        expect(yNextTall - yNextSmall).toBe(220)
     })
 })

--- a/web/src/routes/blog/BlogIndex.tsx
+++ b/web/src/routes/blog/BlogIndex.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useMemo, useRef } from 'react'
 import { Link } from 'react-router-dom'
 import { PhysicsPage, type CardContent } from '../../physics/PhysicsPage'
 import { registry as pretextRegistry } from '../../text/registry'
@@ -9,6 +9,14 @@ import {
     CARD_PADDING,
     type MeasureFn,
 } from './BlogIndex.measure'
+import { useRegisterPageDef } from '../../transitions/PageDefRegistry'
+import { useHashSection } from '../../transitions/useHashSection'
+import {
+    partitionPageDef,
+    NAV_CARD_W,
+    NAV_CARD_H,
+} from '../../layout/sectionLayout'
+import { NavCardContent } from '../../transitions/NavCardContent'
 import type { PageDef, CardSpec } from '../../physics/PageDef'
 import type { Post } from '../../blog/types'
 import type { Viewport } from '../../physics/PhysicsWorld'
@@ -19,17 +27,27 @@ export const CHAIN_GAP = 60
 export const CHAIN_X_FRACTION = 0.5
 export const CHAIN_TOP = 80
 
+const ROUTE_KEY = '/blog'
+const T4_DURATION_MS = 700
+
 const posts = getPosts()
+
+interface BuiltChain {
+    pageDef: PageDef
+    cardContent: Record<string, CardContent>
+    heights: Record<string, number>
+}
 
 export function buildChain(
     postList: Post[],
     vp: Viewport,
     measure: MeasureFn,
-): { pageDef: PageDef; cardContent: Record<string, CardContent> } {
+): BuiltChain {
     const textMaxWidth = Math.max(1, vp.width * 0.6 - GUTTER * 2 - CARD_PADDING * 2)
 
     const cards: CardSpec[] = []
     const cardContent: Record<string, CardContent> = {}
+    const heights: Record<string, number> = {}
 
     let y = CHAIN_TOP
 
@@ -78,12 +96,18 @@ export function buildChain(
             ),
         }
 
+        heights[id] = height
         y += height + CHAIN_GAP
     }
 
     return {
-        pageDef: { gravity: 'down', cards },
+        pageDef: {
+            gravity: 'down',
+            cards,
+            sections: { mode: 'auto-chain' },
+        },
         cardContent,
+        heights,
     }
 }
 
@@ -93,25 +117,139 @@ function getViewport(): Viewport {
         : { width: 1024, height: 768 }
 }
 
-const emptyPage: { pageDef: PageDef; cardContent: Record<string, CardContent> } = {
-    pageDef: { gravity: 'down', cards: [] },
+const EMPTY_CHAIN: BuiltChain = {
+    pageDef: { gravity: 'down', cards: [], sections: { mode: 'auto-chain' } },
     cardContent: {},
+    heights: {},
 }
 
 export default function BlogIndex() {
-    const [page, setPage] = useState(emptyPage)
+    const [chain, setChain] = useState<BuiltChain>(EMPTY_CHAIN)
+    const [viewport, setViewport] = useState<Viewport>(getViewport)
+    const { sectionIndex, goToSection } = useHashSection()
+
+    useRegisterPageDef(chain.pageDef)
 
     useEffect(() => {
         function update() {
             const vp = getViewport()
+            setViewport(vp)
             const measure = (text: string, fontKey: string, mw: number) =>
                 pretextRegistry.measure(text, fontKey, mw)
-            setPage(buildChain(posts, vp, measure))
+            setChain(buildChain(posts, vp, measure))
         }
         update()
         window.addEventListener('resize', update, { passive: true })
         return () => window.removeEventListener('resize', update)
     }, [])
 
-    return <PhysicsPage pageDef={page.pageDef} cardContent={page.cardContent} />
+    const sections = useMemo(
+        () => partitionPageDef(chain.pageDef, viewport, ROUTE_KEY, chain.heights),
+        [chain, viewport],
+    )
+
+    // Clamp to bounds — section count can shrink on resize, leaving the URL
+    // pointing past the end. We render the last available section and leave
+    // the URL alone so a future resize that grows the count restores it.
+    const currentIdx = Math.min(
+        Math.max(sectionIndex - 1, 0),
+        Math.max(sections.length - 1, 0),
+    )
+    const current = sections[currentIdx]
+    const sectionCount = sections.length
+
+    const sectionPageDef = useMemo<PageDef>(
+        () => ({
+            gravity: 'down',
+            cards: [
+                ...(current?.cards ?? []),
+                ...(current?.navCards ?? []),
+            ],
+        }),
+        [current],
+    )
+
+    const sectionContent = useMemo<Record<string, CardContent>>(() => {
+        const out: Record<string, CardContent> = {}
+        for (const card of current?.cards ?? []) {
+            const content = chain.cardContent[card.id]
+            if (content) out[card.id] = content
+        }
+        for (const nav of current?.navCards ?? []) {
+            const isBack = nav.id.includes('-nav-back-')
+            // 1-indexed target — back targets currentIdx, next targets currentIdx+2.
+            const targetSectionIndex = isBack ? currentIdx : currentIdx + 2
+            out[nav.id] = {
+                text: isBack ? '← back' : 'next →',
+                width: NAV_CARD_W,
+                height: NAV_CARD_H,
+                draggable: false,
+                children: (
+                    <NavCardContent
+                        target={isBack ? 'prev' : 'next'}
+                        targetSectionIndex={targetSectionIndex}
+                        sectionCount={sectionCount}
+                        onActivate={() => goToSection(targetSectionIndex)}
+                    />
+                ),
+            }
+        }
+        return out
+    }, [current, currentIdx, sectionCount, chain.cardContent, goToSection])
+
+    // Keyboard nav — ← / → drive section nav when not typing.
+    useEffect(() => {
+        function onKeydown(e: KeyboardEvent) {
+            if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return
+            const a = document.activeElement
+            const tag = (a as HTMLElement | null)?.tagName ?? ''
+            if (
+                tag === 'INPUT' ||
+                tag === 'TEXTAREA' ||
+                tag === 'SELECT' ||
+                (a as HTMLElement | null)?.isContentEditable
+            ) {
+                return
+            }
+            if (e.key === 'ArrowLeft' && currentIdx > 0) {
+                e.preventDefault()
+                goToSection(currentIdx) // 1-indexed target = currentIdx
+            } else if (
+                e.key === 'ArrowRight' &&
+                currentIdx < sectionCount - 1
+            ) {
+                e.preventDefault()
+                goToSection(currentIdx + 2) // 1-indexed target = currentIdx + 2
+            }
+        }
+        window.addEventListener('keydown', onKeydown)
+        return () => window.removeEventListener('keydown', onKeydown)
+    }, [currentIdx, sectionCount, goToSection])
+
+    // Focus follow — after T4 completes, focus the first focusable element
+    // in the new section. Skip on initial mount so we don't steal focus on
+    // page load.
+    const firstMountRef = useRef(true)
+    useEffect(() => {
+        if (firstMountRef.current) {
+            firstMountRef.current = false
+            return
+        }
+        const id = window.setTimeout(() => {
+            const root = document.querySelector<HTMLElement>(
+                '[data-section-root]',
+            )
+            const focusable = root?.querySelector<HTMLElement>(
+                'a, button, [tabindex]:not([tabindex="-1"])',
+            )
+            focusable?.focus()
+        }, T4_DURATION_MS)
+        return () => window.clearTimeout(id)
+    }, [sectionIndex])
+
+    return (
+        <div data-section-root>
+            <PhysicsPage pageDef={sectionPageDef} cardContent={sectionContent} />
+        </div>
+    )
 }

--- a/web/src/routes/blog/BlogIndex.tsx
+++ b/web/src/routes/blog/BlogIndex.tsx
@@ -11,10 +11,13 @@ import {
 } from './BlogIndex.measure'
 import { useRegisterPageDef } from '../../transitions/PageDefRegistry'
 import { useHashSection } from '../../transitions/useHashSection'
+import { edgeToInsets } from '../../physics/PhysicsContext'
+import { useFrameEdge } from '../../canvas/useFrameEdge'
 import {
     partitionPageDef,
     NAV_CARD_W,
     NAV_CARD_H,
+    NAV_TOP_INSET,
 } from '../../layout/sectionLayout'
 import { NavCardContent } from '../../transitions/NavCardContent'
 import type { PageDef, CardSpec } from '../../physics/PageDef'
@@ -36,6 +39,55 @@ interface BuiltChain {
     pageDef: PageDef
     cardContent: Record<string, CardContent>
     heights: Record<string, number>
+}
+
+/**
+ * Lays out a section's cards top-to-bottom in chain order.
+ *   - back-nav (head): pinned at NAV_TOP_INSET below the physics ceiling
+ *   - content cards: stack with CHAIN_GAP starting just below back-nav
+ *     (or at CHAIN_TOP relative to the ceiling if no back-nav)
+ *   - next-nav (tail): hangs from the last content card with CHAIN_GAP
+ *     — its trail tether to the floor provides the long "chain continues
+ *     below" string, which lengthens or shortens with the chain.
+ *
+ * `insets` are the physics inset (FrameBar). Anchoring relative to the
+ * actual edges (not the window) keeps tether lengths sane.
+ */
+export function layoutSection(
+    cards: readonly CardSpec[],
+    heights: Record<string, number>,
+    _viewport: Viewport,
+    insets: { top: number; bottom: number } = { top: 0, bottom: 0 },
+): CardSpec[] {
+    const isBackNav = (card: CardSpec, i: number) =>
+        i === 0 && card.kind === 'nav'
+
+    const ceilingY = insets.top
+
+    const startsWithBackNav = cards.length > 0 && isBackNav(cards[0]!, 0)
+    let y = startsWithBackNav
+        ? ceilingY + NAV_TOP_INSET + NAV_CARD_H + CHAIN_GAP
+        : ceilingY + CHAIN_TOP
+
+    return cards.map((card, i) => {
+        let capturedY: number
+        if (isBackNav(card, i)) {
+            capturedY = ceilingY + NAV_TOP_INSET + NAV_CARD_H / 2
+            y = ceilingY + NAV_TOP_INSET + NAV_CARD_H + CHAIN_GAP
+        } else {
+            const h =
+                heights[card.id] ?? (card.kind === 'nav' ? NAV_CARD_H : 0)
+            capturedY = y + h / 2
+            y += h + CHAIN_GAP
+        }
+        return {
+            ...card,
+            anchor: (vp: Viewport) => ({
+                x: vp.width * CHAIN_X_FRACTION,
+                y: capturedY,
+            }),
+        }
+    })
 }
 
 export function buildChain(
@@ -127,6 +179,8 @@ export default function BlogIndex() {
     const [chain, setChain] = useState<BuiltChain>(EMPTY_CHAIN)
     const [viewport, setViewport] = useState<Viewport>(getViewport)
     const { sectionIndex, goToSection } = useHashSection()
+    const { edge } = useFrameEdge()
+    const insets = useMemo(() => edgeToInsets(edge), [edge])
 
     useRegisterPageDef(chain.pageDef)
 
@@ -161,12 +215,14 @@ export default function BlogIndex() {
     const sectionPageDef = useMemo<PageDef>(
         () => ({
             gravity: 'down',
-            cards: [
-                ...(current?.cards ?? []),
-                ...(current?.navCards ?? []),
-            ],
+            cards: layoutSection(
+                current?.chain ?? [],
+                chain.heights,
+                viewport,
+                insets,
+            ),
         }),
-        [current],
+        [current, chain.heights, viewport, insets],
     )
 
     const sectionContent = useMemo<Record<string, CardContent>>(() => {
@@ -180,7 +236,7 @@ export default function BlogIndex() {
             // 1-indexed target — back targets currentIdx, next targets currentIdx+2.
             const targetSectionIndex = isBack ? currentIdx : currentIdx + 2
             out[nav.id] = {
-                text: isBack ? '← back' : 'next →',
+                text: isBack ? '↑ back' : 'next ↓',
                 width: NAV_CARD_W,
                 height: NAV_CARD_H,
                 draggable: false,

--- a/web/src/routes/blog/BlogPost.tsx
+++ b/web/src/routes/blog/BlogPost.tsx
@@ -1,8 +1,10 @@
-import { useState, useEffect } from 'react'
+import { useMemo, useState, useEffect } from 'react'
 import { useParams } from 'react-router-dom'
 import { PhysicsCard } from '../../physics/PhysicsCard'
+import { useRegisterPageDef } from '../../transitions/PageDefRegistry'
 import { getPosts } from '../../blog/posts'
 import { mdxComponents } from '../../blog/components/mdx-components'
+import type { PageDef } from '../../physics/PageDef'
 import './BlogPost.css'
 
 const posts = getPosts()
@@ -20,6 +22,22 @@ export default function BlogPost() {
     const { slug } = useParams<{ slug: string }>()
     const post = posts.find((p) => p.slug === slug)
     const [dims, setDims] = useState<CardDims | null>(null)
+
+    const pageDef = useMemo<PageDef>(
+        () => ({
+            gravity: 'down',
+            cards: [
+                {
+                    id: `post-${slug}`,
+                    kind: 'blog',
+                    parent: null,
+                    anchor: (vp) => ({ x: vp.width / 2, y: vp.height / 2 }),
+                },
+            ],
+        }),
+        [slug],
+    )
+    useRegisterPageDef(pageDef)
 
     useEffect(() => {
         const update = () => {

--- a/web/src/routes/stuff/FlashDetail.tsx
+++ b/web/src/routes/stuff/FlashDetail.tsx
@@ -3,6 +3,7 @@ import { useParams, Link, Navigate } from 'react-router-dom'
 import { PhysicsPage, type CardContent } from '../../physics/PhysicsPage'
 import { getPieceBySlug } from '../../stuff/flash/pieces'
 import { RuffleEmbed } from '../../stuff/flash/RuffleEmbed'
+import { useRegisterPageDef } from '../../transitions/PageDefRegistry'
 import type { PageDef } from '../../physics/PageDef'
 import type { Piece } from '../../stuff/flash/pieces'
 import type { Viewport } from '../../physics/PhysicsWorld'
@@ -165,6 +166,8 @@ function buildPage(
     return { pageDef, cardContent }
 }
 
+const EMPTY_PAGE_DEF: PageDef = { gravity: 'down', cards: [] }
+
 export default function FlashDetail() {
     const { slug } = useParams<{ slug: string }>()
     const piece = slug ? getPieceBySlug(slug) : undefined
@@ -179,10 +182,16 @@ export default function FlashDetail() {
         [slug],
     )
 
-    if (!piece) {
+    const built = useMemo(
+        () => (piece ? buildPage(piece, offsets) : null),
+        [piece, offsets],
+    )
+
+    useRegisterPageDef(built?.pageDef ?? EMPTY_PAGE_DEF)
+
+    if (!piece || !built) {
         return <Navigate to="/stuff/flash" replace />
     }
 
-    const { pageDef, cardContent } = buildPage(piece, offsets)
-    return <PhysicsPage pageDef={pageDef} cardContent={cardContent} />
+    return <PhysicsPage pageDef={built.pageDef} cardContent={built.cardContent} />
 }

--- a/web/src/transitions/CardRegistry.tsx
+++ b/web/src/transitions/CardRegistry.tsx
@@ -13,6 +13,7 @@ export type CardLifecycle = 'active' | 'exiting'
 export interface PhysicsCardEntry {
     id: string
     parent: ParentRef
+    trail?: ParentRef
     kind: string
     buoyancy: Buoyancy
     anchor: { x: number; y: number }

--- a/web/src/transitions/NavCardContent.tsx
+++ b/web/src/transitions/NavCardContent.tsx
@@ -1,0 +1,48 @@
+import type { CSSProperties } from 'react'
+
+export interface NavCardContentProps {
+    target: 'prev' | 'next'
+    /** Section index this control navigates TO (1-based, for aria-label). */
+    targetSectionIndex: number
+    /** Total section count, for aria-label. */
+    sectionCount: number
+    onActivate: () => void
+}
+
+const buttonStyle: CSSProperties = {
+    background: 'transparent',
+    border: 'none',
+    cursor: 'pointer',
+    color: 'inherit',
+    font: 'inherit',
+    width: '100%',
+    height: '100%',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+}
+
+export function NavCardContent({
+    target,
+    targetSectionIndex,
+    sectionCount,
+    onActivate,
+}: NavCardContentProps) {
+    const label =
+        target === 'prev'
+            ? `Previous section, ${targetSectionIndex} of ${sectionCount}`
+            : `Next section, ${targetSectionIndex} of ${sectionCount}`
+    const glyph = target === 'prev' ? '← back' : 'next →'
+
+    return (
+        <button
+            type="button"
+            aria-label={label}
+            onClick={onActivate}
+            style={buttonStyle}
+        >
+            {glyph}
+        </button>
+    )
+}

--- a/web/src/transitions/NavCardContent.tsx
+++ b/web/src/transitions/NavCardContent.tsx
@@ -33,7 +33,7 @@ export function NavCardContent({
         target === 'prev'
             ? `Previous section, ${targetSectionIndex} of ${sectionCount}`
             : `Next section, ${targetSectionIndex} of ${sectionCount}`
-    const glyph = target === 'prev' ? '← back' : 'next →'
+    const glyph = target === 'prev' ? '↑ back' : 'next ↓'
 
     return (
         <button

--- a/web/src/transitions/PageDefRegistry.test.tsx
+++ b/web/src/transitions/PageDefRegistry.test.tsx
@@ -1,0 +1,148 @@
+import { describe, test, expect } from 'vitest'
+import { renderHook, render, act } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { type ReactNode } from 'react'
+import {
+    PageDefRegistryProvider,
+    usePageDefRegistry,
+    useRegisterPageDef,
+} from './PageDefRegistry'
+import type { PageDef } from '../physics/PageDef'
+
+function makeDef(): PageDef {
+    return { gravity: 'down', cards: [] }
+}
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+    <MemoryRouter>
+        <PageDefRegistryProvider>{children}</PageDefRegistryProvider>
+    </MemoryRouter>
+)
+
+describe('PageDefRegistry', () => {
+    test('register + resolve round-trip', () => {
+        const { result } = renderHook(() => usePageDefRegistry(), { wrapper })
+        const def = makeDef()
+
+        act(() => {
+            result.current.register('/blog', def)
+        })
+
+        expect(result.current.resolve('/blog')).toBe(def)
+    })
+
+    test('resolve returns undefined for unknown path', () => {
+        const { result } = renderHook(() => usePageDefRegistry(), { wrapper })
+
+        expect(result.current.resolve('/nowhere')).toBeUndefined()
+    })
+
+    test('unregister with the same pageDef removes the entry', () => {
+        const { result } = renderHook(() => usePageDefRegistry(), { wrapper })
+        const def = makeDef()
+
+        act(() => {
+            result.current.register('/blog', def)
+            result.current.unregister('/blog', def)
+        })
+
+        expect(result.current.resolve('/blog')).toBeUndefined()
+    })
+
+    test('unregister with a stale pageDef is a no-op (fast remount race)', () => {
+        const { result } = renderHook(() => usePageDefRegistry(), { wrapper })
+        const defA = makeDef()
+        const defB = makeDef()
+
+        act(() => {
+            result.current.register('/blog', defA)
+            result.current.register('/blog', defB) // B overwrites A
+            result.current.unregister('/blog', defA) // stale unregister
+        })
+
+        expect(result.current.resolve('/blog')).toBe(defB)
+    })
+
+    test('register with same path overwrites', () => {
+        const { result } = renderHook(() => usePageDefRegistry(), { wrapper })
+        const defA = makeDef()
+        const defB = makeDef()
+
+        act(() => {
+            result.current.register('/blog', defA)
+            result.current.register('/blog', defB)
+        })
+
+        expect(result.current.resolve('/blog')).toBe(defB)
+    })
+
+    test('useRegisterPageDef registers under the current pathname', () => {
+        const def = makeDef()
+
+        let resolveRef:
+            | ReturnType<typeof usePageDefRegistry>['resolve']
+            | null = null
+        function Spy() {
+            resolveRef = usePageDefRegistry().resolve
+            return null
+        }
+        function Probe() {
+            useRegisterPageDef(def)
+            return null
+        }
+
+        render(
+            <MemoryRouter initialEntries={['/stuff/flash/foo']}>
+                <PageDefRegistryProvider>
+                    <Spy />
+                    <Probe />
+                </PageDefRegistryProvider>
+            </MemoryRouter>,
+        )
+
+        expect(resolveRef!('/stuff/flash/foo')).toBe(def)
+        expect(resolveRef!('/stuff/flash')).toBeUndefined()
+    })
+
+    test('useRegisterPageDef unmount clears the entry', () => {
+        const def = makeDef()
+
+        function Probe() {
+            useRegisterPageDef(def)
+            return null
+        }
+        function Mounter({ show }: { show: boolean }) {
+            return show ? <Probe /> : null
+        }
+
+        let resolveRef:
+            | ReturnType<typeof usePageDefRegistry>['resolve']
+            | null = null
+        function Spy() {
+            resolveRef = usePageDefRegistry().resolve
+            return null
+        }
+
+        const { rerender } = render(
+            <MemoryRouter initialEntries={['/blog']}>
+                <PageDefRegistryProvider>
+                    <Spy />
+                    <Mounter show={true} />
+                </PageDefRegistryProvider>
+            </MemoryRouter>,
+        )
+
+        expect(resolveRef!('/blog')).toBe(def)
+
+        rerender(
+            <MemoryRouter initialEntries={['/blog']}>
+                <PageDefRegistryProvider>
+                    <Spy />
+                    <Mounter show={false} />
+                </PageDefRegistryProvider>
+            </MemoryRouter>,
+        )
+
+        expect(resolveRef!('/blog')).toBeUndefined()
+    })
+})

--- a/web/src/transitions/PageDefRegistry.tsx
+++ b/web/src/transitions/PageDefRegistry.tsx
@@ -1,0 +1,66 @@
+import { createContext, use, useEffect, useState, type ReactNode } from 'react'
+import { useLocation } from 'react-router-dom'
+import type { PageDef } from '../physics/PageDef'
+
+export interface PageDefRegistryAPI {
+    register(path: string, def: PageDef): void
+    unregister(path: string, def: PageDef): void
+    resolve(path: string): PageDef | undefined
+}
+
+class PageDefRegistryStore implements PageDefRegistryAPI {
+    private entries = new Map<string, PageDef>()
+
+    register = (path: string, def: PageDef): void => {
+        this.entries.set(path, def)
+    }
+
+    // Identity-guarded: only deletes when the entry still matches the def the
+    // caller registered. Prevents fast remounts (StrictMode, route swaps) where
+    // the incoming mount registers a new def before the outgoing unmount fires.
+    unregister = (path: string, def: PageDef): void => {
+        if (this.entries.get(path) === def) {
+            this.entries.delete(path)
+        }
+    }
+
+    resolve = (path: string): PageDef | undefined => {
+        return this.entries.get(path)
+    }
+}
+
+const PageDefRegistryContext = createContext<PageDefRegistryAPI | null>(null)
+
+export function PageDefRegistryProvider({ children }: { children: ReactNode }) {
+    const [store] = useState(() => new PageDefRegistryStore())
+    return (
+        <PageDefRegistryContext.Provider value={store}>
+            {children}
+        </PageDefRegistryContext.Provider>
+    )
+}
+
+export function usePageDefRegistry(): PageDefRegistryAPI {
+    const api = use(PageDefRegistryContext)
+    if (!api)
+        throw new Error(
+            'usePageDefRegistry: must be used inside <PageDefRegistryProvider>',
+        )
+    return api
+}
+
+/**
+ * Register a PageDef under the current `location.pathname` for the lifetime of
+ * the calling component. Callers are responsible for memoizing `pageDef`
+ * (e.g. via `useMemo`) so the effect does not re-run on every parent render.
+ */
+export function useRegisterPageDef(pageDef: PageDef): void {
+    const registry = usePageDefRegistry()
+    const { pathname } = useLocation()
+    useEffect(() => {
+        registry.register(pathname, pageDef)
+        return () => {
+            registry.unregister(pathname, pageDef)
+        }
+    }, [registry, pathname, pageDef])
+}

--- a/web/src/transitions/PhysicsCardImpl.tsx
+++ b/web/src/transitions/PhysicsCardImpl.tsx
@@ -21,6 +21,7 @@ export function PhysicsCardImpl({ entry }: PhysicsCardImplProps) {
     const {
         id,
         parent,
+        trail,
         kind,
         buoyancy,
         anchor,
@@ -45,6 +46,7 @@ export function PhysicsCardImpl({ entry }: PhysicsCardImplProps) {
     const anchorRef = useRef(anchor)
     anchorRef.current = anchor
     const tetherHandleRef = useRef<TetherHandle | null>(null)
+    const trailTetherHandleRef = useRef<TetherHandle | null>(null)
 
     const registry = useMinimizedRegistry()
     const isMinimized = useIsMinimized(minimizable ? id : undefined)
@@ -101,6 +103,7 @@ export function PhysicsCardImpl({ entry }: PhysicsCardImplProps) {
         if (buoyancy) world.setBuoyancy(handle, buoyancy)
 
         let rafId = 0
+        let trailRafId = 0
         if (parent) {
             const resolved = resolveParent(world, parent)
             if (resolved.handle != null) {
@@ -121,6 +124,35 @@ export function PhysicsCardImpl({ entry }: PhysicsCardImplProps) {
                         return
                     }
                     tetherHandleRef.current = wireTetherFor(
+                        world,
+                        retried.handle,
+                        retried.kind,
+                        handle,
+                        anchorRef.current,
+                    )
+                })
+            }
+        }
+        if (trail) {
+            const resolved = resolveParent(world, trail)
+            if (resolved.handle != null) {
+                trailTetherHandleRef.current = wireTetherFor(
+                    world,
+                    resolved.handle,
+                    resolved.kind,
+                    handle,
+                    anchorRef.current,
+                )
+            } else {
+                trailRafId = requestAnimationFrame(() => {
+                    const retried = resolveParent(world, trail)
+                    if (retried.handle == null) {
+                        console.warn(
+                            `PhysicsCard: trail "${trail}" not found after one frame; tether skipped`,
+                        )
+                        return
+                    }
+                    trailTetherHandleRef.current = wireTetherFor(
                         world,
                         retried.handle,
                         retried.kind,
@@ -196,9 +228,14 @@ export function PhysicsCardImpl({ entry }: PhysicsCardImplProps) {
 
         return () => {
             cancelAnimationFrame(rafId)
+            cancelAnimationFrame(trailRafId)
             if (tetherHandleRef.current !== null) {
                 world.untether(tetherHandleRef.current)
                 tetherHandleRef.current = null
+            }
+            if (trailTetherHandleRef.current !== null) {
+                world.untether(trailTetherHandleRef.current)
+                trailTetherHandleRef.current = null
             }
             world.unregister(handle)
             handleRef.current = null
@@ -208,7 +245,7 @@ export function PhysicsCardImpl({ entry }: PhysicsCardImplProps) {
                 window.removeEventListener('pointerup', onPointerUp)
             }
         }
-    }, [world, id, width, height, isMinimized, draggable, parent, buoyancy])
+    }, [world, id, width, height, isMinimized, draggable, parent, trail, buoyancy])
 
     useEffect(() => {
         if (handleRef.current === null) return
@@ -227,7 +264,21 @@ export function PhysicsCardImpl({ entry }: PhysicsCardImplProps) {
                 )
             }
         }
-    }, [world, anchor.x, anchor.y, parent])
+        if (trailTetherHandleRef.current !== null && trail) {
+            world.untether(trailTetherHandleRef.current)
+            trailTetherHandleRef.current = null
+            const resolved = resolveParent(world, trail)
+            if (resolved.handle != null) {
+                trailTetherHandleRef.current = wireTetherFor(
+                    world,
+                    resolved.handle,
+                    resolved.kind,
+                    handleRef.current,
+                    anchor,
+                )
+            }
+        }
+    }, [world, anchor.x, anchor.y, parent, trail])
 
     useEffect(() => {
         if (isMinimized || !minimizable) return

--- a/web/src/transitions/TransitionDirector.test.tsx
+++ b/web/src/transitions/TransitionDirector.test.tsx
@@ -5,6 +5,7 @@ import { MemoryRouter, Routes, Route, useNavigate } from 'react-router-dom'
 import { PhysicsProvider } from '../physics/PhysicsContext'
 import { TransitionDirector } from './TransitionDirector'
 import { PhysicsLayer } from './PhysicsLayer'
+import { PageDefRegistryProvider } from './PageDefRegistry'
 import { PhysicsCard } from '../physics/PhysicsCard'
 import type { PageDef } from '../physics/PageDef'
 
@@ -80,15 +81,17 @@ function Harness() {
     return (
         <MemoryRouter initialEntries={['/a']}>
             <PhysicsProvider>
-                <TransitionDirector pageDefs={pageDefs}>
-                    <PhysicsLayer />
-                    <NavigateButton to="/a" label="go-a" />
-                    <NavigateButton to="/b" label="go-b" />
-                    <Routes>
-                        <Route path="/a" element={<RouteA />} />
-                        <Route path="/b" element={<RouteB />} />
-                    </Routes>
-                </TransitionDirector>
+                <PageDefRegistryProvider>
+                    <TransitionDirector pageDefs={pageDefs}>
+                        <PhysicsLayer />
+                        <NavigateButton to="/a" label="go-a" />
+                        <NavigateButton to="/b" label="go-b" />
+                        <Routes>
+                            <Route path="/a" element={<RouteA />} />
+                            <Route path="/b" element={<RouteB />} />
+                        </Routes>
+                    </TransitionDirector>
+                </PageDefRegistryProvider>
             </PhysicsProvider>
         </MemoryRouter>
     )
@@ -123,13 +126,15 @@ describe('TransitionDirector — provider mount', () => {
             return (
                 <MemoryRouter initialEntries={[path]} key={path}>
                     <PhysicsProvider>
-                        <TransitionDirector pageDefs={pageDefs}>
-                            <PhysicsLayer />
-                            <Routes>
-                                <Route path="/a" element={<RouteA />} />
-                                <Route path="/b" element={<RouteB />} />
-                            </Routes>
-                        </TransitionDirector>
+                        <PageDefRegistryProvider>
+                            <TransitionDirector pageDefs={pageDefs}>
+                                <PhysicsLayer />
+                                <Routes>
+                                    <Route path="/a" element={<RouteA />} />
+                                    <Route path="/b" element={<RouteB />} />
+                                </Routes>
+                            </TransitionDirector>
+                        </PageDefRegistryProvider>
                     </PhysicsProvider>
                 </MemoryRouter>
             )

--- a/web/src/transitions/TransitionDirector.tsx
+++ b/web/src/transitions/TransitionDirector.tsx
@@ -11,7 +11,13 @@ import { useLocation, useNavigationType, type Location } from 'react-router-dom'
 import { usePhysicsWorld } from '../physics/PhysicsContext'
 import { useCardRegistry, type PhysicsCardEntry } from './CardRegistry'
 import { classifyDirection, type NavigationType } from './classifyDirection'
-import { dispatch, type EdgeTransitions, type TransitionPlan } from './dispatch'
+import {
+    dispatch,
+    type EdgeTransitions,
+    type PageDefResolver,
+    type TransitionPlan,
+} from './dispatch'
+import { usePageDefRegistry } from './PageDefRegistry'
 import { usePrefersReducedMotion } from '../lib/usePrefersReducedMotion'
 import { stringCutDrop } from './primitives/stringCutDrop'
 import { pourInDrop, type PourInDropEntry } from './primitives/pourInDrop'
@@ -87,7 +93,16 @@ export function TransitionDirector({
     const navType = useNavigationType() as NavigationType
     const reduced = usePrefersReducedMotion()
     const registry = useCardRegistry()
+    const pageDefRegistry = usePageDefRegistry()
     const world = usePhysicsWorld()
+
+    // Runtime registrations (via useRegisterPageDef) take precedence over the
+    // static map. This is how dynamic routes (/blog/:slug, /stuff/flash/:slug)
+    // participate in dispatch.
+    const resolvePageDef: PageDefResolver = useCallback(
+        (path: string) => pageDefRegistry.resolve(path) ?? pageDefs[path],
+        [pageDefRegistry, pageDefs],
+    )
 
     const prevLocationRef = useRef<Location | null>(null)
     const reducedRef = useRef(reduced)
@@ -156,7 +171,7 @@ export function TransitionDirector({
 
     const dispatchTransition = useCallback(
         (fromPath: string, toPath: string, direction: ReturnType<typeof classifyDirection>) => {
-            const plan = dispatch(fromPath, toPath, pageDefs, edges, direction)
+            const plan = dispatch(fromPath, toPath, resolvePageDef, edges, direction)
             return executeTransition(fromPath, toPath, plan).catch((err) => {
                 if (import.meta.env.DEV) throw err
                 console.warn(
@@ -168,7 +183,7 @@ export function TransitionDirector({
                 }
             })
         },
-        [pageDefs, edges, executeTransition, registry],
+        [resolvePageDef, edges, executeTransition, registry],
     )
 
     // Phase 1: BEFORE old route's cleanups, mark every currently-active card

--- a/web/src/transitions/TransitionDirector.tsx
+++ b/web/src/transitions/TransitionDirector.tsx
@@ -186,6 +186,37 @@ export function TransitionDirector({
         [resolvePageDef, edges, executeTransition, registry],
     )
 
+    const isTransitionTrigger = useCallback(
+        (
+            prev: Location,
+            next: Location,
+        ): { trigger: boolean; from: string; to: string } => {
+            const samePath = prev.pathname === next.pathname
+            if (!samePath) {
+                return {
+                    trigger: true,
+                    from: prev.pathname,
+                    to: next.pathname,
+                }
+            }
+            const hashChanged = prev.hash !== next.hash
+            if (!hashChanged) {
+                return { trigger: false, from: '', to: '' }
+            }
+            // Same-pathname hash change is only a transition if the destination
+            // pageDef opts in via `sections`. Otherwise, treat as a non-event
+            // (e.g. clicking a `#footer` link should not animate cards).
+            const sections = resolvePageDef(next.pathname)?.sections
+            if (!sections) return { trigger: false, from: '', to: '' }
+            return {
+                trigger: true,
+                from: `${prev.pathname}${prev.hash}`,
+                to: `${next.pathname}${next.hash}`,
+            }
+        },
+        [resolvePageDef],
+    )
+
     // Phase 1: BEFORE old route's cleanups, mark every currently-active card
     // as exiting so the registry preserves them across the unmount. Sourcing
     // from the registry (instead of pageDefs[prev]) covers routes that are
@@ -193,11 +224,13 @@ export function TransitionDirector({
     // cards would otherwise pop out instantly when the route unmounts.
     useLayoutEffect(() => {
         const prev = prevLocationRef.current
-        if (!prev || prev.pathname === location.pathname) return
+        if (!prev) return
+        const { trigger } = isTransitionTrigger(prev, location)
+        if (!trigger) return
         for (const entry of registry.snapshot()) {
             if (entry.state === 'active') registry.markExiting(entry.id)
         }
-    }, [location, registry])
+    }, [location, registry, isTransitionTrigger])
 
     // Phase 2: AFTER children's effects (new cards now registered in PhysicsWorld),
     // dispatch and execute the transition primitives.
@@ -207,14 +240,15 @@ export function TransitionDirector({
             prevLocationRef.current = location
             return
         }
-        if (prev.pathname === location.pathname) {
+        const { trigger, from, to } = isTransitionTrigger(prev, location)
+        if (!trigger) {
             prevLocationRef.current = location
             return
         }
         const direction = classifyDirection(navType)
-        dispatchTransition(prev.pathname, location.pathname, direction)
+        dispatchTransition(from, to, direction)
         prevLocationRef.current = location
-    }, [location, navType, dispatchTransition])
+    }, [location, navType, dispatchTransition, isTransitionTrigger])
 
     const runTransition = useCallback(
         ({ from, to }: RunTransitionArgs) => {

--- a/web/src/transitions/dispatch.test.ts
+++ b/web/src/transitions/dispatch.test.ts
@@ -1,22 +1,26 @@
 import { describe, test, expect } from 'vitest'
 import { dispatch } from './dispatch'
 import type { PageDef } from '../physics/PageDef'
-import type { EdgeTransitions } from './dispatch'
+import type { EdgeTransitions, PageDefResolver } from './dispatch'
 
 const homeDef: PageDef = { gravity: 'down', cards: [] }
 const blogDef: PageDef = { gravity: 'down', cards: [] }
 
+function resolverOf(map: Record<string, PageDef>): PageDefResolver {
+    return (path: string) => map[path]
+}
+
 describe('dispatch', () => {
     test('edge-table match wins over PageDef transitions', () => {
-        const pageDefs: Record<string, PageDef> = {
+        const resolve = resolverOf({
             '/a': { ...homeDef, transitions: { exit: 'string-cut-drop' } },
             '/b': { ...blogDef, transitions: { enter: 'pour-in-drop' } },
-        }
+        })
         const edges: EdgeTransitions = {
             '/a→/b': { primitive: 'anchor-slide', axis: 'horizontal' },
         }
 
-        const plan = dispatch('/a', '/b', pageDefs, edges, 'forward')
+        const plan = dispatch('/a', '/b', resolve, edges, 'forward')
 
         expect(plan.kind).toBe('coupled')
         if (plan.kind === 'coupled') {
@@ -26,28 +30,25 @@ describe('dispatch', () => {
     })
 
     test('PageDef decoupled pair wins over history-direction default', () => {
-        const pageDefs: Record<string, PageDef> = {
+        const resolve = resolverOf({
             '/a': { ...homeDef, transitions: { exit: 'cross-fade' } },
             '/b': blogDef,
-        }
+        })
 
-        const plan = dispatch('/a', '/b', pageDefs, {}, 'forward')
+        const plan = dispatch('/a', '/b', resolve, {}, 'forward')
 
         expect(plan.kind).toBe('decoupled')
         if (plan.kind === 'decoupled') {
             expect(plan.exit).toBe('cross-fade')
-            expect(plan.enter).toBe('pour-in-drop') // falls back to default enter
+            expect(plan.enter).toBe('pour-in-drop')
             expect(plan.overlapMs).toBe(200)
         }
     })
 
     test('forward with no overrides → string-cut-drop + pour-in-drop decoupled', () => {
-        const pageDefs: Record<string, PageDef> = {
-            '/a': homeDef,
-            '/b': blogDef,
-        }
+        const resolve = resolverOf({ '/a': homeDef, '/b': blogDef })
 
-        const plan = dispatch('/a', '/b', pageDefs, {}, 'forward')
+        const plan = dispatch('/a', '/b', resolve, {}, 'forward')
 
         expect(plan).toEqual({
             kind: 'decoupled',
@@ -58,12 +59,9 @@ describe('dispatch', () => {
     })
 
     test('back with no overrides → same T1+T2 decoupled pair', () => {
-        const pageDefs: Record<string, PageDef> = {
-            '/a': homeDef,
-            '/b': blogDef,
-        }
+        const resolve = resolverOf({ '/a': homeDef, '/b': blogDef })
 
-        const plan = dispatch('/a', '/b', pageDefs, {}, 'back')
+        const plan = dispatch('/a', '/b', resolve, {}, 'back')
 
         expect(plan.kind).toBe('decoupled')
         if (plan.kind === 'decoupled') {
@@ -73,12 +71,9 @@ describe('dispatch', () => {
     })
 
     test('sibling with no overrides → anchor-slide horizontal coupled, sign=+1', () => {
-        const pageDefs: Record<string, PageDef> = {
-            '/a': homeDef,
-            '/b': blogDef,
-        }
+        const resolve = resolverOf({ '/a': homeDef, '/b': blogDef })
 
-        const plan = dispatch('/a', '/b', pageDefs, {}, 'sibling')
+        const plan = dispatch('/a', '/b', resolve, {}, 'sibling')
 
         expect(plan.kind).toBe('coupled')
         if (plan.kind === 'coupled') {
@@ -90,12 +85,12 @@ describe('dispatch', () => {
     })
 
     test('sibling with destination siblingOrder=left flips sign to -1', () => {
-        const pageDefs: Record<string, PageDef> = {
+        const resolve = resolverOf({
             '/a': homeDef,
             '/b': { ...blogDef, siblingOrder: 'left' },
-        }
+        })
 
-        const plan = dispatch('/a', '/b', pageDefs, {}, 'sibling')
+        const plan = dispatch('/a', '/b', resolve, {}, 'sibling')
 
         expect(plan.kind).toBe('coupled')
         if (plan.kind === 'coupled') {
@@ -104,12 +99,12 @@ describe('dispatch', () => {
     })
 
     test('edge with omitted sign uses direction (back → -1)', () => {
-        const pageDefs: Record<string, PageDef> = { '/a': homeDef, '/b': blogDef }
+        const resolve = resolverOf({ '/a': homeDef, '/b': blogDef })
         const edges: EdgeTransitions = {
             '/a→/b': { primitive: 'anchor-slide', axis: 'horizontal' },
         }
 
-        const plan = dispatch('/a', '/b', pageDefs, edges, 'back')
+        const plan = dispatch('/a', '/b', resolve, edges, 'back')
 
         expect(plan.kind).toBe('coupled')
         if (plan.kind === 'coupled') {
@@ -118,16 +113,35 @@ describe('dispatch', () => {
     })
 
     test('edge with explicit sign overrides direction', () => {
-        const pageDefs: Record<string, PageDef> = { '/a': homeDef, '/b': blogDef }
+        const resolve = resolverOf({ '/a': homeDef, '/b': blogDef })
         const edges: EdgeTransitions = {
             '/a→/b': { primitive: 'anchor-slide', axis: 'horizontal', sign: 1 },
         }
 
-        const plan = dispatch('/a', '/b', pageDefs, edges, 'back')
+        const plan = dispatch('/a', '/b', resolve, edges, 'back')
 
         expect(plan.kind).toBe('coupled')
         if (plan.kind === 'coupled') {
             expect(plan.config.sign).toBe(1)
+        }
+    })
+
+    test('resolver is consulted by path (not a pre-built map snapshot)', () => {
+        // Simulates runtime registration: the resolver returns a PageDef that
+        // wasn't known at director-construction time.
+        const runtime = new Map<string, PageDef>()
+        const resolve: PageDefResolver = (p) => runtime.get(p)
+
+        runtime.set('/blog/abc', {
+            ...blogDef,
+            transitions: { enter: 'cross-fade' },
+        })
+
+        const plan = dispatch('/a', '/blog/abc', resolve, {}, 'forward')
+
+        expect(plan.kind).toBe('decoupled')
+        if (plan.kind === 'decoupled') {
+            expect(plan.enter).toBe('cross-fade')
         }
     })
 })

--- a/web/src/transitions/dispatch.test.ts
+++ b/web/src/transitions/dispatch.test.ts
@@ -126,6 +126,66 @@ describe('dispatch', () => {
         }
     })
 
+    test('hash-section: same path with sections → coupled anchor-slide vertical w/ ceiling sensor', () => {
+        const resolve = resolverOf({
+            '/blog': { ...blogDef, sections: { mode: 'auto-chain' } },
+        })
+
+        const plan = dispatch('/blog', '/blog#s2', resolve, {}, 'forward')
+
+        expect(plan.kind).toBe('coupled')
+        if (plan.kind === 'coupled') {
+            expect(plan.config.primitive).toBe('anchor-slide')
+            expect(plan.config.axis).toBe('vertical')
+            expect(plan.config.sign).toBe(1)
+            expect(plan.config.sensorEdges).toBe('ceiling')
+        }
+    })
+
+    test('hash-section: back direction yields sign=-1 and floor sensor', () => {
+        const resolve = resolverOf({
+            '/blog': { ...blogDef, sections: { mode: 'auto-chain' } },
+        })
+
+        const plan = dispatch('/blog#s3', '/blog#s2', resolve, {}, 'back')
+
+        expect(plan.kind).toBe('coupled')
+        if (plan.kind === 'coupled') {
+            expect(plan.config.axis).toBe('vertical')
+            expect(plan.config.sign).toBe(-1)
+            expect(plan.config.sensorEdges).toBe('floor')
+        }
+    })
+
+    test('hash-section: pageDef without sections falls through to default', () => {
+        const resolve = resolverOf({ '/blog': blogDef })
+
+        // Same pathname, but no sections declared → not a section transition.
+        // Falls through to history-direction default.
+        const plan = dispatch('/blog', '/blog#s2', resolve, {}, 'forward')
+
+        // With no sections, same-path transitions are unusual; the safest
+        // fallback is the default decoupled T1+T2 (or whatever the regular
+        // dispatch would produce). Just assert it's NOT a vertical anchor-slide
+        // — the section branch did not fire.
+        if (plan.kind === 'coupled') {
+            expect(plan.config.axis).not.toBe('vertical')
+        }
+    })
+
+    test('hash-section: different pathnames bypass the section branch', () => {
+        const resolve = resolverOf({
+            '/blog': { ...blogDef, sections: { mode: 'auto-chain' } },
+            '/a': homeDef,
+        })
+
+        const plan = dispatch('/a', '/blog#s2', resolve, {}, 'forward')
+
+        // Cross-route nav, even with a hash on the target, should not invoke
+        // the section branch.
+        expect(plan.kind).toBe('decoupled')
+    })
+
     test('resolver is consulted by path (not a pre-built map snapshot)', () => {
         // Simulates runtime registration: the resolver returns a PageDef that
         // wasn't known at director-construction time.

--- a/web/src/transitions/dispatch.ts
+++ b/web/src/transitions/dispatch.ts
@@ -6,6 +6,7 @@ export interface AnchorSlideConfig {
     axis: 'horizontal' | 'vertical'
     sign: 1 | -1
     durationMs: number
+    sensorEdges?: 'ceiling' | 'floor' | 'none'
 }
 
 export type CoupledConfig = AnchorSlideConfig
@@ -37,6 +38,22 @@ function signFromDirection(direction: Direction): 1 | -1 {
     return direction === 'back' ? -1 : 1
 }
 
+function splitPathAndHash(s: string): { pathname: string; hash: string } {
+    const i = s.indexOf('#')
+    if (i === -1) return { pathname: s, hash: '' }
+    return { pathname: s.slice(0, i), hash: s.slice(i) }
+}
+
+/**
+ * Parse a hash like `#s2` → 2. Empty / unrecognised → 1 (canonical section).
+ */
+export function parseSectionHash(hash: string): number {
+    const m = /^#s(\d+)$/.exec(hash)
+    if (!m) return 1
+    const n = Number.parseInt(m[1]!, 10)
+    return Number.isFinite(n) && n >= 1 ? n : 1
+}
+
 export function dispatch(
     from: string,
     to: string,
@@ -44,6 +61,34 @@ export function dispatch(
     edges: EdgeTransitions,
     direction: Direction,
 ): TransitionPlan {
+    const fromParts = splitPathAndHash(from)
+    const toParts = splitPathAndHash(to)
+
+    // Within-page section transition: same pathname, sections-bearing pageDef,
+    // hashes differ. Produces a vertical anchor-slide whose sign is determined
+    // by the section delta, not history direction.
+    if (fromParts.pathname === toParts.pathname && fromParts.hash !== toParts.hash) {
+        const def = resolvePageDef(toParts.pathname)
+        if (def?.sections) {
+            const fromIdx = parseSectionHash(fromParts.hash)
+            const toIdx = parseSectionHash(toParts.hash)
+            const sign: 1 | -1 = toIdx > fromIdx ? 1 : -1
+            // T4: forward (sign=+1) drags chain up through the ceiling;
+            // back (sign=-1) drags down through the floor.
+            const sensorEdges: 'ceiling' | 'floor' = sign === 1 ? 'ceiling' : 'floor'
+            return {
+                kind: 'coupled',
+                config: {
+                    primitive: 'anchor-slide',
+                    axis: 'vertical',
+                    sign,
+                    durationMs: DEFAULT_ANCHOR_SLIDE_DURATION_MS,
+                    sensorEdges,
+                },
+            }
+        }
+    }
+
     const edgeKey = `${from}→${to}`
     const edge = edges[edgeKey]
     if (edge) {
@@ -58,8 +103,8 @@ export function dispatch(
         }
     }
 
-    const fromDef = resolvePageDef(from)
-    const toDef = resolvePageDef(to)
+    const fromDef = resolvePageDef(fromParts.pathname)
+    const toDef = resolvePageDef(toParts.pathname)
     const fromExit = fromDef?.transitions?.exit
     const toEnter = toDef?.transitions?.enter
     if (fromExit || toEnter) {

--- a/web/src/transitions/dispatch.ts
+++ b/web/src/transitions/dispatch.ts
@@ -28,6 +28,8 @@ export interface EdgeConfig {
 
 export type EdgeTransitions = Record<string, EdgeConfig>
 
+export type PageDefResolver = (path: string) => PageDef | undefined
+
 const DEFAULT_DECOUPLED_OVERLAP_MS = 200
 const DEFAULT_ANCHOR_SLIDE_DURATION_MS = 700
 
@@ -38,7 +40,7 @@ function signFromDirection(direction: Direction): 1 | -1 {
 export function dispatch(
     from: string,
     to: string,
-    pageDefs: Record<string, PageDef>,
+    resolvePageDef: PageDefResolver,
     edges: EdgeTransitions,
     direction: Direction,
 ): TransitionPlan {
@@ -56,8 +58,10 @@ export function dispatch(
         }
     }
 
-    const fromExit = pageDefs[from]?.transitions?.exit
-    const toEnter = pageDefs[to]?.transitions?.enter
+    const fromDef = resolvePageDef(from)
+    const toDef = resolvePageDef(to)
+    const fromExit = fromDef?.transitions?.exit
+    const toEnter = toDef?.transitions?.enter
     if (fromExit || toEnter) {
         return {
             kind: 'decoupled',
@@ -68,7 +72,7 @@ export function dispatch(
     }
 
     if (direction === 'sibling') {
-        const siblingOrder = pageDefs[to]?.siblingOrder
+        const siblingOrder = toDef?.siblingOrder
         const sign: 1 | -1 = siblingOrder === 'left' ? -1 : 1
         return {
             kind: 'coupled',

--- a/web/src/transitions/primitives/anchorSlide.test.ts
+++ b/web/src/transitions/primitives/anchorSlide.test.ts
@@ -89,9 +89,11 @@ describe('anchorSlide (T3) — horizontal', () => {
         )
 
         step(0)
-        // toCard with sign=+1: enters from origin side (left) — initial position pushed off-screen left
+        // toCard with sign=+1 horizontal: enters from the RIGHT (the opposite
+        // side of the from-card's exit direction) — both cards slide left
+        // together as a unified strip.
         const initialPos = world.getPosition(b)
-        expect(initialPos.x).toBeLessThanOrEqual(-100)
+        expect(initialPos.x).toBeGreaterThanOrEqual(viewport.width)
 
         // At end, reaches its layout position
         step(700)
@@ -226,6 +228,60 @@ describe('anchorSlide (T3) — horizontal', () => {
         // sign=+1 vertical → from-card exits upward (y decreases)
         expect(final.y).toBeLessThan(start.y)
         expect(final.y).toBeLessThan(-50)
+    })
+
+    test('vertical sign=+1: to-card enters from BELOW (opposite of from-exit direction)', () => {
+        // Unified-strip slide: from-card exits UP (sign=+1 vertical) and the
+        // new card enters from BELOW the viewport, both moving up together.
+        // The previous behaviour had to-card entering from above — which made
+        // the two cards pass through each other vertically.
+        const viewport = { width: 800, height: 600 }
+        const world = new PhysicsWorld({ viewport })
+        const b = world.registerById(
+            'b',
+            { x: 400, y: 300 },
+            { width: 200, height: 100 },
+        )
+        const step = anchorSlide(
+            world,
+            { fromIds: [], toIds: ['b'] },
+            {
+                axis: 'vertical',
+                sign: 1,
+                durationMs: 700,
+                viewport,
+            },
+        )
+        step(0)
+        // sign=+1 vertical → to-card starts BELOW (y > viewport.height)
+        expect(world.getPosition(b).y).toBeGreaterThan(viewport.height)
+        step(700)
+        expect(world.getPosition(b).y).toBeCloseTo(300, 1)
+    })
+
+    test('vertical sign=-1: to-card enters from ABOVE (falls down into view)', () => {
+        const viewport = { width: 800, height: 600 }
+        const world = new PhysicsWorld({ viewport })
+        const b = world.registerById(
+            'b',
+            { x: 400, y: 300 },
+            { width: 200, height: 100 },
+        )
+        const step = anchorSlide(
+            world,
+            { fromIds: [], toIds: ['b'] },
+            {
+                axis: 'vertical',
+                sign: -1,
+                durationMs: 700,
+                viewport,
+            },
+        )
+        step(0)
+        // sign=-1 vertical → to-card starts ABOVE (negative y)
+        expect(world.getPosition(b).y).toBeLessThan(0)
+        step(700)
+        expect(world.getPosition(b).y).toBeCloseTo(300, 1)
     })
 
     test('sensorEdges: ceiling — toggles ceiling sensor on init, restores at end', () => {

--- a/web/src/transitions/primitives/anchorSlide.test.ts
+++ b/web/src/transitions/primitives/anchorSlide.test.ts
@@ -199,6 +199,122 @@ describe('anchorSlide (T3) — horizontal', () => {
         expect(restored[0]!.parent).toBe(world.ceilingHandle)
     })
 
+    test('vertical axis: from-card exits along axis × -sign', () => {
+        const viewport = { width: 800, height: 600 }
+        const world = new PhysicsWorld({ viewport })
+        const a = world.registerById(
+            'a',
+            { x: 400, y: 300 },
+            { width: 200, height: 100 },
+        )
+
+        const step = anchorSlide(
+            world,
+            { fromIds: ['a'], toIds: [] },
+            {
+                axis: 'vertical',
+                sign: 1,
+                durationMs: 700,
+                viewport,
+            },
+        )
+
+        step(0)
+        const start = world.getPosition(a)
+        step(700)
+        const final = world.getPosition(a)
+        // sign=+1 vertical → from-card exits upward (y decreases)
+        expect(final.y).toBeLessThan(start.y)
+        expect(final.y).toBeLessThan(-50)
+    })
+
+    test('sensorEdges: ceiling — toggles ceiling sensor on init, restores at end', () => {
+        const viewport = { width: 800, height: 600 }
+        const world = new PhysicsWorld({ viewport })
+        world.registerById(
+            'a',
+            { x: 400, y: 300 },
+            { width: 200, height: 100 },
+        )
+
+        expect(world.isSensor(world.ceilingHandle)).toBe(false)
+
+        const step = anchorSlide(
+            world,
+            { fromIds: ['a'], toIds: [] },
+            {
+                axis: 'vertical',
+                sign: 1,
+                durationMs: 700,
+                viewport,
+                sensorEdges: 'ceiling',
+            },
+        )
+
+        step(0)
+        expect(world.isSensor(world.ceilingHandle)).toBe(true)
+
+        step(700)
+        expect(world.isSensor(world.ceilingHandle)).toBe(false)
+    })
+
+    test('sensorEdges: floor — toggles floor sensor (back/T4-back direction)', () => {
+        const viewport = { width: 800, height: 600 }
+        const world = new PhysicsWorld({ viewport })
+        world.registerById(
+            'a',
+            { x: 400, y: 300 },
+            { width: 200, height: 100 },
+        )
+
+        const step = anchorSlide(
+            world,
+            { fromIds: ['a'], toIds: [] },
+            {
+                axis: 'vertical',
+                sign: -1,
+                durationMs: 100,
+                viewport,
+                sensorEdges: 'floor',
+            },
+        )
+
+        step(0)
+        expect(world.isSensor(world.floorHandle)).toBe(true)
+        expect(world.isSensor(world.ceilingHandle)).toBe(false)
+
+        step(100)
+        expect(world.isSensor(world.floorHandle)).toBe(false)
+    })
+
+    test('sensorEdges omitted — neither edge is toggled', () => {
+        const viewport = { width: 800, height: 600 }
+        const world = new PhysicsWorld({ viewport })
+        world.registerById(
+            'a',
+            { x: 400, y: 300 },
+            { width: 200, height: 100 },
+        )
+
+        const step = anchorSlide(
+            world,
+            { fromIds: ['a'], toIds: [] },
+            {
+                axis: 'vertical',
+                sign: 1,
+                durationMs: 100,
+                viewport,
+            },
+        )
+
+        step(0)
+        expect(world.isSensor(world.ceilingHandle)).toBe(false)
+        expect(world.isSensor(world.floorHandle)).toBe(false)
+        step(100)
+        expect(world.isSensor(world.ceilingHandle)).toBe(false)
+        expect(world.isSensor(world.floorHandle)).toBe(false)
+    })
+
     test('from-card tether is captured on init and NOT restored (card is dying)', () => {
         const viewport = { width: 800, height: 600 }
         const world = new PhysicsWorld({ viewport })

--- a/web/src/transitions/primitives/anchorSlide.ts
+++ b/web/src/transitions/primitives/anchorSlide.ts
@@ -124,8 +124,12 @@ export function anchorSlide(
                 const pos = world.getPosition(handle)
                 const layout = { x: pos.x, y: pos.y }
                 toLayout.set(id, layout)
-                // To-card enters from axis × -sign direction (origin side)
-                const enterOffset = offsetFor((-sign) as -1 | 1)
+                // To-card enters from the OPPOSITE side of the from-card's
+                // exit (sign direction) so the two move as a unified strip:
+                // e.g. forward vertical (sign=+1) → from exits up, to enters
+                // from below. Without this the cards would pass through
+                // each other in opposite directions.
+                const enterOffset = offsetFor(sign)
                 const start = {
                     x: layout.x + enterOffset.x,
                     y: layout.y + enterOffset.y,

--- a/web/src/transitions/primitives/anchorSlide.ts
+++ b/web/src/transitions/primitives/anchorSlide.ts
@@ -16,6 +16,12 @@ export interface AnchorSlideOpts {
     sign: 1 | -1
     durationMs: number
     viewport: Viewport
+    /**
+     * Temporarily toggle a viewport edge to sensor mode for the duration of the
+     * slide. Used by T4 (within-page section pagination) so chains can pass
+     * through the ceiling (forward) or floor (back) edge. Restored at the end.
+     */
+    sensorEdges?: 'ceiling' | 'floor' | 'none'
 }
 
 const OFFSCREEN_PAD = 100
@@ -59,9 +65,16 @@ export function anchorSlide(
     targets: AnchorSlideTargets,
     opts: AnchorSlideOpts,
 ): PrimitiveStep {
-    const { axis, sign, durationMs, viewport } = opts
+    const { axis, sign, durationMs, viewport, sensorEdges } = opts
     let elapsedMs = 0
     let initialized = false
+
+    const sensorEdgeHandle =
+        sensorEdges === 'ceiling'
+            ? world.ceilingHandle
+            : sensorEdges === 'floor'
+              ? world.floorHandle
+              : undefined
 
     const fromInitial = new Map<string, Vec2>()
     const fromFinal = new Map<string, Vec2>()
@@ -85,6 +98,9 @@ export function anchorSlide(
 
     return (dtMs) => {
         if (!initialized) {
+            if (sensorEdgeHandle !== undefined) {
+                world.setSensor(sensorEdgeHandle, true)
+            }
             for (const id of targets.fromIds) {
                 const handle = world.getHandleById(id)
                 if (handle === undefined) continue
@@ -168,6 +184,9 @@ export function anchorSlide(
                         captured.anchorA,
                     )
                 }
+            }
+            if (sensorEdgeHandle !== undefined) {
+                world.setSensor(sensorEdgeHandle, false)
             }
             return true
         }

--- a/web/src/transitions/useHashSection.test.tsx
+++ b/web/src/transitions/useHashSection.test.tsx
@@ -1,0 +1,86 @@
+import { describe, test, expect } from 'vitest'
+import { render, act } from '@testing-library/react'
+import { MemoryRouter, useLocation } from 'react-router-dom'
+import { useEffect, useRef } from 'react'
+import { useHashSection } from './useHashSection'
+
+function Capture({
+    onAPI,
+    onLocation,
+}: {
+    onAPI: (api: ReturnType<typeof useHashSection>) => void
+    onLocation: (loc: { pathname: string; hash: string }) => void
+}) {
+    const api = useHashSection()
+    onAPI(api)
+    const loc = useLocation()
+    const lastReport = useRef('')
+    useEffect(() => {
+        const key = `${loc.pathname}${loc.hash}`
+        if (key !== lastReport.current) {
+            lastReport.current = key
+            onLocation({ pathname: loc.pathname, hash: loc.hash })
+        }
+    }, [loc, onLocation])
+    return null
+}
+
+describe('useHashSection', () => {
+    test('sectionIndex reflects current hash', () => {
+        let api: ReturnType<typeof useHashSection> | null = null
+        render(
+            <MemoryRouter initialEntries={['/blog#s3']}>
+                <Capture onAPI={(a) => (api = a)} onLocation={() => {}} />
+            </MemoryRouter>,
+        )
+        expect(api!.sectionIndex).toBe(3)
+    })
+
+    test('sectionIndex is 1 when no hash present', () => {
+        let api: ReturnType<typeof useHashSection> | null = null
+        render(
+            <MemoryRouter initialEntries={['/blog']}>
+                <Capture onAPI={(a) => (api = a)} onLocation={() => {}} />
+            </MemoryRouter>,
+        )
+        expect(api!.sectionIndex).toBe(1)
+    })
+
+    test('goToSection(N) navigates to /pathname#sN', () => {
+        let api: ReturnType<typeof useHashSection> | null = null
+        const seen: { pathname: string; hash: string }[] = []
+        render(
+            <MemoryRouter initialEntries={['/blog']}>
+                <Capture
+                    onAPI={(a) => (api = a)}
+                    onLocation={(l) => seen.push(l)}
+                />
+            </MemoryRouter>,
+        )
+
+        act(() => {
+            api!.goToSection(2)
+        })
+
+        expect(seen.at(-1)).toEqual({ pathname: '/blog', hash: '#s2' })
+    })
+
+    test('goToSection(1) clears the hash (canonical section 1)', () => {
+        let api: ReturnType<typeof useHashSection> | null = null
+        const seen: { pathname: string; hash: string }[] = []
+        render(
+            <MemoryRouter initialEntries={['/blog#s2']}>
+                <Capture
+                    onAPI={(a) => (api = a)}
+                    onLocation={(l) => seen.push(l)}
+                />
+            </MemoryRouter>,
+        )
+
+        act(() => {
+            api!.goToSection(1)
+        })
+
+        expect(seen.at(-1)).toEqual({ pathname: '/blog', hash: '' })
+    })
+})

--- a/web/src/transitions/useHashSection.ts
+++ b/web/src/transitions/useHashSection.ts
@@ -1,0 +1,31 @@
+import { useCallback } from 'react'
+import { useLocation, useNavigate } from 'react-router-dom'
+import { parseSectionHash } from './dispatch'
+
+export interface UseHashSectionAPI {
+    sectionIndex: number
+    goToSection: (n: number, opts?: { push?: boolean }) => void
+}
+
+/**
+ * Read the current section from `location.hash` (`#sN`; absent = section 1)
+ * and expose a navigator for changing sections. The actual transition is
+ * dispatched by `TransitionDirector`'s observer, which sees the hash change
+ * and runs the section branch in `dispatch()` if the resolved pageDef has
+ * `sections`. This hook owns the URL; it does NOT trigger transitions.
+ */
+export function useHashSection(): UseHashSectionAPI {
+    const { pathname, hash } = useLocation()
+    const navigate = useNavigate()
+
+    const goToSection = useCallback(
+        (n: number, opts?: { push?: boolean }) => {
+            const newHash = n <= 1 ? '' : `#s${n}`
+            const replace = opts?.push === false
+            navigate(`${pathname}${newHash}`, { replace })
+        },
+        [navigate, pathname],
+    )
+
+    return { sectionIndex: parseSectionHash(hash), goToSection }
+}


### PR DESCRIPTION
## Summary

- Auto-paginates card chains when they overflow the viewport, keeping physics viewport-locked. Sections deep-link via `/route#sN` and animate with a new vertical anchor-slide (T4) that temporarily sensors the ceiling (forward) or floor (back) so chains pass through.
- Adds a runtime `PageDefRegistry` — dynamic routes (`/blog/:slug`, `/stuff/flash/:slug`) now participate in dispatch via `useRegisterPageDef`, closing the static-map gap that slice 21 left open.
- Introduces `kind: 'nav'` PhysicsCards (back/next), arrow-key navigation, focus follow, and aria labels.

## Notes / deviations

- **Auto-pagination is the default, not per-route opt-in** (confirmed with Chai). The issue framed `sections` as a flag a route sets; in practice the partitioner kicks in whenever a chain would overflow the viewport. The PageDef `sections` field remains as the opt-in for `mode: 'author'` (explicit grouping) and as the config carrier (`maxPerSection`, `sectionsPushHistory`).
- **`useHashSection` does not dispatch transitions** — it only owns URL state. Originally I had the hook calling `runTransition`, but the cleaner factoring is to let `TransitionDirector`'s observer see the location change and decide whether to animate (gated on the resolved pageDef having `sections`, so a stray `#footer` link can't trigger a slide).
- **T4 uses the existing `setSensor` API** rather than a new `setEdgeSensor`. PhysicsWorld already exposed `setSensor(handle, isSensor)` and `ceilingHandle`/`floorHandle`; I added a small `isSensor` getter for observability in tests.
- Nav-card tether length is derived from anchor distance to floor (~80px) rather than the spec's `NAV_TETHER_LEN = 24` constant. The constant is exported from `sectionLayout.ts` but not currently parameterizable on `PhysicsCard` (which derives length from anchors). I left this as the auto-derived default — a future change to `PhysicsCard` could honor an explicit `tetherLength` prop.
- BlogIndex `buildChain` now returns `{ pageDef, cardContent, heights }` (heights map added for the partitioner). No behavior change for callers that ignore `heights`.

## Acceptance criteria

- [x] PageDef `sections` field supported with `mode: 'author'` and `mode: 'auto-chain'` (types + partitioner tests)
- [x] Auto-chain partitioning splits sections at correct viewport boundaries (`sectionLayout.test.ts`)
- [x] Per-card `sectionBreak: 'before' | 'after'` overrides auto-overflow (tested)
- [x] `useHashSection()` subscribes to location and dispatches section transitions (rerouted through the director; tested)
- [x] Section 1 has no hash; sections N>1 use `#sN` (`goToSection(1)` clears hash; tested)
- [x] `sectionsPushHistory` toggles push vs replace; default = push (`{push:false}` → replace; type field declared)
- [ ] Browser back/forward navigates between sections when push is enabled — relies on react-router's `navigate()` push behavior; needs in-browser verification
- [x] `anchor-slide` vertical (T4): forward pulls chain up, back pushes down (`anchorSlide` vertical axis test)
- [x] Ceiling/floor collision in sensor mode during T4 (sensorEdges tests; dispatch sets `'ceiling'` forward, `'floor'` back)
- [x] `kind: 'nav'` PhysicsCard, floor-strung, draggable but stable (kind added; parent: 'floor'; tether auto-derived)
- [x] Nav card visibility: section 1 → only next, last → only back, middle → both, narrow → single (partitioner test)
- [x] Arrow keys (← / →) trigger back/next when no input focused (keydown listener in BlogIndex)
- [x] Focus moves to new section's first focusable element after T4 completes (`setTimeout(700)` in BlogIndex)
- [x] `aria-label` on nav cards reflects section position (NavCardContent)
- [x] Reduced motion: section change is 150ms cross-fade (inherited from director's reduced-motion branch)
- [x] Narrow viewport: section count automatically grows (partitioner uses live `viewport.height`; tested)
- [x] `useRegisterPageDef(pageDef)` + `PageDefRegistry` context, keyed by `location.pathname`, auto-unregister on unmount (`PageDefRegistry.test.tsx`)
- [x] `TransitionDirector` resolves runtime first, then falls back to static map (composed resolver passed to `dispatch()`)
- [x] `FlashDetail` and `BlogPost` use `useRegisterPageDef` for slug-parameterized pageDefs
- [x] Tests: partitioner / `sectionBreak` / hash dispatch / T4 forward+back / nav visibility / keyboard nav / runtime registry precedence — all green

## Test plan

```sh
cd web
npm run typecheck   # clean
npm run test        # 322 tests pass
npm run build       # vite-react-ssg prerender intact (data-server-rendered="true" present)
```

Manual checks (run `npm run dev` and open in browser — I could not drive a browser from this session):

1. `/blog` renders section 1 with a chain of posts + a `Next →` nav card bottom-right.
2. Click `Next →`: T4 vertical — chain drags up off-screen, new section's chain enters from below; URL becomes `/blog#s2`.
3. Browser back → reverse T4; URL returns to `/blog`.
4. `←` / `→` arrow keys navigate sections; ignored while typing in an input.
5. Deep link `/blog#s2` loads directly into section 2.
6. DevTools rendering tab → `prefers-reduced-motion: reduce`: section swap is a 150ms cross-fade; nav cards still functional.
7. Resize narrow (~400px): nav becomes a single centered card; section count grows.
8. `/stuff/flash/<slug>` deep link works (FlashDetail registers its pageDef at runtime).
9. `/blog/<slug>` deep link works (BlogPost registers its pageDef at runtime).

Regression watch: `/` ↔ `/lifelog` ↔ `/stuff` ↔ `/blog` cross-route T3 still horizontal anchor-slide; Home / Lifelog / Stuff / Flash gallery unchanged.

Closes #81