### PR TITLE
Slice 92: physics React layer tests (#92)

### DIFF
--- a/web/src/physics/PhysicsContext.test.tsx
+++ b/web/src/physics/PhysicsContext.test.tsx
@@ -1,0 +1,148 @@
+import { describe, test, expect, beforeEach, vi } from 'vitest'
+
+beforeEach(() => {
+    localStorage.clear()
+    vi.resetModules()
+    vi.restoreAllMocks()
+})
+
+async function setup() {
+    const rtl = await import('@testing-library/react')
+    const ctx = await import('./PhysicsContext')
+    const { PhysicsWorld } = await import('./PhysicsWorld')
+    const { getFrameEdgeController } = await import('../canvas/useFrameEdge')
+    return { ...rtl, ...ctx, PhysicsWorld, getFrameEdgeController }
+}
+
+describe('usePhysicsWorld', () => {
+    test('throws outside <PhysicsProvider> with the documented message', async () => {
+        const { renderHook, usePhysicsWorld } = await setup()
+        const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+        expect(() => renderHook(() => usePhysicsWorld())).toThrow(
+            'usePhysicsWorld: must be used inside <PhysicsProvider>',
+        )
+        spy.mockRestore()
+    })
+
+    test('inside <PhysicsProvider> returns a PhysicsWorld instance', async () => {
+        const { renderHook, usePhysicsWorld, PhysicsProvider, PhysicsWorld } =
+            await setup()
+        const { result } = renderHook(() => usePhysicsWorld(), {
+            wrapper: ({ children }) => (
+                <PhysicsProvider>{children}</PhysicsProvider>
+            ),
+        })
+        expect(result.current).toBeInstanceOf(PhysicsWorld)
+    })
+})
+
+describe('edgeToInsets', () => {
+    test("'top' → { top: FRAME_BAR_HEIGHT, bottom: 0 }", async () => {
+        const { edgeToInsets, FRAME_BAR_HEIGHT } = await setup()
+        expect(edgeToInsets('top')).toEqual({
+            top: FRAME_BAR_HEIGHT,
+            bottom: 0,
+        })
+    })
+
+    test("'bottom' → { top: 0, bottom: FRAME_BAR_HEIGHT }", async () => {
+        const { edgeToInsets, FRAME_BAR_HEIGHT } = await setup()
+        expect(edgeToInsets('bottom')).toEqual({
+            top: 0,
+            bottom: FRAME_BAR_HEIGHT,
+        })
+    })
+})
+
+describe('PhysicsProvider', () => {
+    test('initializes the world with the current window viewport', async () => {
+        const { render, PhysicsProvider, usePhysicsWorld } = await setup()
+        let captured: ReturnType<typeof usePhysicsWorld> | null = null
+        function Probe() {
+            captured = usePhysicsWorld()
+            return null
+        }
+        render(
+            <PhysicsProvider>
+                <Probe />
+            </PhysicsProvider>,
+        )
+        expect(captured).not.toBeNull()
+        // setViewport runs synchronously in the mount effect; the floor
+        // body's centre x reflects the resulting viewport width.
+        const world = captured!
+        const floor = world.getPosition(world.floorHandle)
+        expect(floor.x).toBe(window.innerWidth / 2)
+    })
+
+    test('window resize calls setViewport with new dims and current insets', async () => {
+        const { act, render, PhysicsProvider, usePhysicsWorld } = await setup()
+        let captured: ReturnType<typeof usePhysicsWorld> | null = null
+        function Probe() {
+            captured = usePhysicsWorld()
+            return null
+        }
+        render(
+            <PhysicsProvider>
+                <Probe />
+            </PhysicsProvider>,
+        )
+        const spy = vi.spyOn(captured!, 'setViewport')
+        act(() => {
+            ;(window as unknown as { innerWidth: number }).innerWidth = 1234
+            ;(window as unknown as { innerHeight: number }).innerHeight = 567
+            window.dispatchEvent(new Event('resize'))
+        })
+        expect(spy).toHaveBeenCalledWith(
+            { width: 1234, height: 567 },
+            { top: 0, bottom: 40 },
+        )
+    })
+
+    test('frame-edge change re-applies viewport with the new insets', async () => {
+        const {
+            act,
+            render,
+            PhysicsProvider,
+            usePhysicsWorld,
+            getFrameEdgeController,
+        } = await setup()
+        let captured: ReturnType<typeof usePhysicsWorld> | null = null
+        function Probe() {
+            captured = usePhysicsWorld()
+            return null
+        }
+        render(
+            <PhysicsProvider>
+                <Probe />
+            </PhysicsProvider>,
+        )
+        const spy = vi.spyOn(captured!, 'setViewport')
+        act(() => {
+            getFrameEdgeController().setEdge('top')
+        })
+        expect(spy).toHaveBeenCalledWith(
+            { width: window.innerWidth, height: window.innerHeight },
+            { top: 40, bottom: 0 },
+        )
+    })
+
+    test('unmount removes the resize listener', async () => {
+        const { render, PhysicsProvider, usePhysicsWorld } = await setup()
+        let captured: ReturnType<typeof usePhysicsWorld> | null = null
+        function Probe() {
+            captured = usePhysicsWorld()
+            return null
+        }
+        const { unmount } = render(
+            <PhysicsProvider>
+                <Probe />
+            </PhysicsProvider>,
+        )
+        const spy = vi.spyOn(captured!, 'setViewport')
+        unmount()
+        const before = spy.mock.calls.length
+        window.dispatchEvent(new Event('resize'))
+        expect(spy.mock.calls.length).toBe(before)
+    })
+})

--- a/web/src/physics/usePageDef.test.tsx
+++ b/web/src/physics/usePageDef.test.tsx
@@ -1,0 +1,82 @@
+import { describe, test, expect, afterEach, vi } from 'vitest'
+import { render, cleanup } from '@testing-library/react'
+import { PhysicsProvider } from './PhysicsContext'
+import { PhysicsWorld } from './PhysicsWorld'
+import { usePageDef } from './usePageDef'
+import type { PageDef } from './PageDef'
+import type { Cardinal } from './PhysicsWorld'
+
+afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+})
+
+function pageDef(gravity: Cardinal): PageDef {
+    return { gravity, cards: [] }
+}
+
+function Consumer({ def }: { def: PageDef }) {
+    usePageDef(def)
+    return null
+}
+
+describe('usePageDef', () => {
+    test('mount calls setGravityDirection with pageDef.gravity', () => {
+        const spy = vi.spyOn(PhysicsWorld.prototype, 'setGravityDirection')
+        render(
+            <PhysicsProvider>
+                <Consumer def={pageDef('up')} />
+            </PhysicsProvider>,
+        )
+        expect(spy).toHaveBeenCalledTimes(1)
+        expect(spy).toHaveBeenCalledWith('up')
+    })
+
+    test('unmount restores gravity to "down"', () => {
+        const spy = vi.spyOn(PhysicsWorld.prototype, 'setGravityDirection')
+        const { unmount } = render(
+            <PhysicsProvider>
+                <Consumer def={pageDef('up')} />
+            </PhysicsProvider>,
+        )
+        spy.mockClear()
+        unmount()
+        expect(spy).toHaveBeenCalledWith('down')
+    })
+
+    test('changing pageDef.gravity re-applies it (cleanup-then-effect)', () => {
+        const spy = vi.spyOn(PhysicsWorld.prototype, 'setGravityDirection')
+        const { rerender } = render(
+            <PhysicsProvider>
+                <Consumer def={pageDef('up')} />
+            </PhysicsProvider>,
+        )
+        spy.mockClear()
+        rerender(
+            <PhysicsProvider>
+                <Consumer def={pageDef('left')} />
+            </PhysicsProvider>,
+        )
+        const args = spy.mock.calls.map((c) => c[0])
+        // useEffect cleanup with old deps fires first (restores 'down'),
+        // then new effect applies the new gravity.
+        expect(args).toEqual(['down', 'left'])
+    })
+
+    test('no-op re-render with stable world+gravity does not re-invoke', () => {
+        const spy = vi.spyOn(PhysicsWorld.prototype, 'setGravityDirection')
+        const def = pageDef('right')
+        const { rerender } = render(
+            <PhysicsProvider>
+                <Consumer def={def} />
+            </PhysicsProvider>,
+        )
+        const callsAfterMount = spy.mock.calls.length
+        rerender(
+            <PhysicsProvider>
+                <Consumer def={def} />
+            </PhysicsProvider>,
+        )
+        expect(spy.mock.calls.length).toBe(callsAfterMount)
+    })
+})


### PR DESCRIPTION
## Summary

- Adds `web/src/physics/usePageDef.test.tsx` covering mount/unmount/change/no-op behaviour of the gravity-applying side-effect hook.
- Adds `web/src/physics/PhysicsContext.test.tsx` covering the provider, `usePhysicsWorld`, `edgeToInsets`, viewport init, window-resize wiring, frame-edge propagation, and unmount cleanup.
- No production code changed; pattern mirrors issues #53 and #91 (happy-dom + RTL + `vi.resetModules` singleton reset).

## Notes / deviations

- "Reads back the world's stored viewport" — `PhysicsWorld` has no `getViewport()`, so the mount-time assertion reads `getPosition(world.floorHandle)` instead (floor centre x = `vp.width/2`, which is the direct observable side-effect of `setViewport`). All other viewport assertions use `vi.spyOn(world, 'setViewport')` to verify both dimensions and insets.
- `usePageDef`'s "gravity change" test pins the exact call sequence `['down', 'left']` (cleanup-then-effect), which is the precise contract of React's effect-deps semantics.

## Acceptance criteria

- [x] `src/physics/usePageDef.test.tsx` covers mount, unmount restore, gravity change.
- [x] `src/physics/PhysicsContext.test.tsx` covers hook throw, hook return, `edgeToInsets`, viewport init, resize, edge change, unmount cleanup.
- [x] `npm run typecheck`, `npm run test`, `npm run build` all pass.
- [x] No production code changed — tests only.

## Test plan

```sh
cd web
npm run typecheck                              # clean
npm run test -- usePageDef PhysicsContext      # 12 tests pass
npm run test                                   # 48 files / 398 tests pass
npm run build                                  # SSG prerender completes for all routes
```

Closes #92