### PR TITLE
Slice 53: hook tests + happy-dom WebGL fallback (#53)

### DIFF
--- a/web/src/canvas/detect-webgl.test.ts
+++ b/web/src/canvas/detect-webgl.test.ts
@@ -31,4 +31,12 @@ describe('detectWebGL', () => {
         }
         expect(detectWebGL(doc)).toBe(false)
     })
+
+    test('returns false under the ambient happy-dom document (no real GPU)', () => {
+        // happy-dom's HTMLCanvasElement.getContext returns null for webgl /
+        // webgl2, so the fallback path is exercised by our default test env.
+        // If happy-dom ever ships a WebGL shim this will fail loudly so we
+        // can revisit the fallback strategy.
+        expect(detectWebGL(document)).toBe(false)
+    })
 })

--- a/web/src/canvas/useFrameEdge.test.ts
+++ b/web/src/canvas/useFrameEdge.test.ts
@@ -1,0 +1,65 @@
+import { describe, test, expect, beforeEach, vi } from 'vitest'
+
+beforeEach(() => {
+    localStorage.clear()
+    vi.resetModules()
+})
+
+async function setup() {
+    const rtl = await import('@testing-library/react')
+    const { useFrameEdge } = await import('./useFrameEdge')
+    return { ...rtl, useFrameEdge }
+}
+
+describe('useFrameEdge', () => {
+    test('defaults to bottom on mount with empty storage', async () => {
+        const { renderHook, useFrameEdge } = await setup()
+        const { result } = renderHook(() => useFrameEdge())
+        expect(result.current.edge).toBe('bottom')
+    })
+
+    test('setEdge re-renders the consuming component with the new edge', async () => {
+        const { renderHook, act, useFrameEdge } = await setup()
+        const { result } = renderHook(() => useFrameEdge())
+
+        act(() => {
+            result.current.setEdge('top')
+        })
+
+        expect(result.current.edge).toBe('top')
+    })
+
+    test('toggleEdge flips bottom → top and re-renders', async () => {
+        const { renderHook, act, useFrameEdge } = await setup()
+        const { result } = renderHook(() => useFrameEdge())
+        expect(result.current.edge).toBe('bottom')
+
+        act(() => {
+            result.current.toggleEdge()
+        })
+
+        expect(result.current.edge).toBe('top')
+    })
+
+    test('two components sharing the singleton both update on setEdge', async () => {
+        const { renderHook, act, useFrameEdge } = await setup()
+        const a = renderHook(() => useFrameEdge())
+        const b = renderHook(() => useFrameEdge())
+        expect(a.result.current.edge).toBe('bottom')
+        expect(b.result.current.edge).toBe('bottom')
+
+        act(() => {
+            a.result.current.setEdge('top')
+        })
+
+        expect(a.result.current.edge).toBe('top')
+        expect(b.result.current.edge).toBe('top')
+    })
+
+    test('persisted edge in localStorage is honoured on mount', async () => {
+        localStorage.setItem('chaipalaka.frame.edge', 'top')
+        const { renderHook, useFrameEdge } = await setup()
+        const { result } = renderHook(() => useFrameEdge())
+        expect(result.current.edge).toBe('top')
+    })
+})

--- a/web/src/canvas/useGallery.test.ts
+++ b/web/src/canvas/useGallery.test.ts
@@ -1,0 +1,89 @@
+import { describe, test, expect, beforeEach, vi } from 'vitest'
+
+const STORAGE_KEY = 'chaipalaka.background.activeId'
+const DEFAULT_ID = 'flow-shader'
+
+beforeEach(() => {
+    localStorage.clear()
+    delete (window as unknown as { __setBackground?: unknown }).__setBackground
+    vi.resetModules()
+})
+
+async function setup() {
+    const rtl = await import('@testing-library/react')
+    const { useGallery } = await import('./useGallery')
+    const { backgroundScenes } = await import('./scenes')
+    return { ...rtl, useGallery, backgroundScenes }
+}
+
+describe('useGallery', () => {
+    test('active reflects the default scene on mount with empty storage', async () => {
+        const { renderHook, useGallery } = await setup()
+        const { result } = renderHook(() => useGallery())
+        expect(result.current.active.id).toBe(DEFAULT_ID)
+    })
+
+    test('setActive(known) updates active and persists to localStorage', async () => {
+        const { renderHook, act, useGallery, backgroundScenes } = await setup()
+        const otherId = backgroundScenes.find((s) => s.id !== DEFAULT_ID)?.id
+        expect(otherId).toBeDefined()
+
+        const { result } = renderHook(() => useGallery())
+
+        act(() => {
+            result.current.setActive(otherId!)
+        })
+
+        expect(result.current.active.id).toBe(otherId)
+        expect(localStorage.getItem(STORAGE_KEY)).toBe(otherId)
+    })
+
+    test('setActive(unknown) is a no-op — active and storage unchanged', async () => {
+        const { renderHook, act, useGallery } = await setup()
+        const { result } = renderHook(() => useGallery())
+        const before = result.current.active.id
+
+        // gallery.setActive warns on unknown ids; silence it for this test.
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+        act(() => {
+            result.current.setActive('does-not-exist')
+        })
+        warnSpy.mockRestore()
+
+        expect(result.current.active.id).toBe(before)
+        expect(localStorage.getItem(STORAGE_KEY)).toBeNull()
+    })
+
+    test('retired "particles" id migrates to "particles-starfield" on mount', async () => {
+        localStorage.setItem(STORAGE_KEY, 'particles')
+        const { renderHook, useGallery } = await setup()
+        const { result } = renderHook(() => useGallery())
+        expect(result.current.active.id).toBe('particles-starfield')
+        expect(localStorage.getItem(STORAGE_KEY)).toBe('particles-starfield')
+    })
+
+    test('retired "geometric" id migrates to "geometric-reaction-diffusion" on mount', async () => {
+        localStorage.setItem(STORAGE_KEY, 'geometric')
+        const { renderHook, useGallery } = await setup()
+        const { result } = renderHook(() => useGallery())
+        expect(result.current.active.id).toBe('geometric-reaction-diffusion')
+        expect(localStorage.getItem(STORAGE_KEY)).toBe(
+            'geometric-reaction-diffusion',
+        )
+    })
+
+    test('window.__setBackground is installed and drives active', async () => {
+        const { renderHook, act, useGallery, backgroundScenes } = await setup()
+        const otherId = backgroundScenes.find((s) => s.id !== DEFAULT_ID)?.id
+        expect(otherId).toBeDefined()
+
+        const { result } = renderHook(() => useGallery())
+        expect(typeof window.__setBackground).toBe('function')
+
+        act(() => {
+            window.__setBackground(otherId!)
+        })
+
+        expect(result.current.active.id).toBe(otherId)
+    })
+})

--- a/web/src/controls/useTheme.test.ts
+++ b/web/src/controls/useTheme.test.ts
@@ -1,0 +1,64 @@
+import { describe, test, expect, beforeEach, vi } from 'vitest'
+
+// useTheme holds a module-level controller singleton. To exercise the
+// "fresh mount" code path between tests we reset modules and re-import
+// both the hook and @testing-library/react so they share the same React
+// instance.
+beforeEach(() => {
+    localStorage.clear()
+    document.documentElement.removeAttribute('data-theme')
+    vi.resetModules()
+})
+
+async function setup() {
+    const rtl = await import('@testing-library/react')
+    const { useTheme } = await import('./useTheme')
+    return { ...rtl, useTheme }
+}
+
+describe('useTheme', () => {
+    test('mount sets document.documentElement.dataset.theme to the current theme', async () => {
+        const { renderHook, useTheme } = await setup()
+        const { result } = renderHook(() => useTheme())
+        expect(document.documentElement.dataset.theme).toBe(result.current.theme)
+        expect(['dark', 'light']).toContain(result.current.theme)
+    })
+
+    test('cycleTheme updates the dataset attribute and the returned theme', async () => {
+        const { renderHook, act, useTheme } = await setup()
+        const { result } = renderHook(() => useTheme())
+        const before = result.current.theme
+
+        act(() => {
+            result.current.cycleTheme()
+        })
+
+        const expected = before === 'dark' ? 'light' : 'dark'
+        expect(result.current.theme).toBe(expected)
+        expect(document.documentElement.dataset.theme).toBe(expected)
+    })
+
+    test('two components sharing the singleton both re-render on cycleTheme', async () => {
+        const { renderHook, act, useTheme } = await setup()
+        const a = renderHook(() => useTheme())
+        const b = renderHook(() => useTheme())
+        expect(a.result.current.theme).toBe(b.result.current.theme)
+        const before = a.result.current.theme
+
+        act(() => {
+            a.result.current.cycleTheme()
+        })
+
+        const expected = before === 'dark' ? 'light' : 'dark'
+        expect(a.result.current.theme).toBe(expected)
+        expect(b.result.current.theme).toBe(expected)
+    })
+
+    test('persisted theme in localStorage is honoured on mount', async () => {
+        localStorage.setItem('chaipalaka.theme', 'light')
+        const { renderHook, useTheme } = await setup()
+        const { result } = renderHook(() => useTheme())
+        expect(result.current.theme).toBe('light')
+        expect(document.documentElement.dataset.theme).toBe('light')
+    })
+})


### PR DESCRIPTION
## Summary

- Adds `renderHook` coverage for the three React adapter hooks that wrap module-level singletons: `useTheme`, `useFrameEdge`, `useGallery` (15 new tests across 3 files).
- Adds one assertion to `detect-webgl.test.ts` that the ambient happy-dom `document` returns `false` from `detectWebGL`, locking in the fallback path under our default test env.
- No production code changed — tests-only slice.

## Notes / deviations

- Singleton isolation: since the AC forbids touching production code, no reset/export was added to the hooks. Instead, each new test file uses `vi.resetModules()` in `beforeEach` and dynamically re-imports both the hook and `@testing-library/react` together inside each test. This keeps the React instance consistent between the freshly re-imported hook and the test renderer.
- `useGallery` tests also cover the two one-shot migrations (`particles` → `particles-starfield`, `geometric` → `geometric-reaction-diffusion`) and the `window.__setBackground` debug hook, on top of the AC items.
- Existing 4 `detect-webgl.test.ts` tests use a `fakeDoc` DI fixture so they're environment-agnostic and didn't need updating — only the new ambient-`document` assertion was added.

## Acceptance criteria

- [x] `src/controls/useTheme.test.ts` — covers mount side-effect, cycle updates attribute, cross-component re-render (and persisted-storage on mount).
- [x] `src/canvas/useFrameEdge.test.ts` — covers setEdge/toggleEdge re-render and cross-component update (plus default-on-mount and persisted-storage).
- [x] `src/canvas/useGallery.test.ts` — covers active-on-mount, setActive(known) persists, setActive(unknown) no-op (plus two migrations and `window.__setBackground`).
- [x] `detect-webgl.test.ts` reviewed; existing DI-based tests confirmed environment-agnostic; new happy-dom assertion added.
- [x] `npm run typecheck`, `npm run test` (356 passed, 41 files), `npm run build` all green locally.
- [x] No production code changed — tests only.

## Test plan

From `web/`:

\`\`\`sh
npm run typecheck
npm run test
npm run build
\`\`\`

Spot-check the new files:

\`\`\`sh
npx vitest run useTheme.test useFrameEdge.test useGallery.test detect-webgl.test
\`\`\`

Expect 20 passing tests across the four files (15 new + 5 in detect-webgl).

Closes #53