### PR TITLE
Slice 94: blog build pipeline tests (#94)

### DIFF
--- a/web/src/blog/remark-extract-toc.test.ts
+++ b/web/src/blog/remark-extract-toc.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest'
+import { unified } from 'unified'
+import remarkParse from 'remark-parse'
+import type { Root } from 'mdast'
+import { remarkExtractToc } from './remark-extract-toc'
+
+function transform(md: string): Root {
+    const processor = unified().use(remarkParse).use(remarkExtractToc)
+    const ast = processor.parse(md)
+    return processor.runSync(ast) as Root
+}
+
+function appendedNode(tree: Root): any {
+    return tree.children[tree.children.length - 1]
+}
+
+function decodeToc(
+    tree: Root,
+): Array<{ depth: number; text: string; slug: string }> {
+    const node = appendedNode(tree)
+    const prefix = 'export const toc = '
+    expect(node.value.startsWith(prefix)).toBe(true)
+    return JSON.parse(node.value.slice(prefix.length))
+}
+
+describe('remarkExtractToc', () => {
+    it('extracts headings at multiple depths into the toc', () => {
+        const toc = decodeToc(transform('# A\n\n## B\n\n### C\n'))
+        expect(toc).toEqual([
+            { depth: 1, text: 'A', slug: 'a' },
+            { depth: 2, text: 'B', slug: 'b' },
+            { depth: 3, text: 'C', slug: 'c' },
+        ])
+    })
+
+    it('slugifies "Hello World" to "hello-world"', () => {
+        const toc = decodeToc(transform('# Hello World\n'))
+        expect(toc).toEqual([
+            { depth: 1, text: 'Hello World', slug: 'hello-world' },
+        ])
+    })
+
+    it('appends -1, -2, ... for duplicate heading text', () => {
+        const toc = decodeToc(transform('## Notes\n\n## Notes\n\n## Notes\n'))
+        expect(toc.map((e) => e.slug)).toEqual(['notes', 'notes-1', 'notes-2'])
+    })
+
+    it('flattens inline formatting in heading text', () => {
+        const toc = decodeToc(
+            transform('## **Bold** and *em* and `code`\n'),
+        )
+        expect(toc).toHaveLength(1)
+        const [entry] = toc
+        expect(entry?.text).toBe('Bold and em and code')
+        expect(entry?.text).not.toMatch(/[*`]/)
+    })
+
+    it('appends an empty toc array when there are no headings', () => {
+        const node = appendedNode(
+            transform('just a paragraph with no headings.\n'),
+        )
+        expect(node.value).toBe('export const toc = []')
+    })
+
+    it('attaches an ExportNamedDeclaration estree node declaring `toc`', () => {
+        const node = appendedNode(transform('# A\n'))
+        const estree = node.data.estree
+        expect(estree.type).toBe('Program')
+        expect(estree.body[0].type).toBe('ExportNamedDeclaration')
+        const decl = estree.body[0].declaration
+        expect(decl.declarations[0].id.name).toBe('toc')
+    })
+})

--- a/web/src/blog/vite-plugin-feeds.test.ts
+++ b/web/src/blog/vite-plugin-feeds.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readFileSync } from 'node:fs'
+import { existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+    escapeXml,
+    buildRss,
+    buildSitemap,
+    vitePluginFeeds,
+} from './vite-plugin-feeds'
+
+describe('escapeXml', () => {
+    it('escapes the five core XML entities', () => {
+        expect(escapeXml('a & b < c > d "e"')).toBe(
+            'a &amp; b &lt; c &gt; d &quot;e&quot;',
+        )
+    })
+
+    it('returns input unchanged when there are no special chars', () => {
+        expect(escapeXml('plain text 123')).toBe('plain text 123')
+    })
+
+    it('escapes ampersands before other entities (no double-escape)', () => {
+        expect(escapeXml('&lt;')).toBe('&amp;lt;')
+    })
+})
+
+describe('buildRss', () => {
+    const base = 'https://example.com'
+
+    it('emits an empty channel when given no posts', () => {
+        const xml = buildRss([], base)
+        expect(xml).toContain('<channel>')
+        expect(xml).toContain('<title>chaipalaka.com</title>')
+        expect(xml).toContain(`<link>${base}</link>`)
+        expect(xml).not.toContain('<item>')
+    })
+
+    it('renders one item with escaped fields for a single post', () => {
+        const xml = buildRss(
+            [
+                {
+                    slug: 'hello',
+                    title: 'A & B',
+                    description: 'd',
+                    date: '2026-01-15',
+                    body: '# body',
+                },
+            ],
+            base,
+        )
+        expect(xml).toContain('<title>A &amp; B</title>')
+        expect(xml).toContain(`<link>${base}/blog/hello</link>`)
+        expect(xml).toContain(
+            `<pubDate>${new Date('2026-01-15').toUTCString()}</pubDate>`,
+        )
+        expect(xml).toContain('<guid isPermaLink="true">')
+        expect(xml).toContain('<content:encoded><![CDATA[# body]]>')
+    })
+})
+
+describe('buildSitemap', () => {
+    const base = 'https://example.com'
+
+    it('lists only the static routes when there are no posts', () => {
+        const xml = buildSitemap([], base)
+        expect(xml).toContain(`<loc>${base}/</loc>`)
+        expect(xml).toContain(`<loc>${base}/blog</loc>`)
+        const locMatches = xml.match(/<loc>/g) ?? []
+        expect(locMatches).toHaveLength(2)
+    })
+
+    it('adds /blog/<slug> and /blog/<slug>/read for each post', () => {
+        const xml = buildSitemap(
+            [
+                {
+                    slug: 'hello',
+                    title: 't',
+                    description: 'd',
+                    date: '2026-01-15',
+                    body: '',
+                },
+            ],
+            base,
+        )
+        expect(xml).toContain(`<loc>${base}/blog/hello</loc>`)
+        expect(xml).toContain(`<loc>${base}/blog/hello/read</loc>`)
+    })
+})
+
+describe('vitePluginFeeds (lifecycle)', () => {
+    let root: string
+    let webDir: string
+    let outDir: string
+    let contentDir: string
+    let originalCwd: string
+
+    beforeEach(() => {
+        originalCwd = process.cwd()
+        root = mkdtempSync(join(tmpdir(), 'feeds-'))
+        webDir = join(root, 'web')
+        outDir = join(webDir, 'dist')
+        contentDir = join(root, 'content', 'blog')
+        mkdirSync(webDir, { recursive: true })
+        mkdirSync(outDir, { recursive: true })
+        mkdirSync(contentDir, { recursive: true })
+        process.chdir(webDir)
+    })
+
+    afterEach(() => {
+        process.chdir(originalCwd)
+        rmSync(root, { recursive: true, force: true })
+    })
+
+    function writePost(
+        dirName: string,
+        frontmatter: Record<string, unknown>,
+        body = 'hello body\n',
+    ): void {
+        const fmLines = Object.entries(frontmatter)
+            .map(([k, v]) =>
+                typeof v === 'string' ? `${k}: "${v}"` : `${k}: ${v}`,
+            )
+            .join('\n')
+        const raw = `---\n${fmLines}\n---\n${body}`
+        const postDir = join(contentDir, dirName)
+        mkdirSync(postDir, { recursive: true })
+        writeFileSync(join(postDir, 'index.mdx'), raw, 'utf-8')
+    }
+
+    async function runClose(mode: 'production' | 'development'): Promise<void> {
+        const plugin = vitePluginFeeds({ baseUrl: 'https://example.com' }) as any
+        plugin.configResolved({ build: { outDir }, mode })
+        await plugin.closeBundle()
+    }
+
+    it('writes rss.xml and sitemap.xml with the post slug stripped of the date prefix', async () => {
+        writePost('2026-01-15-hello', {
+            title: 'Hello',
+            description: 'desc',
+            date: '2026-01-15',
+        })
+        await runClose('production')
+
+        const rssPath = join(outDir, 'rss.xml')
+        const sitemapPath = join(outDir, 'sitemap.xml')
+        expect(existsSync(rssPath)).toBe(true)
+        expect(existsSync(sitemapPath)).toBe(true)
+
+        const rss = readFileSync(rssPath, 'utf-8')
+        const sitemap = readFileSync(sitemapPath, 'utf-8')
+        expect(rss).toContain('<title>Hello</title>')
+        expect(rss).toContain('<link>https://example.com/blog/hello</link>')
+        expect(sitemap).toContain('<loc>https://example.com/blog/hello</loc>')
+        expect(sitemap).toContain(
+            '<loc>https://example.com/blog/hello/read</loc>',
+        )
+    })
+
+    it('orders rss items by date descending', async () => {
+        writePost('2026-01-15-early', {
+            title: 'Early',
+            description: 'd',
+            date: '2026-01-15',
+        })
+        writePost('2026-06-01-late', {
+            title: 'Late',
+            description: 'd',
+            date: '2026-06-01',
+        })
+        await runClose('production')
+
+        const rss = readFileSync(join(outDir, 'rss.xml'), 'utf-8')
+        const lateIdx = rss.indexOf('<title>Late</title>')
+        const earlyIdx = rss.indexOf('<title>Early</title>')
+        expect(lateIdx).toBeGreaterThan(-1)
+        expect(earlyIdx).toBeGreaterThan(-1)
+        expect(lateIdx).toBeLessThan(earlyIdx)
+    })
+
+    it('filters draft posts out in production mode', async () => {
+        writePost('2026-01-15-pub', {
+            title: 'Published',
+            description: 'd',
+            date: '2026-01-15',
+        })
+        writePost('2026-02-01-wip', {
+            title: 'Wip',
+            description: 'd',
+            date: '2026-02-01',
+            draft: true,
+        })
+        await runClose('production')
+
+        const rss = readFileSync(join(outDir, 'rss.xml'), 'utf-8')
+        const sitemap = readFileSync(join(outDir, 'sitemap.xml'), 'utf-8')
+        expect(rss).toContain('<title>Published</title>')
+        expect(rss).not.toContain('<title>Wip</title>')
+        expect(sitemap).toContain('/blog/pub')
+        expect(sitemap).not.toContain('/blog/wip')
+    })
+
+    it('includes draft posts when mode is not production', async () => {
+        writePost('2026-01-15-pub', {
+            title: 'Published',
+            description: 'd',
+            date: '2026-01-15',
+        })
+        writePost('2026-02-01-wip', {
+            title: 'Wip',
+            description: 'd',
+            date: '2026-02-01',
+            draft: true,
+        })
+        await runClose('development')
+
+        const rss = readFileSync(join(outDir, 'rss.xml'), 'utf-8')
+        expect(rss).toContain('<title>Published</title>')
+        expect(rss).toContain('<title>Wip</title>')
+    })
+})

--- a/web/src/blog/vite-plugin-feeds.ts
+++ b/web/src/blog/vite-plugin-feeds.ts
@@ -15,7 +15,7 @@ interface PostMeta {
     body: string
 }
 
-function escapeXml(s: string): string {
+export function escapeXml(s: string): string {
     return s
         .replace(/&/g, '&amp;')
         .replace(/</g, '&lt;')
@@ -50,7 +50,7 @@ async function collectPosts(
     )
 }
 
-function buildRss(posts: PostMeta[], baseUrl: string): string {
+export function buildRss(posts: PostMeta[], baseUrl: string): string {
     const items = posts
         .map((p) => {
             const link = `${baseUrl}/blog/${p.slug}`
@@ -80,7 +80,7 @@ ${items}
 </rss>`
 }
 
-function buildSitemap(posts: PostMeta[], baseUrl: string): string {
+export function buildSitemap(posts: PostMeta[], baseUrl: string): string {
     const staticRoutes = ['/', '/blog']
     const dynamicRoutes = posts.flatMap((p) => [
         `/blog/${p.slug}`,


### PR DESCRIPTION
## Summary

- Adds `web/src/blog/remark-extract-toc.test.ts` — 6 tests covering the remark plugin (multi-depth headings, slug semantics, github-slugger dedup, inline-formatting flatten, empty case, estree shape).
- Adds `web/src/blog/vite-plugin-feeds.test.ts` — 11 tests covering `escapeXml`, `buildRss` (empty + populated), `buildSitemap` (empty + populated), and the plugin's `closeBundle` lifecycle via a temp-dir fixture (rss/sitemap written, date-descending sort, draft filtering in prod vs dev, slug prefix strip).
- Promotes three helpers in `web/src/blog/vite-plugin-feeds.ts` to exports (`escapeXml`, `buildRss`, `buildSitemap`) so they can be unit-tested without spinning up a fake Vite. `collectPosts` stays private.

## Notes / deviations

- The plugin reads from `process.cwd() + '/../content/blog'`. Per the issue, the lifecycle test rigs `process.cwd()` via `process.chdir` against a `mkdtempSync` fixture (no production refactor to accept the dir as an option).
- No other production behaviour change in `vite-plugin-feeds.ts`. Build output is unchanged (verified: `rss.xml` and `sitemap.xml` still emitted on `npm run build`).

## Acceptance criteria

- [x] `src/blog/remark-extract-toc.test.ts` covers single-heading, multi-depth, dedup, inline-formatting flatten, empty case.
- [x] `src/blog/vite-plugin-feeds.test.ts` covers `escapeXml`, `buildRss` empty + with posts, `buildSitemap` empty + with posts.
- [x] `src/blog/vite-plugin-feeds.test.ts` also covers plugin lifecycle: rss/sitemap written, sort order, draft filter, slug prefix strip.
- [x] `escapeXml`, `buildRss`, `buildSitemap` are exported from `vite-plugin-feeds.ts` (no other production behavior change).
- [x] `npm run typecheck`, `npm run test`, `npm run build` all pass.

## Test plan

From `web/`:

\`\`\`sh
npm run typecheck   # clean
npm run test        # 55 files, 445 tests pass (incl. the 17 new ones)
npm run build       # rss.xml + sitemap.xml emitted to dist/
\`\`\`

Closes #94