### PR TITLE
Slice 93: test hardening — blog MDX components (#93)

### DIFF
--- a/web/src/blog/components/BookCard.test.tsx
+++ b/web/src/blog/components/BookCard.test.tsx
@@ -1,0 +1,170 @@
+import { describe, test, expect, beforeEach, vi } from 'vitest'
+
+beforeEach(() => {
+    vi.resetModules()
+    vi.restoreAllMocks()
+})
+
+interface BookFromApi {
+    slug: string
+    title: string
+    author: string
+    status: 'currently-reading'
+    cover?: string
+}
+
+function stubFetchResolve(books: BookFromApi[]) {
+    return vi
+        .spyOn(globalThis, 'fetch')
+        .mockResolvedValue({
+            json: () => Promise.resolve({ books, stale: false }),
+        } as unknown as Response)
+}
+
+function stubFetchReject() {
+    return vi
+        .spyOn(globalThis, 'fetch')
+        .mockRejectedValue(new Error('network'))
+}
+
+async function setup() {
+    const rtl = await import('@testing-library/react')
+    const mod = await import('./BookCard')
+    return { ...rtl, ...mod }
+}
+
+describe('BookCard', () => {
+    test('loading state renders placeholder span', async () => {
+        // Never-resolving fetch keeps loading=true forever.
+        vi.spyOn(globalThis, 'fetch').mockReturnValue(
+            new Promise(() => {}) as Promise<Response>,
+        )
+        const { render, BookCard } = await setup()
+        const { container } = render(<BookCard slug="any" />)
+        const span = container.querySelector('span')
+        expect(span).toBeTruthy()
+        expect(span?.className).toBe('book-card book-card--placeholder')
+        expect(span?.textContent).toBe('—')
+    })
+
+    test('resolve with matching slug renders full card (cover, status, title, author)', async () => {
+        stubFetchResolve([
+            {
+                slug: 'pale-fire',
+                title: 'Pale Fire',
+                author: 'Vladimir Nabokov',
+                status: 'currently-reading',
+                cover: 'https://example.com/pf.jpg',
+            },
+        ])
+        const { render, waitFor, BookCard } = await setup()
+        const { container } = render(<BookCard slug="pale-fire" />)
+        await waitFor(() => {
+            expect(
+                container.querySelector('.book-card__title'),
+            ).toBeTruthy()
+        })
+        expect(
+            (container.querySelector('img.book-card__cover') as HTMLImageElement)
+                .src,
+        ).toBe('https://example.com/pf.jpg')
+        expect(
+            container.querySelector('.book-card__status')?.textContent,
+        ).toBe('Reading')
+        expect(
+            container.querySelector('.book-card__title')?.textContent,
+        ).toBe('Pale Fire')
+        expect(
+            container.querySelector('.book-card__author')?.textContent,
+        ).toBe('Vladimir Nabokov')
+    })
+
+    test('resolve with no matching slug renders placeholder', async () => {
+        stubFetchResolve([
+            {
+                slug: 'other',
+                title: 'Other',
+                author: 'X',
+                status: 'currently-reading',
+            },
+        ])
+        const { render, waitFor, BookCard } = await setup()
+        const { container } = render(<BookCard slug="missing" />)
+        await waitFor(() => {
+            const span = container.querySelector('span.book-card--placeholder')
+            expect(span).toBeTruthy()
+        })
+        expect(container.querySelector('.book-card__title')).toBeNull()
+    })
+
+    test('fetch reject renders placeholder', async () => {
+        stubFetchReject()
+        const { render, waitFor, BookCard } = await setup()
+        const { container } = render(<BookCard slug="pale-fire" />)
+        await waitFor(() => {
+            expect(
+                container.querySelector('span.book-card--placeholder'),
+            ).toBeTruthy()
+        })
+    })
+
+    test('two <BookCard> instances trigger exactly one fetch("/api/books")', async () => {
+        const spy = stubFetchResolve([])
+        const { render, waitFor, BookCard } = await setup()
+        const { container } = render(
+            <>
+                <BookCard slug="a" />
+                <BookCard slug="b" />
+            </>,
+        )
+        await waitFor(() => {
+            expect(
+                container.querySelectorAll('span.book-card--placeholder')
+                    .length,
+            ).toBe(2)
+        })
+        expect(spy).toHaveBeenCalledTimes(1)
+        expect(spy).toHaveBeenCalledWith('/api/books')
+    })
+
+    test('cover not starting with http renders no <img>', async () => {
+        stubFetchResolve([
+            {
+                slug: 'local',
+                title: 'Local',
+                author: 'L',
+                status: 'currently-reading',
+                cover: '/local/cover.jpg',
+            },
+        ])
+        const { render, waitFor, BookCard } = await setup()
+        const { container } = render(<BookCard slug="local" />)
+        await waitFor(() => {
+            expect(
+                container.querySelector('.book-card__title'),
+            ).toBeTruthy()
+        })
+        expect(container.querySelector('img')).toBeNull()
+    })
+
+    test('status "currently-reading" renders text "Reading"', async () => {
+        stubFetchResolve([
+            {
+                slug: 's',
+                title: 'T',
+                author: 'A',
+                status: 'currently-reading',
+            },
+        ])
+        const { render, waitFor, BookCard } = await setup()
+        const { container } = render(<BookCard slug="s" />)
+        await waitFor(() => {
+            expect(
+                container.querySelector('.book-card__status'),
+            ).toBeTruthy()
+        })
+        expect(
+            container.querySelector('.book-card__status')?.textContent,
+        ).toBe('Reading')
+    })
+})

--- a/web/src/blog/components/Callout.test.tsx
+++ b/web/src/blog/components/Callout.test.tsx
@@ -1,0 +1,28 @@
+import { describe, test, expect } from 'vitest'
+import { render } from '@testing-library/react'
+import { Callout } from './Callout'
+
+describe('Callout', () => {
+    test.each(['note', 'warn', 'aside'] as const)(
+        'type=%s renders <aside role="note" class="callout callout--%s">',
+        (type) => {
+            const { container } = render(
+                <Callout type={type}>hello</Callout>,
+            )
+            const aside = container.querySelector('aside')
+            expect(aside).toBeTruthy()
+            expect(aside?.getAttribute('role')).toBe('note')
+            expect(aside?.className).toBe(`callout callout--${type}`)
+        },
+    )
+
+    test('renders children inside the aside', () => {
+        const { container } = render(
+            <Callout type="note">
+                <p>body text</p>
+            </Callout>,
+        )
+        const aside = container.querySelector('aside')
+        expect(aside?.innerHTML).toContain('<p>body text</p>')
+    })
+})

--- a/web/src/blog/components/Figure.test.tsx
+++ b/web/src/blog/components/Figure.test.tsx
@@ -1,0 +1,55 @@
+import { describe, test, expect } from 'vitest'
+import { render } from '@testing-library/react'
+import { Figure } from './Figure'
+
+describe('Figure', () => {
+    test('renders <figure><img><figcaption>', () => {
+        const { container } = render(
+            <Figure src="/x.png" caption="cap" />,
+        )
+        const figure = container.querySelector('figure')
+        expect(figure).toBeTruthy()
+        expect(figure?.querySelector('img')).toBeTruthy()
+        expect(figure?.querySelector('figcaption')).toBeTruthy()
+    })
+
+    test('alt provided → img.alt === alt', () => {
+        const { container } = render(
+            <Figure src="/x.png" caption="cap" alt="explicit alt" />,
+        )
+        const img = container.querySelector('img') as HTMLImageElement
+        expect(img.alt).toBe('explicit alt')
+    })
+
+    test('alt absent → img.alt falls back to caption', () => {
+        const { container } = render(
+            <Figure src="/x.png" caption="cap text" />,
+        )
+        const img = container.querySelector('img') as HTMLImageElement
+        expect(img.alt).toBe('cap text')
+    })
+
+    test('credit provided → <span class="figure-credit"> — {credit}</span> inside figcaption', () => {
+        const { container } = render(
+            <Figure src="/x.png" caption="cap" credit="Photog Name" />,
+        )
+        const credit = container.querySelector('figcaption .figure-credit')
+        expect(credit).toBeTruthy()
+        expect(credit?.textContent).toBe(' — Photog Name')
+    })
+
+    test('credit absent → no figure-credit span', () => {
+        const { container } = render(
+            <Figure src="/x.png" caption="cap" />,
+        )
+        expect(container.querySelector('.figure-credit')).toBeNull()
+    })
+
+    test('<img> has loading="lazy"', () => {
+        const { container } = render(
+            <Figure src="/x.png" caption="cap" />,
+        )
+        const img = container.querySelector('img') as HTMLImageElement
+        expect(img.getAttribute('loading')).toBe('lazy')
+    })
+})

--- a/web/src/blog/components/NowPlaying.test.tsx
+++ b/web/src/blog/components/NowPlaying.test.tsx
@@ -1,0 +1,163 @@
+import { describe, test, expect, beforeEach, vi } from 'vitest'
+
+beforeEach(() => {
+    vi.resetModules()
+    vi.restoreAllMocks()
+})
+
+interface Track {
+    artist: string
+    title: string
+    album?: string
+    albumArt?: string
+    isNowPlaying: boolean
+}
+
+function stubFetchResolve(track: Track | null) {
+    return vi
+        .spyOn(globalThis, 'fetch')
+        .mockResolvedValue({
+            json: () => Promise.resolve({ track, stale: false }),
+        } as unknown as Response)
+}
+
+function stubFetchReject() {
+    return vi
+        .spyOn(globalThis, 'fetch')
+        .mockRejectedValue(new Error('network'))
+}
+
+async function setup() {
+    const rtl = await import('@testing-library/react')
+    const mod = await import('./NowPlaying')
+    return { ...rtl, ...mod }
+}
+
+describe('NowPlaying', () => {
+    test('loading renders placeholder span', async () => {
+        vi.spyOn(globalThis, 'fetch').mockReturnValue(
+            new Promise(() => {}) as Promise<Response>,
+        )
+        const { render, NowPlaying } = await setup()
+        const { container } = render(<NowPlaying />)
+        const span = container.querySelector('span')
+        expect(span?.className).toBe('now-playing now-playing--placeholder')
+        expect(span?.textContent).toBe('—')
+    })
+
+    test('data.track == null renders placeholder', async () => {
+        stubFetchResolve(null)
+        const { render, waitFor, NowPlaying } = await setup()
+        const { container } = render(<NowPlaying />)
+        await waitFor(() => {
+            expect(
+                container.querySelector('span.now-playing--placeholder'),
+            ).toBeTruthy()
+        })
+    })
+
+    test('isNowPlaying=true shows live indicator with dot', async () => {
+        stubFetchResolve({
+            artist: 'Artist',
+            title: 'Song',
+            isNowPlaying: true,
+        })
+        const { render, waitFor, NowPlaying } = await setup()
+        const { container } = render(<NowPlaying />)
+        await waitFor(() => {
+            expect(container.querySelector('.now-playing__live')).toBeTruthy()
+        })
+        expect(container.querySelector('.now-playing__dot')).toBeTruthy()
+    })
+
+    test('isNowPlaying=false has no live indicator', async () => {
+        stubFetchResolve({
+            artist: 'Artist',
+            title: 'Song',
+            isNowPlaying: false,
+        })
+        const { render, waitFor, NowPlaying } = await setup()
+        const { container } = render(<NowPlaying />)
+        await waitFor(() => {
+            expect(container.querySelector('.now-playing__title')).toBeTruthy()
+        })
+        expect(container.querySelector('.now-playing__live')).toBeNull()
+    })
+
+    test('albumArt present + album renders <img> with alt "{album} cover"', async () => {
+        stubFetchResolve({
+            artist: 'Artist',
+            title: 'Song',
+            album: 'AlbumName',
+            albumArt: 'https://example.com/art.jpg',
+            isNowPlaying: false,
+        })
+        const { render, waitFor, NowPlaying } = await setup()
+        const { container } = render(<NowPlaying />)
+        await waitFor(() => {
+            expect(container.querySelector('img')).toBeTruthy()
+        })
+        const img = container.querySelector('img') as HTMLImageElement
+        expect(img.alt).toBe('AlbumName cover')
+    })
+
+    test('albumArt present + no album renders <img> with alt "{title} cover"', async () => {
+        stubFetchResolve({
+            artist: 'Artist',
+            title: 'Song',
+            albumArt: 'https://example.com/art.jpg',
+            isNowPlaying: false,
+        })
+        const { render, waitFor, NowPlaying } = await setup()
+        const { container } = render(<NowPlaying />)
+        await waitFor(() => {
+            expect(container.querySelector('img')).toBeTruthy()
+        })
+        const img = container.querySelector('img') as HTMLImageElement
+        expect(img.alt).toBe('Song cover')
+    })
+
+    test('albumArt absent renders no <img>', async () => {
+        stubFetchResolve({
+            artist: 'Artist',
+            title: 'Song',
+            isNowPlaying: false,
+        })
+        const { render, waitFor, NowPlaying } = await setup()
+        const { container } = render(<NowPlaying />)
+        await waitFor(() => {
+            expect(container.querySelector('.now-playing__title')).toBeTruthy()
+        })
+        expect(container.querySelector('img')).toBeNull()
+    })
+
+    test('two <NowPlaying> instances trigger exactly one fetch("/api/now-playing")', async () => {
+        const spy = stubFetchResolve(null)
+        const { render, waitFor, NowPlaying } = await setup()
+        const { container } = render(
+            <>
+                <NowPlaying />
+                <NowPlaying />
+            </>,
+        )
+        await waitFor(() => {
+            expect(
+                container.querySelectorAll('span.now-playing--placeholder')
+                    .length,
+            ).toBe(2)
+        })
+        expect(spy).toHaveBeenCalledTimes(1)
+        expect(spy).toHaveBeenCalledWith('/api/now-playing')
+    })
+
+    test('fetch reject renders placeholder', async () => {
+        stubFetchReject()
+        const { render, waitFor, NowPlaying } = await setup()
+        const { container } = render(<NowPlaying />)
+        await waitFor(() => {
+            expect(
+                container.querySelector('span.now-playing--placeholder'),
+            ).toBeTruthy()
+        })
+    })
+})

--- a/web/src/blog/components/Video.test.tsx
+++ b/web/src/blog/components/Video.test.tsx
@@ -1,0 +1,35 @@
+import { describe, test, expect } from 'vitest'
+import { render } from '@testing-library/react'
+import { Video } from './Video'
+
+describe('Video', () => {
+    test('renders <figure><video src controls></figure>', () => {
+        const { container } = render(<Video src="/clip.mp4" />)
+        const figure = container.querySelector('figure')
+        const video = figure?.querySelector('video')
+        expect(figure).toBeTruthy()
+        expect(video).toBeTruthy()
+        expect(video?.getAttribute('src')).toBe('/clip.mp4')
+        expect(video?.hasAttribute('controls')).toBe(true)
+    })
+
+    test('caption provided renders <figcaption> after the video', () => {
+        const { container } = render(
+            <Video src="/clip.mp4" caption="a sea otter" />,
+        )
+        const caption = container.querySelector('figcaption')
+        expect(caption).toBeTruthy()
+        expect(caption?.textContent).toBe('a sea otter')
+    })
+
+    test('caption absent renders no <figcaption>', () => {
+        const { container } = render(<Video src="/clip.mp4" />)
+        expect(container.querySelector('figcaption')).toBeNull()
+    })
+
+    test('<video> has inline style width: 100%', () => {
+        const { container } = render(<Video src="/clip.mp4" />)
+        const video = container.querySelector('video') as HTMLVideoElement
+        expect(video.style.width).toBe('100%')
+    })
+})


### PR DESCRIPTION
## Summary

- Adds happy-dom + @testing-library/react tests for the 5 MDX components rendered inside blog posts: `BookCard`, `NowPlaying`, `Video`, `Figure`, `Callout`.
- 30 new tests; no production code changed.
- `BookCard` and `NowPlaying` cache a module-level in-flight fetch promise; tests isolate that cache via `vi.resetModules()` + dynamic re-import per test, following the precedent in `web/src/physics/PhysicsContext.test.tsx`.

## Notes / deviations

None. Followed the issue spec verbatim and did not add a reset helper.

## Acceptance criteria

- [x] `src/blog/components/BookCard.test.tsx` covers loading, found, not-found, error, fetch-dedup, cover URL gating, status label.
- [x] `src/blog/components/Video.test.tsx` covers presence/absence of caption + controls.
- [x] `src/blog/components/NowPlaying.test.tsx` covers loading, no-track, live-indicator gating, albumArt gating, fetch-dedup, error.
- [x] `src/blog/components/Figure.test.tsx` covers alt fallback, credit gating, loading=lazy.
- [x] `src/blog/components/Callout.test.tsx` covers all three types + role + children.
- [x] `npm run typecheck`, `npm run test`, `npm run build` all pass.
- [x] No production code changed — tests only.

## Test plan

From `web/`:

\`\`\`sh
npm run typecheck
npm run test
npm run build
\`\`\`

All three pass locally; full vitest run is 53 files / 428 tests green (30 new in this PR).

Closes #93