### PR TITLE
Slice 91: transitions React layer test hardening (#91)

### DIFF
--- a/web/src/transitions/NavCardContent.test.tsx
+++ b/web/src/transitions/NavCardContent.test.tsx
@@ -1,0 +1,53 @@
+import { describe, test, expect, vi, afterEach } from 'vitest'
+import { render, cleanup, fireEvent } from '@testing-library/react'
+import { NavCardContent } from './NavCardContent'
+
+afterEach(() => {
+    cleanup()
+})
+
+describe('NavCardContent', () => {
+    test('target="prev" renders a button with the previous-section aria-label and glyph', () => {
+        const { getByRole } = render(
+            <NavCardContent
+                target="prev"
+                targetSectionIndex={2}
+                sectionCount={5}
+                onActivate={() => {}}
+            />,
+        )
+        const button = getByRole('button')
+        expect(button.tagName).toBe('BUTTON')
+        expect(button.getAttribute('type')).toBe('button')
+        expect(button.getAttribute('aria-label')).toBe('Previous section, 2 of 5')
+        expect(button.textContent).toBe('↑ back')
+    })
+
+    test('target="next" renders a button with the next-section aria-label and glyph', () => {
+        const { getByRole } = render(
+            <NavCardContent
+                target="next"
+                targetSectionIndex={3}
+                sectionCount={5}
+                onActivate={() => {}}
+            />,
+        )
+        const button = getByRole('button')
+        expect(button.getAttribute('aria-label')).toBe('Next section, 3 of 5')
+        expect(button.textContent).toBe('next ↓')
+    })
+
+    test('clicking the button calls onActivate exactly once', () => {
+        const onActivate = vi.fn()
+        const { getByRole } = render(
+            <NavCardContent
+                target="prev"
+                targetSectionIndex={1}
+                sectionCount={4}
+                onActivate={onActivate}
+            />,
+        )
+        fireEvent.click(getByRole('button'))
+        expect(onActivate).toHaveBeenCalledTimes(1)
+    })
+})

--- a/web/src/transitions/PhysicsCardImpl.test.tsx
+++ b/web/src/transitions/PhysicsCardImpl.test.tsx
@@ -1,0 +1,530 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest'
+import { act, render, cleanup, fireEvent } from '@testing-library/react'
+import { useState } from 'react'
+import { PhysicsProvider, usePhysicsWorld } from '../physics/PhysicsContext'
+import { CardRegistryProvider } from './CardRegistry'
+import { PhysicsCardImpl } from './PhysicsCardImpl'
+import { useMinimizedRegistry } from '../canvas/useMinimizedRegistry'
+import type { PhysicsCardEntry } from './CardRegistry'
+import type { PhysicsWorld } from '../physics/PhysicsWorld'
+import type { MinimizedRegistry } from '../canvas/MinimizedRegistry'
+
+vi.mock('../canvas/flip', () => ({
+    flipMorph: vi.fn(),
+}))
+
+import { flipMorph } from '../canvas/flip'
+
+// Helper: build a PhysicsCardEntry with sensible defaults.
+function makeEntry(overrides: Partial<PhysicsCardEntry> = {}): PhysicsCardEntry {
+    return {
+        id: overrides.id ?? 'card-1',
+        parent: overrides.parent ?? null,
+        trail: overrides.trail,
+        kind: overrides.kind ?? 'card',
+        buoyancy: overrides.buoyancy ?? 'heavy',
+        anchor: overrides.anchor ?? { x: 200, y: 200 },
+        content: {
+            text: 'hello',
+            width: 120,
+            height: 80,
+            variant: 'default',
+            ...(overrides.content ?? {}),
+        },
+        state: 'active',
+    }
+}
+
+function fireRealPointerDown(el: Element, opts: { onCardHeader?: boolean } = {}) {
+    const ev = new Event('pointerdown', { bubbles: true, cancelable: true }) as Event & {
+        clientX: number
+        clientY: number
+        pointerId: number
+    }
+    ev.clientX = 50
+    ev.clientY = 50
+    ev.pointerId = 1
+    const target = opts.onCardHeader
+        ? (el.querySelector('[data-card-header]') ?? el)
+        : el
+    target.dispatchEvent(ev)
+}
+
+async function flushRaf() {
+    await act(async () => {
+        await new Promise<void>((r) =>
+            requestAnimationFrame(() => r(undefined)),
+        )
+    })
+}
+
+function renderWith(ui: React.ReactNode) {
+    let world: PhysicsWorld | null = null
+    let registry: MinimizedRegistry | null = null
+    function Probe() {
+        world = usePhysicsWorld()
+        registry = useMinimizedRegistry()
+        return null
+    }
+    const utils = render(
+        <PhysicsProvider>
+            <CardRegistryProvider>
+                <Probe />
+                {ui}
+            </CardRegistryProvider>
+        </PhysicsProvider>,
+    )
+    return {
+        ...utils,
+        getWorld: () => world!,
+        getRegistry: () => registry!,
+    }
+}
+
+// MinimizedRegistry is a module-level singleton. Each test that minimizes a
+// card is responsible for restoring it (or using a unique id), so cross-test
+// state doesn't bleed.
+afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+})
+
+beforeEach(() => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+})
+
+describe('PhysicsCardImpl — article shape & data attrs', () => {
+    test('renders article.physics-card with data-card-id and data-variant attrs', () => {
+        const entry = makeEntry({
+            id: 'shape-1',
+            content: { text: 't', width: 120, height: 80, variant: 'lifelog' },
+        })
+        const { container } = renderWith(<PhysicsCardImpl entry={entry} />)
+        const article = container.querySelector('article.physics-card')
+        expect(article).toBeTruthy()
+        expect(article!.getAttribute('data-card-id')).toBe('shape-1')
+        expect(article!.getAttribute('data-variant')).toBe('lifelog')
+    })
+})
+
+describe('PhysicsCardImpl — first-paint reveal gate', () => {
+    test('article is rendered with visibility: hidden inline before the first RAF', () => {
+        const entry = makeEntry({ id: 'reveal-1' })
+        const { container } = renderWith(<PhysicsCardImpl entry={entry} />)
+        const article = container.querySelector(
+            'article.physics-card',
+        ) as HTMLElement
+        expect(article).toBeTruthy()
+        expect(article.style.visibility).toBe('hidden')
+    })
+
+    test('after one RAF the visibility override is cleared', async () => {
+        const entry = makeEntry({ id: 'reveal-2' })
+        const { container } = renderWith(<PhysicsCardImpl entry={entry} />)
+        await flushRaf()
+        const article = container.querySelector(
+            'article.physics-card',
+        ) as HTMLElement
+        expect(article.style.visibility).not.toBe('hidden')
+    })
+})
+
+describe('PhysicsCardImpl — minimize', () => {
+    test('renders a header bar with a Minimize button when minimizable=true', () => {
+        const entry = makeEntry({
+            id: 'min-1',
+            content: {
+                text: 't',
+                width: 120,
+                height: 80,
+                minimizable: true,
+                label: 'My card',
+            },
+        })
+        const { container } = renderWith(<PhysicsCardImpl entry={entry} />)
+        const article = container.querySelector('article.physics-card')!
+        const header = article.querySelector('[data-card-header]')
+        expect(header).toBeTruthy()
+        const btn = header!.querySelector(
+            'button[title="Minimize"]',
+        ) as HTMLButtonElement | null
+        expect(btn).toBeTruthy()
+    })
+
+    test('clicking the minimize button moves the card to the minimized registry and unmounts the article', async () => {
+        const entry = makeEntry({
+            id: 'min-2',
+            kind: 'lifelog',
+            content: {
+                text: 't',
+                width: 120,
+                height: 80,
+                minimizable: true,
+                label: 'Min me',
+            },
+        })
+        const { container, getRegistry } = renderWith(
+            <PhysicsCardImpl entry={entry} />,
+        )
+        await flushRaf()
+        const btn = container.querySelector(
+            'button[title="Minimize"]',
+        ) as HTMLButtonElement
+        expect(btn).toBeTruthy()
+
+        await act(async () => {
+            fireEvent.click(btn)
+        })
+
+        const reg = getRegistry()
+        const list = reg.list()
+        expect(list).toHaveLength(1)
+        expect(list[0]!.id).toBe('min-2')
+        expect(list[0]!.label).toBe('Min me')
+        expect(list[0]!.kind).toBe('lifelog')
+        expect(list[0]!.fromRect).toBeTruthy()
+
+        // After minimize, the article should be gone from the DOM.
+        expect(container.querySelector('article.physics-card')).toBeNull()
+
+        // Clean up so the singleton doesn't bleed.
+        reg.restore('min-2')
+    })
+
+    test('falls back to text as the label when no explicit label is provided', async () => {
+        const entry = makeEntry({
+            id: 'min-3',
+            content: {
+                text: 'fallback-text',
+                width: 120,
+                height: 80,
+                minimizable: true,
+            },
+        })
+        const { container, getRegistry } = renderWith(
+            <PhysicsCardImpl entry={entry} />,
+        )
+        await flushRaf()
+        const btn = container.querySelector(
+            'button[title="Minimize"]',
+        ) as HTMLButtonElement
+        await act(async () => {
+            fireEvent.click(btn)
+        })
+        const reg = getRegistry()
+        expect(reg.list()[0]!.label).toBe('fallback-text')
+        reg.restore('min-3')
+    })
+})
+
+describe('PhysicsCardImpl — drag handler install', () => {
+    test('draggable=true (default) sets cursor: grabbing on pointerdown', () => {
+        const entry = makeEntry({ id: 'drag-on' })
+        const { container } = renderWith(<PhysicsCardImpl entry={entry} />)
+        const article = container.querySelector(
+            'article.physics-card',
+        ) as HTMLElement
+        article.setPointerCapture = () => {}
+        fireRealPointerDown(article)
+        expect(article.style.cursor).toBe('grabbing')
+    })
+
+    test('draggable=true calls world.setDragging(handle, true) on pointerdown', () => {
+        const entry = makeEntry({ id: 'drag-spy' })
+        const { container, getWorld } = renderWith(
+            <PhysicsCardImpl entry={entry} />,
+        )
+        const setDragging = vi.spyOn(getWorld(), 'setDragging')
+        const article = container.querySelector(
+            'article.physics-card',
+        ) as HTMLElement
+        article.setPointerCapture = () => {}
+        fireRealPointerDown(article)
+        expect(setDragging).toHaveBeenCalledTimes(1)
+        const handle = getWorld().getHandleById('drag-spy')
+        expect(setDragging).toHaveBeenCalledWith(handle, true)
+    })
+
+    test('draggable=false does NOT change cursor or call setDragging on pointerdown', () => {
+        const entry = makeEntry({
+            id: 'drag-off',
+            content: { text: 't', width: 120, height: 80, draggable: false },
+        })
+        const { container, getWorld } = renderWith(
+            <PhysicsCardImpl entry={entry} />,
+        )
+        const setDragging = vi.spyOn(getWorld(), 'setDragging')
+        const article = container.querySelector(
+            'article.physics-card',
+        ) as HTMLElement
+        article.setPointerCapture = () => {}
+        fireRealPointerDown(article)
+        expect(article.style.cursor).not.toBe('grabbing')
+        expect(setDragging).not.toHaveBeenCalled()
+    })
+})
+
+describe('PhysicsCardImpl — parent tether wiring', () => {
+    test('parent="ceiling" wires a tether from the card to the ceiling handle', async () => {
+        const entry = makeEntry({ id: 'tether-ceil', parent: 'ceiling' })
+        const { getWorld } = renderWith(<PhysicsCardImpl entry={entry} />)
+        await flushRaf()
+        const world = getWorld()
+        const childHandle = world.getHandleById('tether-ceil')!
+        const records = world
+            .listTetherRecords()
+            .filter((r) => r.child === childHandle)
+        expect(records).toHaveLength(1)
+        expect(records[0]!.parent).toBe(world.ceilingHandle)
+    })
+
+    test('parent="floor" wires a tether from the card to the floor handle', async () => {
+        const entry = makeEntry({ id: 'tether-floor', parent: 'floor' })
+        const { getWorld } = renderWith(<PhysicsCardImpl entry={entry} />)
+        await flushRaf()
+        const world = getWorld()
+        const childHandle = world.getHandleById('tether-floor')!
+        const records = world
+            .listTetherRecords()
+            .filter((r) => r.child === childHandle)
+        expect(records).toHaveLength(1)
+        expect(records[0]!.parent).toBe(world.floorHandle)
+    })
+
+    test('parent=<cardId> resolves to a sibling card already registered in the same render', async () => {
+        const parentEntry = makeEntry({ id: 'parent-card', parent: 'ceiling' })
+        const childEntry = makeEntry({
+            id: 'child-card',
+            parent: 'parent-card',
+            anchor: { x: 300, y: 300 },
+        })
+        const { getWorld } = renderWith(
+            <>
+                <PhysicsCardImpl entry={parentEntry} />
+                <PhysicsCardImpl entry={childEntry} />
+            </>,
+        )
+        await flushRaf()
+        const world = getWorld()
+        const parentHandle = world.getHandleById('parent-card')!
+        const childHandle = world.getHandleById('child-card')!
+        const childRecords = world
+            .listTetherRecords()
+            .filter((r) => r.child === childHandle)
+        expect(childRecords).toHaveLength(1)
+        expect(childRecords[0]!.parent).toBe(parentHandle)
+    })
+
+    test('parent referring to a non-existent card retries on the next RAF, then warns and skips', async () => {
+        const warnSpy = vi.spyOn(console, 'warn')
+        const entry = makeEntry({
+            id: 'lonely-child',
+            parent: 'nonexistent-parent',
+        })
+        const { getWorld } = renderWith(<PhysicsCardImpl entry={entry} />)
+        // First RAF flushes the reveal gate; second flushes the parent-resolve retry.
+        await flushRaf()
+        await flushRaf()
+        const world = getWorld()
+        const childHandle = world.getHandleById('lonely-child')!
+        const childRecords = world
+            .listTetherRecords()
+            .filter((r) => r.child === childHandle)
+        expect(childRecords).toHaveLength(0)
+        expect(warnSpy).toHaveBeenCalled()
+        expect(warnSpy.mock.calls[0]![0]).toContain('"nonexistent-parent"')
+    })
+
+    test('trail tether wires a second tether to the trail target', async () => {
+        const entry = makeEntry({
+            id: 'dual-tether',
+            parent: 'ceiling',
+            trail: 'floor',
+        })
+        const { getWorld } = renderWith(<PhysicsCardImpl entry={entry} />)
+        await flushRaf()
+        const world = getWorld()
+        const childHandle = world.getHandleById('dual-tether')!
+        const records = world
+            .listTetherRecords()
+            .filter((r) => r.child === childHandle)
+        expect(records).toHaveLength(2)
+        const parents = records.map((r) => r.parent).sort()
+        expect(parents).toEqual([world.ceilingHandle, world.floorHandle].sort())
+    })
+})
+
+describe('PhysicsCardImpl — anchor changes', () => {
+    test('changing the anchor calls world.setAnchor and re-wires the parent tether', async () => {
+        function Harness() {
+            const [anchor, setAnchor] = useState({ x: 100, y: 100 })
+            return (
+                <>
+                    <PhysicsCardImpl
+                        entry={makeEntry({
+                            id: 'anchor-card',
+                            parent: 'ceiling',
+                            anchor,
+                        })}
+                    />
+                    <button
+                        data-testid="bump"
+                        type="button"
+                        onClick={() => setAnchor({ x: 250, y: 250 })}
+                    >
+                        bump
+                    </button>
+                </>
+            )
+        }
+
+        const { container, getWorld } = renderWith(<Harness />)
+        await flushRaf()
+        const world = getWorld()
+        const setAnchorSpy = vi.spyOn(world, 'setAnchor')
+        const childHandle = world.getHandleById('anchor-card')!
+        const recordsBefore = world
+            .listTetherRecords()
+            .filter((r) => r.child === childHandle)
+        expect(recordsBefore).toHaveLength(1)
+        const oldTetherHandle = recordsBefore[0]!.handle
+
+        await act(async () => {
+            fireEvent.click(
+                container.querySelector('[data-testid="bump"]')!,
+            )
+        })
+        await flushRaf()
+
+        expect(setAnchorSpy).toHaveBeenCalledWith(childHandle, {
+            x: 250,
+            y: 250,
+        })
+        const recordsAfter = world
+            .listTetherRecords()
+            .filter((r) => r.child === childHandle)
+        // Still exactly one tether to the ceiling, but a new handle (old one
+        // was untethered + a fresh one wired).
+        expect(recordsAfter).toHaveLength(1)
+        expect(recordsAfter[0]!.parent).toBe(world.ceilingHandle)
+        expect(recordsAfter[0]!.handle).not.toBe(oldTetherHandle)
+    })
+})
+
+describe('PhysicsCardImpl — unmount cleanup', () => {
+    test('unmounting untethers, unregisters the body, and the card disappears from the world', async () => {
+        function Harness({ mounted }: { mounted: boolean }) {
+            return mounted ? (
+                <PhysicsCardImpl
+                    entry={makeEntry({ id: 'unmount-me', parent: 'ceiling' })}
+                />
+            ) : null
+        }
+        let world: PhysicsWorld | null = null
+        function Probe() {
+            world = usePhysicsWorld()
+            return null
+        }
+        const { rerender } = render(
+            <PhysicsProvider>
+                <CardRegistryProvider>
+                    <Probe />
+                    <Harness mounted={true} />
+                </CardRegistryProvider>
+            </PhysicsProvider>,
+        )
+        await flushRaf()
+        expect(world!.getHandleById('unmount-me')).toBeTruthy()
+        expect(
+            world!
+                .listTetherRecords()
+                .some((r) => r.child === world!.getHandleById('unmount-me')!),
+        ).toBe(true)
+
+        rerender(
+            <PhysicsProvider>
+                <CardRegistryProvider>
+                    <Probe />
+                    <Harness mounted={false} />
+                </CardRegistryProvider>
+            </PhysicsProvider>,
+        )
+        await flushRaf()
+        expect(world!.getHandleById('unmount-me')).toBeUndefined()
+        expect(world!.listTetherRecords()).toHaveLength(0)
+    })
+})
+
+describe('PhysicsCardImpl — restore from chip', () => {
+    test('un-minimizing with a pending chip rect bypasses the reveal-gate hide and calls flipMorph', async () => {
+        const entry = makeEntry({
+            id: 'restore-me',
+            content: {
+                text: 'restorable',
+                width: 200,
+                height: 100,
+                minimizable: true,
+                label: 'Restorable',
+            },
+        })
+        const { container, getRegistry } = renderWith(
+            <PhysicsCardImpl entry={entry} />,
+        )
+        await flushRaf()
+
+        // Minimize via the in-DOM button so registry.minimize captures a real fromRect.
+        const btn = container.querySelector(
+            'button[title="Minimize"]',
+        ) as HTMLButtonElement
+        await act(async () => {
+            fireEvent.click(btn)
+        })
+        expect(container.querySelector('article.physics-card')).toBeNull()
+
+        const reg = getRegistry()
+        const fromChipRect = {
+            left: 10,
+            top: 20,
+            right: 110,
+            bottom: 120,
+            width: 100,
+            height: 100,
+            x: 10,
+            y: 20,
+            toJSON() {
+                return {}
+            },
+        } as DOMRect
+
+        // Restore with an explicit chip rect — this populates pendingRestoreRects
+        // for the card so its useEffect on un-minimize will see it.
+        await act(async () => {
+            reg.restore('restore-me', fromChipRect)
+        })
+
+        // The article has re-mounted. The restore-from-chip effect runs
+        // synchronously after the main effect; it calls setRevealed(true)
+        // immediately, so React re-renders without the visibility:hidden
+        // override.
+        const article = container.querySelector(
+            'article.physics-card',
+        ) as HTMLElement
+        expect(article).toBeTruthy()
+        expect(article.style.visibility).not.toBe('hidden')
+
+        // flipMorph fires inside a requestAnimationFrame after the rect is
+        // consumed — advance one frame.
+        await flushRaf()
+        expect(flipMorph).toHaveBeenCalledTimes(1)
+        const callArgs = (flipMorph as unknown as ReturnType<typeof vi.fn>)
+            .mock.calls[0]!
+        expect(callArgs[0]).toBe(fromChipRect)
+        expect(callArgs[1]).toBe(article)
+        expect(callArgs[2]).toEqual(
+            expect.objectContaining({ opacityFrom: 0.5 }),
+        )
+
+        // Clean up so the singleton stays empty.
+        reg.restore('restore-me')
+    })
+})

--- a/web/src/transitions/PhysicsLayer.test.tsx
+++ b/web/src/transitions/PhysicsLayer.test.tsx
@@ -1,0 +1,105 @@
+import { describe, test, expect, afterEach, vi } from 'vitest'
+import { act, render, cleanup } from '@testing-library/react'
+import { PhysicsProvider } from '../physics/PhysicsContext'
+import {
+    CardRegistryProvider,
+    useCardRegistry,
+} from './CardRegistry'
+import { PhysicsLayer } from './PhysicsLayer'
+import type { CardRegistryAPI, PhysicsCardEntry } from './CardRegistry'
+
+vi.mock('../canvas/flip', () => ({
+    flipMorph: vi.fn(),
+}))
+
+afterEach(() => {
+    cleanup()
+})
+
+function makeEntry(id: string, overrides: Partial<PhysicsCardEntry> = {}): PhysicsCardEntry {
+    return {
+        id,
+        parent: null,
+        kind: 'card',
+        buoyancy: 'heavy',
+        anchor: { x: 100, y: 100 },
+        content: {
+            text: id,
+            width: 120,
+            height: 80,
+            variant: 'default',
+        },
+        state: 'active',
+        ...overrides,
+    }
+}
+
+function renderLayer() {
+    let api: CardRegistryAPI | null = null
+    function Probe() {
+        api = useCardRegistry()
+        return null
+    }
+    const utils = render(
+        <PhysicsProvider>
+            <CardRegistryProvider>
+                <Probe />
+                <PhysicsLayer />
+            </CardRegistryProvider>
+        </PhysicsProvider>,
+    )
+    return { ...utils, getApi: () => api! }
+}
+
+describe('PhysicsLayer', () => {
+    test('renders a <div data-physics-layer> wrapper', () => {
+        const { container } = renderLayer()
+        expect(
+            container.querySelector('[data-physics-layer]'),
+        ).toBeTruthy()
+    })
+
+    test('renders one article per registered entry with matching data-card-id', async () => {
+        const { container, getApi } = renderLayer()
+        await act(async () => {
+            getApi().register(makeEntry('layer-a'))
+            getApi().register(makeEntry('layer-b'))
+        })
+        const articles = container.querySelectorAll(
+            'article.physics-card',
+        )
+        expect(articles).toHaveLength(2)
+        const ids = Array.from(articles)
+            .map((a) => a.getAttribute('data-card-id'))
+            .sort()
+        expect(ids).toEqual(['layer-a', 'layer-b'])
+    })
+
+    test('registering a new entry adds an article; releasing removes it', async () => {
+        const { container, getApi } = renderLayer()
+        await act(async () => {
+            getApi().register(makeEntry('layer-x'))
+            getApi().register(makeEntry('layer-y'))
+        })
+        expect(
+            container.querySelectorAll('article.physics-card'),
+        ).toHaveLength(2)
+
+        await act(async () => {
+            getApi().register(makeEntry('layer-z'))
+        })
+        expect(
+            container.querySelectorAll('article.physics-card'),
+        ).toHaveLength(3)
+
+        await act(async () => {
+            getApi().release('layer-y')
+        })
+        const remaining = Array.from(
+            container.querySelectorAll('article.physics-card'),
+        )
+            .map((a) => a.getAttribute('data-card-id'))
+            .sort()
+        expect(remaining).toEqual(['layer-x', 'layer-z'])
+    })
+})

--- a/web/src/transitions/edges.test.ts
+++ b/web/src/transitions/edges.test.ts
@@ -1,0 +1,39 @@
+import { describe, test, expect } from 'vitest'
+import { edges } from './edges'
+
+const ROUTES = ['/', '/lifelog', '/stuff', '/blog'] as const
+
+describe('transitions/edges', () => {
+    test('has an entry for every ordered pair of distinct canvas routes', () => {
+        for (const from of ROUTES) {
+            for (const to of ROUTES) {
+                if (from === to) continue
+                const key = `${from}→${to}`
+                expect(
+                    Object.prototype.hasOwnProperty.call(edges, key),
+                    `expected edge key "${key}"`,
+                ).toBe(true)
+            }
+        }
+    })
+
+    test('has no extra entries beyond the 12 canvas-route pairs', () => {
+        expect(Object.keys(edges)).toHaveLength(12)
+    })
+
+    test('every entry routes through anchor-slide on the horizontal axis', () => {
+        for (const [key, value] of Object.entries(edges)) {
+            expect(value.primitive, `${key}.primitive`).toBe('anchor-slide')
+            expect(value.axis, `${key}.axis`).toBe('horizontal')
+        }
+    })
+
+    test('no entry sets sign (must fall back to the history-direction default)', () => {
+        for (const [key, value] of Object.entries(edges)) {
+            expect(
+                'sign' in (value as unknown as Record<string, unknown>),
+                `${key} unexpectedly sets sign`,
+            ).toBe(false)
+        }
+    })
+})

--- a/web/src/transitions/pageDefs.test.ts
+++ b/web/src/transitions/pageDefs.test.ts
@@ -1,0 +1,20 @@
+import { describe, test, expect } from 'vitest'
+import { pageDefs, notFoundFallbackPageDef } from './pageDefs'
+import { pageDef as notFoundPageDef } from '../routes/NotFound'
+
+describe('transitions/pageDefs', () => {
+    test('exports the three canvas-route pageDefs (/, /lifelog, /stuff)', () => {
+        expect(Object.keys(pageDefs).sort()).toEqual(['/', '/lifelog', '/stuff'])
+    })
+
+    test('every entry has { gravity, cards } shape', () => {
+        for (const [path, def] of Object.entries(pageDefs)) {
+            expect(typeof def.gravity, `${path}.gravity`).toBe('string')
+            expect(Array.isArray(def.cards), `${path}.cards`).toBe(true)
+        }
+    })
+
+    test('notFoundFallbackPageDef is the same reference as the NotFound route pageDef', () => {
+        expect(notFoundFallbackPageDef).toBe(notFoundPageDef)
+    })
+})


### PR DESCRIPTION
## Summary

- Adds five test files under `web/src/transitions/` to close the test-hardening gap on the React-side glue between transition primitives and the DOM.
- Mirrors the issue #53 pattern (happy-dom + `@testing-library/react` + targeted `vi.mock`).
- No production code changed — tests only. 27 new tests, full suite green (46 files / 386 tests).

## Notes / deviations

- Only `web/src/canvas/flip.ts` (`flipMorph`) is mocked. `wireTetherFor` is left as the real implementation so tether assertions exercise `PhysicsWorld` end-to-end via `listTetherRecords()` — same approach the existing `web/src/physics/PhysicsCard.test.tsx` uses (its "trail prop wires a second tether" case is the canonical pattern).
- MinimizedRegistry singleton isolation between tests is handled by (a) using unique card IDs per test, and (b) each test that minimizes explicitly calls `registry.restore(id)` before exiting. No `vi.resetModules()` dance needed.
- The "draggable=false" / pointerdown test follows the existing PhysicsCard.test.tsx idiom of constructing a synthetic pointerdown Event (happy-dom doesn't have a usable `PointerEvent` ctor) and stubbing `setPointerCapture`.
- Restore-from-chip is verified two ways: the article's inline style does not include `visibility: hidden` after the un-minimize re-render (bypass works), AND `flipMorph` is called once with `(fromChipRect, articleEl, { opacityFrom: 0.5, ... })`.

## Acceptance criteria

- [x] `src/transitions/NavCardContent.test.tsx` covers all three behaviors (prev label, next label, single onActivate call).
- [x] `src/transitions/edges.test.ts` covers structural + value assertions (12 keys, every pair present, anchor-slide/horizontal, no `sign`).
- [x] `src/transitions/PhysicsCardImpl.test.tsx` covers mount/unmount, minimize, drag-toggle, parent resolution + retry, anchor change, restore-from-chip (17 tests).
- [x] `src/transitions/PhysicsLayer.test.tsx` covers wrapper + dynamic registry sync (3 tests).
- [x] `src/transitions/pageDefs.test.ts` covers structural assertions + NotFound reference equality (3 tests).
- [x] `npm run typecheck`, `npm run test`, `npm run build` all pass.
- [x] No production code changed.

## Test plan

```sh
cd web
npm run typecheck                 # passes
npm run test --run                # 46 files, 386 tests pass
npm run build                     # vite-react-ssg prerender succeeds
```

Per-file sanity:

```sh
npm run test -- src/transitions/NavCardContent.test.tsx --run
npm run test -- src/transitions/edges.test.ts --run
npm run test -- src/transitions/PhysicsCardImpl.test.tsx --run
npm run test -- src/transitions/PhysicsLayer.test.tsx --run
npm run test -- src/transitions/pageDefs.test.ts --run
```

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)