### PR TITLE
Slice 95: route component tests (#95)

### DIFF
--- a/web/src/routes/Home.test.tsx
+++ b/web/src/routes/Home.test.tsx
@@ -1,0 +1,58 @@
+import { describe, test, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+import Home, { pageDef } from './Home'
+import { PhysicsProvider } from '../physics/PhysicsContext'
+import { CardRegistryProvider } from '../transitions/CardRegistry'
+import { PhysicsLayer } from '../transitions/PhysicsLayer'
+
+vi.mock('../canvas/flip', () => ({
+    flipMorph: vi.fn(),
+}))
+
+function renderHome() {
+    return render(
+        <PhysicsProvider>
+            <CardRegistryProvider>
+                <PhysicsLayer />
+                <Home />
+            </CardRegistryProvider>
+        </PhysicsProvider>,
+    )
+}
+
+describe('Home — pageDef shape', () => {
+    test('gravity is down', () => {
+        expect(pageDef.gravity).toBe('down')
+    })
+
+    test('exactly 2 cards with ids card-a and card-b', () => {
+        expect(pageDef.cards).toHaveLength(2)
+        const ids = pageDef.cards.map((c) => c.id).sort()
+        expect(ids).toEqual(['card-a', 'card-b'])
+    })
+
+    test('both cards are headline kind, parented to ceiling', () => {
+        for (const c of pageDef.cards) {
+            expect(c.kind).toBe('headline')
+            expect(c.parent).toBe('ceiling')
+        }
+    })
+})
+
+describe('Home — render', () => {
+    test('mounts without throwing', () => {
+        expect(() => renderHome()).not.toThrow()
+    })
+
+    test('renders one article.physics-card per card with matching data-card-id', () => {
+        const { container } = renderHome()
+        const articles = Array.from(
+            container.querySelectorAll('article.physics-card'),
+        )
+        expect(articles).toHaveLength(2)
+        const ids = articles
+            .map((a) => a.getAttribute('data-card-id'))
+            .sort()
+        expect(ids).toEqual(['card-a', 'card-b'])
+    })
+})

--- a/web/src/routes/NotFound.test.tsx
+++ b/web/src/routes/NotFound.test.tsx
@@ -1,0 +1,91 @@
+import { describe, test, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+
+vi.mock('../canvas/flip', () => ({
+    flipMorph: vi.fn(),
+}))
+
+// Stub the blog posts module so NotFound's `getPosts().slice(0, 3)` is
+// deterministic and doesn't depend on the real MDX pipeline.
+vi.mock('../blog/posts', () => ({
+    getPosts: () => [
+        {
+            slug: 'post-one',
+            frontmatter: {
+                title: 'Post One',
+                description: 'd',
+                date: '2026-05-01',
+                tags: [],
+                draft: false,
+            },
+            toc: [],
+            Component: () => null,
+        },
+        {
+            slug: 'post-two',
+            frontmatter: {
+                title: 'Post Two',
+                description: 'd',
+                date: '2026-04-01',
+                tags: [],
+                draft: false,
+            },
+            toc: [],
+            Component: () => null,
+        },
+    ],
+}))
+
+import NotFound, { pageDef } from './NotFound'
+import { PhysicsProvider } from '../physics/PhysicsContext'
+import { CardRegistryProvider } from '../transitions/CardRegistry'
+import { PhysicsLayer } from '../transitions/PhysicsLayer'
+
+function renderNotFound() {
+    return render(
+        <MemoryRouter initialEntries={['/bogus']}>
+            <PhysicsProvider>
+                <CardRegistryProvider>
+                    <PhysicsLayer />
+                    <NotFound />
+                </CardRegistryProvider>
+            </PhysicsProvider>
+        </MemoryRouter>,
+    )
+}
+
+describe('NotFound — pageDef shape', () => {
+    test('gravity is up', () => {
+        expect(pageDef.gravity).toBe('up')
+    })
+
+    test('has at least 3 cards (headline + portfolio + link), up to 3 more from recent posts', () => {
+        expect(pageDef.cards.length).toBeGreaterThanOrEqual(3)
+        expect(pageDef.cards.length).toBeLessThanOrEqual(6)
+        const ids = pageDef.cards.map((c) => c.id)
+        expect(ids).toContain('notfound-headline')
+        expect(ids).toContain('notfound-portfolio')
+        expect(ids).toContain('notfound-link')
+    })
+})
+
+describe('NotFound — render', () => {
+    test('mounts without throwing', () => {
+        expect(() => renderNotFound()).not.toThrow()
+    })
+
+    test('renders <h1>404</h1> and the page-not-found copy', () => {
+        const { container, getByText } = renderNotFound()
+        const h1 = container.querySelector('h1')
+        expect(h1).toBeTruthy()
+        expect(h1!.textContent).toBe('404')
+        expect(getByText(/doesn't exist/i)).toBeTruthy()
+    })
+
+    test('renders a link to /stuff and a link to /', () => {
+        const { container } = renderNotFound()
+        expect(container.querySelector('a[href="/stuff"]')).toBeTruthy()
+        expect(container.querySelector('a[href="/"]')).toBeTruthy()
+    })
+})

--- a/web/src/routes/Stuff.test.tsx
+++ b/web/src/routes/Stuff.test.tsx
@@ -1,0 +1,63 @@
+import { describe, test, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import Stuff, { pageDef } from './Stuff'
+import { PhysicsProvider } from '../physics/PhysicsContext'
+import { CardRegistryProvider } from '../transitions/CardRegistry'
+import { PhysicsLayer } from '../transitions/PhysicsLayer'
+
+vi.mock('../canvas/flip', () => ({
+    flipMorph: vi.fn(),
+}))
+
+function renderStuff() {
+    return render(
+        <MemoryRouter initialEntries={['/stuff']}>
+            <PhysicsProvider>
+                <CardRegistryProvider>
+                    <PhysicsLayer />
+                    <Stuff />
+                </CardRegistryProvider>
+            </PhysicsProvider>
+        </MemoryRouter>,
+    )
+}
+
+describe('Stuff — pageDef shape', () => {
+    test('has 4 cards with the expected ids', () => {
+        const ids = pageDef.cards.map((c) => c.id).sort()
+        expect(ids).toEqual([
+            'stuff-digital-art',
+            'stuff-flash',
+            'stuff-site',
+            'stuff-software',
+        ])
+    })
+
+    test('all cards are portfolio kind, parented to ceiling', () => {
+        for (const c of pageDef.cards) {
+            expect(c.kind).toBe('portfolio')
+            expect(c.parent).toBe('ceiling')
+        }
+    })
+})
+
+describe('Stuff — render', () => {
+    test('mounts without throwing', () => {
+        expect(() => renderStuff()).not.toThrow()
+    })
+
+    test('Flash card contains a link to /stuff/flash', () => {
+        const { container } = renderStuff()
+        const flashLink = container.querySelector('a[href="/stuff/flash"]')
+        expect(flashLink).toBeTruthy()
+    })
+
+    test('three coming-soon cards render aria-disabled articles', () => {
+        const { container } = renderStuff()
+        const disabledArticles = container.querySelectorAll(
+            'article[aria-disabled="true"]',
+        )
+        expect(disabledArticles).toHaveLength(3)
+    })
+})

--- a/web/src/routes/blog/BlogPost.test.tsx
+++ b/web/src/routes/blog/BlogPost.test.tsx
@@ -1,0 +1,137 @@
+import { describe, test, expect, vi } from 'vitest'
+import { render, act } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import type { PageDef } from '../../physics/PageDef'
+
+vi.mock('../../canvas/flip', () => ({
+    flipMorph: vi.fn(),
+}))
+
+// Stub the MDX-backed posts module so the test runtime doesn't pull the
+// real Vite MDX pipeline.
+vi.mock('../../blog/posts', () => ({
+    getPosts: () => [
+        {
+            slug: 'hello',
+            frontmatter: {
+                title: 'Hello World',
+                description: 'd',
+                date: '2026-05-09',
+                tags: ['meta', 'intro'],
+                draft: false,
+            },
+            toc: [],
+            Component: () => <div data-testid="mdx-body">body</div>,
+        },
+        {
+            slug: 'no-tags',
+            frontmatter: {
+                title: 'Untagged',
+                description: 'd',
+                date: '2026-04-01',
+                tags: [],
+                draft: false,
+            },
+            toc: [],
+            Component: () => <div data-testid="mdx-body">body</div>,
+        },
+    ],
+}))
+
+// Capture the pageDef passed to useRegisterPageDef.
+const registered: { def: PageDef | null } = { def: null }
+vi.mock('../../transitions/PageDefRegistry', () => ({
+    useRegisterPageDef: (def: PageDef) => {
+        registered.def = def
+    },
+}))
+
+import { PhysicsProvider } from '../../physics/PhysicsContext'
+import { CardRegistryProvider } from '../../transitions/CardRegistry'
+import { PhysicsLayer } from '../../transitions/PhysicsLayer'
+import BlogPost from './BlogPost'
+
+function renderAt(path: string) {
+    registered.def = null
+    return render(
+        <MemoryRouter initialEntries={[path]}>
+            <PhysicsProvider>
+                <CardRegistryProvider>
+                    <PhysicsLayer />
+                    <Routes>
+                        <Route path="/blog/:slug" element={<BlogPost />} />
+                    </Routes>
+                </CardRegistryProvider>
+            </PhysicsProvider>
+        </MemoryRouter>,
+    )
+}
+
+describe('BlogPost — slug miss', () => {
+    test('returns null DOM when slug does not match any post', () => {
+        const { container } = renderAt('/blog/does-not-exist')
+        // No headline/title for an unknown slug — only the PhysicsLayer wrapper.
+        expect(container.querySelector('h1')).toBeNull()
+    })
+})
+
+describe('BlogPost — slug match', () => {
+    test('mounts without throwing', () => {
+        expect(() => renderAt('/blog/hello')).not.toThrow()
+    })
+
+    test('renders <h1> with the frontmatter title', () => {
+        const { container } = renderAt('/blog/hello')
+        const h1 = container.querySelector('h1')
+        expect(h1).toBeTruthy()
+        expect(h1!.textContent).toBe('Hello World')
+    })
+
+    test('date is rendered via <time dateTime="..."> with the ISO date and long-format US date as text', () => {
+        const { container } = renderAt('/blog/hello')
+        const time = container.querySelector('time')
+        expect(time).toBeTruthy()
+        expect(time!.getAttribute('datetime')).toBe('2026-05-09')
+        // The visible date depends on the runner's timezone (UTC midnight may
+        // render as May 8 in PT). Assert month + year, not exact day-of-month.
+        expect(time!.textContent).toMatch(/May \d{1,2}, 2026/)
+    })
+
+    test('tags are joined with ", " when present', () => {
+        const { container } = renderAt('/blog/hello')
+        expect(container.textContent).toContain('meta, intro')
+    })
+
+    test('tag dot-separator is absent when tags is empty', () => {
+        const { container } = renderAt('/blog/no-tags')
+        // The " · " separator only renders when tags are non-empty.
+        const meta = container.querySelector('.post-meta')
+        expect(meta).toBeTruthy()
+        expect(meta!.textContent ?? '').not.toContain('·')
+    })
+
+    test('"Read in plain mode" link points to /blog/{slug}/read', () => {
+        const { container } = renderAt('/blog/hello')
+        const plainLink = container.querySelector('a.plain-mode-link')
+        expect(plainLink).toBeTruthy()
+        expect(plainLink!.getAttribute('href')).toBe('/blog/hello/read')
+    })
+
+    test('useRegisterPageDef called with a PageDef containing one card id=post-{slug}', () => {
+        renderAt('/blog/hello')
+        expect(registered.def).not.toBeNull()
+        const def = registered.def!
+        expect(def.cards).toHaveLength(1)
+        expect(def.cards[0]!.id).toBe('post-hello')
+    })
+
+    test('renders the stubbed MDX body component', () => {
+        // BlogPost gates the body render behind a window-resize effect; flush it.
+        // jsdom/happy-dom dispatch resize synchronously, so this is enough.
+        let utils: ReturnType<typeof renderAt>
+        act(() => {
+            utils = renderAt('/blog/hello')
+        })
+        expect(utils!.queryByTestId('mdx-body')).toBeTruthy()
+    })
+})

--- a/web/src/routes/blog/BlogPostReader.test.tsx
+++ b/web/src/routes/blog/BlogPostReader.test.tsx
@@ -1,0 +1,83 @@
+import { describe, test, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+
+// Stub posts so the test runtime doesn't pull the real Vite MDX pipeline.
+// BlogPostReader exercises a non-empty TOC; include one entry.
+vi.mock('../../blog/posts', () => ({
+    getPosts: () => [
+        {
+            slug: 'hello',
+            frontmatter: {
+                title: 'Hello World',
+                description: 'd',
+                date: '2026-05-09',
+                tags: ['meta'],
+                draft: false,
+            },
+            toc: [{ depth: 2, text: 'Section', slug: 'section' }],
+            Component: () => <div data-testid="mdx-body">body</div>,
+        },
+    ],
+}))
+
+import BlogPostReader from './BlogPostReader'
+
+function renderAt(path: string) {
+    return render(
+        <MemoryRouter initialEntries={[path]}>
+            <Routes>
+                <Route path="/blog/:slug/read" element={<BlogPostReader />} />
+            </Routes>
+        </MemoryRouter>,
+    )
+}
+
+describe('BlogPostReader — slug miss', () => {
+    test('returns null when slug does not match any post', () => {
+        const { container } = renderAt('/blog/does-not-exist/read')
+        // The router renders an empty wrapper around a null route element.
+        expect(container.querySelector('main.reader')).toBeNull()
+    })
+})
+
+describe('BlogPostReader — slug match', () => {
+    test('mounts without throwing', () => {
+        expect(() => renderAt('/blog/hello/read')).not.toThrow()
+    })
+
+    test('renders <main class="reader"> wrapper', () => {
+        const { container } = renderAt('/blog/hello/read')
+        expect(container.querySelector('main.reader')).toBeTruthy()
+    })
+
+    test('renders <nav class="reader__toc"> with one <li data-depth="2"> per TOC entry', () => {
+        const { container } = renderAt('/blog/hello/read')
+        const nav = container.querySelector('nav.reader__toc')
+        expect(nav).toBeTruthy()
+        const items = nav!.querySelectorAll('li')
+        expect(items).toHaveLength(1)
+        expect(items[0]!.getAttribute('data-depth')).toBe('2')
+        const anchor = items[0]!.querySelector('a')
+        expect(anchor!.getAttribute('href')).toBe('#section')
+    })
+
+    test('article body renders <h1> with the frontmatter title', () => {
+        const { container } = renderAt('/blog/hello/read')
+        const h1 = container.querySelector('article.reader__body h1')
+        expect(h1).toBeTruthy()
+        expect(h1!.textContent).toBe('Hello World')
+    })
+
+    test('article body renders <time dateTime="..."> with the ISO date', () => {
+        const { container } = renderAt('/blog/hello/read')
+        const time = container.querySelector('article.reader__body time')
+        expect(time).toBeTruthy()
+        expect(time!.getAttribute('datetime')).toBe('2026-05-09')
+    })
+
+    test('article body renders the stubbed MDX body component', () => {
+        const { queryByTestId } = renderAt('/blog/hello/read')
+        expect(queryByTestId('mdx-body')).toBeTruthy()
+    })
+})

--- a/web/src/routes/stuff/Flash.test.tsx
+++ b/web/src/routes/stuff/Flash.test.tsx
@@ -1,0 +1,168 @@
+import { describe, test, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import type { Piece } from '../../stuff/flash/pieces'
+
+vi.mock('../../canvas/flip', () => ({
+    flipMorph: vi.fn(),
+}))
+
+// Stub the pieces module so the test runtime doesn't pull the real MDX
+// pipeline. Flash.tsx imports getPiecesByCategory eagerly at module scope.
+vi.mock('../../stuff/flash/pieces', () => ({
+    getPiecesByCategory: () => new Map<string, Piece[]>(),
+    getPieceBySlug: () => undefined,
+}))
+
+import Flash, { buildFlashIndex } from './Flash'
+import { PhysicsProvider } from '../../physics/PhysicsContext'
+import { CardRegistryProvider } from '../../transitions/CardRegistry'
+import { PhysicsLayer } from '../../transitions/PhysicsLayer'
+
+const CHAIN_TOP = 100
+const HEADER_H = 140
+const PIECE_H = 320
+const CHAIN_GAP = 60
+
+function makePiece(slug: string, title = slug): Piece {
+    return {
+        slug,
+        frontmatter: {
+            title,
+            description: '',
+            category: 'unused',
+            quality: 5,
+            thumbnail: 't.png',
+            swf: 's.swf',
+            swf_width: 320,
+            swf_height: 240,
+            tags: [],
+            draft: false,
+        },
+        Component: () => null,
+    }
+}
+
+describe('buildFlashIndex — empty input', () => {
+    test('empty map → empty pageDef and empty cardContent', () => {
+        const { pageDef, cardContent } = buildFlashIndex(new Map(), {
+            width: 1024,
+            height: 768,
+        })
+        expect(pageDef.gravity).toBe('down')
+        expect(pageDef.cards).toEqual([])
+        expect(cardContent).toEqual({})
+    })
+})
+
+describe('buildFlashIndex — sorted categories + chain topology', () => {
+    test('category keys are sorted alphabetically', () => {
+        const groups = new Map<string, Piece[]>([
+            ['zebra', [makePiece('z1')]],
+            ['alpha', [makePiece('a1')]],
+        ])
+        const { pageDef } = buildFlashIndex(groups, {
+            width: 1024,
+            height: 768,
+        })
+        const headers = pageDef.cards.filter((c) => c.kind === 'headline')
+        expect(headers.map((h) => h.id)).toEqual([
+            'flash-cat-alpha',
+            'flash-cat-zebra',
+        ])
+    })
+
+    test('first card per category is the header (headline, parent=ceiling)', () => {
+        const groups = new Map<string, Piece[]>([
+            ['shorts', [makePiece('a'), makePiece('b')]],
+        ])
+        const { pageDef } = buildFlashIndex(groups, {
+            width: 1024,
+            height: 768,
+        })
+        const header = pageDef.cards.find((c) => c.id === 'flash-cat-shorts')!
+        expect(header.kind).toBe('headline')
+        expect(header.parent).toBe('ceiling')
+    })
+
+    test('piece cards are flash-piece-{slug}, portfolio kind, parented in chain order', () => {
+        const groups = new Map<string, Piece[]>([
+            ['shorts', [makePiece('a'), makePiece('b'), makePiece('c')]],
+        ])
+        const { pageDef } = buildFlashIndex(groups, {
+            width: 1024,
+            height: 768,
+        })
+        // chain: header → a → b → c
+        const a = pageDef.cards.find((c) => c.id === 'flash-piece-a')!
+        const b = pageDef.cards.find((c) => c.id === 'flash-piece-b')!
+        const c = pageDef.cards.find((c) => c.id === 'flash-piece-c')!
+        expect(a.kind).toBe('portfolio')
+        expect(b.kind).toBe('portfolio')
+        expect(c.kind).toBe('portfolio')
+        expect(a.parent).toBe('flash-cat-shorts')
+        expect(b.parent).toBe('flash-piece-a')
+        expect(c.parent).toBe('flash-piece-b')
+    })
+})
+
+describe('buildFlashIndex — anchor math', () => {
+    test('header x = width * (i+1)/(N+1); y = CHAIN_TOP + HEADER_H/2', () => {
+        const groups = new Map<string, Piece[]>([
+            ['alpha', [makePiece('a1')]],
+            ['beta', [makePiece('b1')]],
+            ['gamma', [makePiece('c1')]],
+        ])
+        const vp = { width: 1200, height: 800 }
+        const { pageDef } = buildFlashIndex(groups, vp)
+        const headers = pageDef.cards.filter((c) => c.kind === 'headline')
+        expect(headers).toHaveLength(3)
+        headers.forEach((h, i) => {
+            const { x, y } = h.anchor(vp)
+            expect(x).toBeCloseTo((vp.width * (i + 1)) / 4, 5)
+            expect(y).toBeCloseTo(CHAIN_TOP + HEADER_H / 2, 5)
+        })
+    })
+
+    test('piece y increments by PIECE_H + CHAIN_GAP per step; piece x matches header x', () => {
+        const groups = new Map<string, Piece[]>([
+            ['alpha', [makePiece('a'), makePiece('b')]],
+        ])
+        const vp = { width: 1200, height: 800 }
+        const { pageDef } = buildFlashIndex(groups, vp)
+        const header = pageDef.cards.find((c) => c.id === 'flash-cat-alpha')!
+        const a = pageDef.cards.find((c) => c.id === 'flash-piece-a')!
+        const b = pageDef.cards.find((c) => c.id === 'flash-piece-b')!
+        const aPos = a.anchor(vp)
+        const bPos = b.anchor(vp)
+        const headerPos = header.anchor(vp)
+
+        // Pieces share x with their header.
+        expect(aPos.x).toBeCloseTo(headerPos.x, 5)
+        expect(bPos.x).toBeCloseTo(headerPos.x, 5)
+
+        // First piece sits one full PIECE_H + CHAIN_GAP below the header centre
+        // (header bottom edge + GAP + half a piece).
+        const expectedAY =
+            CHAIN_TOP + HEADER_H + CHAIN_GAP + PIECE_H / 2
+        expect(aPos.y).toBeCloseTo(expectedAY, 5)
+        expect(bPos.y - aPos.y).toBeCloseTo(PIECE_H + CHAIN_GAP, 5)
+    })
+})
+
+describe('Flash — default export render', () => {
+    test('mounts without throwing under MemoryRouter', () => {
+        expect(() =>
+            render(
+                <MemoryRouter initialEntries={['/stuff/flash']}>
+                    <PhysicsProvider>
+                        <CardRegistryProvider>
+                            <PhysicsLayer />
+                            <Flash />
+                        </CardRegistryProvider>
+                    </PhysicsProvider>
+                </MemoryRouter>,
+            ),
+        ).not.toThrow()
+    })
+})

--- a/web/src/routes/stuff/FlashDetail.test.tsx
+++ b/web/src/routes/stuff/FlashDetail.test.tsx
@@ -1,0 +1,175 @@
+import { describe, test, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom'
+import type { PageDef } from '../../physics/PageDef'
+import type { Piece } from '../../stuff/flash/pieces'
+import type { CardContent } from '../../physics/PhysicsPage'
+
+vi.mock('../../canvas/flip', () => ({
+    flipMorph: vi.fn(),
+}))
+
+// Mock the Ruffle embed so the test doesn't pull a real script into the
+// happy-dom runtime.
+vi.mock('../../stuff/flash/RuffleEmbed', () => ({
+    RuffleEmbed: () => <div data-testid="ruffle-stub" />,
+}))
+
+// Capture the props PhysicsPage was rendered with — this is the cleanest way
+// to assert per-card props (draggable, etc.) without driving the full physics
+// pipeline.
+const physicsPageCalls: Array<{
+    pageDef: PageDef
+    cardContent: Record<string, CardContent>
+}> = []
+vi.mock('../../physics/PhysicsPage', async () => {
+    const mod = await vi.importActual<
+        typeof import('../../physics/PhysicsPage')
+    >('../../physics/PhysicsPage')
+    return {
+        ...mod,
+        PhysicsPage: (props: {
+            pageDef: PageDef
+            cardContent: Record<string, CardContent>
+        }) => {
+            physicsPageCalls.push(props)
+            return <div data-testid="physics-page-stub" />
+        },
+    }
+})
+
+const registered: { def: PageDef | null } = { def: null }
+vi.mock('../../transitions/PageDefRegistry', () => ({
+    useRegisterPageDef: (def: PageDef) => {
+        registered.def = def
+    },
+}))
+
+const piecesByCategory = new Map<string, Piece[]>()
+const piecesBySlug = new Map<string, Piece>()
+vi.mock('../../stuff/flash/pieces', () => ({
+    getPiecesByCategory: () => piecesByCategory,
+    getPieceBySlug: (slug: string) => piecesBySlug.get(slug),
+}))
+
+import FlashDetail from './FlashDetail'
+
+function makePiece(slug: string): Piece {
+    return {
+        slug,
+        frontmatter: {
+            title: `Title ${slug}`,
+            description: 'd',
+            category: 'shorts',
+            quality: 7,
+            thumbnail: 't.png',
+            swf: `${slug}.swf`,
+            swf_width: 320,
+            swf_height: 240,
+            tags: ['flash', 'demo'],
+            draft: false,
+        },
+        Component: () => <div data-testid="notes-body">notes</div>,
+    }
+}
+
+function renderAt(path: string) {
+    physicsPageCalls.length = 0
+    registered.def = null
+    let location = ''
+    function LocationProbe() {
+        location = useLocation().pathname
+        return null
+    }
+    const utils = render(
+        <MemoryRouter initialEntries={[path]}>
+            <LocationProbe />
+            <Routes>
+                <Route path="/stuff/flash/:slug" element={<FlashDetail />} />
+                <Route path="/stuff/flash" element={<div data-testid="flash-index" />} />
+            </Routes>
+        </MemoryRouter>,
+    )
+    return { ...utils, getLocation: () => location }
+}
+
+describe('FlashDetail — slug miss', () => {
+    test('renders <Navigate> to /stuff/flash (router lands on the index route)', () => {
+        const { getLocation, queryByTestId } = renderAt('/stuff/flash/missing')
+        expect(getLocation()).toBe('/stuff/flash')
+        // The fallback index route was rendered.
+        expect(queryByTestId('flash-index')).toBeTruthy()
+    })
+})
+
+describe('FlashDetail — slug match', () => {
+    const slug = 'demo-piece'
+
+    function setup() {
+        piecesBySlug.clear()
+        piecesBySlug.set(slug, makePiece(slug))
+        return renderAt(`/stuff/flash/${slug}`)
+    }
+
+    test('mounts without throwing', () => {
+        expect(() => setup()).not.toThrow()
+    })
+
+    test('builds a PageDef with exactly 4 cards: flash-back, flash-title, flash-swf, flash-notes', () => {
+        setup()
+        expect(physicsPageCalls).toHaveLength(1)
+        const def = physicsPageCalls[0]!.pageDef
+        const ids = def.cards.map((c) => c.id)
+        expect(ids).toEqual([
+            'flash-back',
+            'flash-title',
+            'flash-swf',
+            'flash-notes',
+        ])
+    })
+
+    test('card kinds and parents match the spec', () => {
+        setup()
+        const def = physicsPageCalls[0]!.pageDef
+        const back = def.cards.find((c) => c.id === 'flash-back')!
+        const title = def.cards.find((c) => c.id === 'flash-title')!
+        const swf = def.cards.find((c) => c.id === 'flash-swf')!
+        const notes = def.cards.find((c) => c.id === 'flash-notes')!
+        expect(back.kind).toBe('link')
+        expect(back.parent).toBe('ceiling')
+        expect(title.kind).toBe('headline')
+        expect(title.parent).toBeNull()
+        expect(swf.kind).toBe('portfolio')
+        expect(swf.parent).toBeNull()
+        expect(notes.kind).toBe('portfolio')
+        expect(notes.parent).toBeNull()
+    })
+
+    test('all 4 cards have draggable=false in cardContent', () => {
+        setup()
+        const content = physicsPageCalls[0]!.cardContent
+        for (const id of ['flash-back', 'flash-title', 'flash-swf', 'flash-notes']) {
+            expect(content[id]).toBeTruthy()
+            expect(content[id]!.draggable).toBe(false)
+        }
+    })
+
+    test('useRegisterPageDef is invoked with the built pageDef', () => {
+        setup()
+        expect(registered.def).not.toBeNull()
+        // The same object passed to PhysicsPage is the one registered.
+        expect(registered.def).toBe(physicsPageCalls[0]!.pageDef)
+    })
+
+    test('flash-back children contain a Link to /stuff/flash with "← Flash" text', () => {
+        setup()
+        const back = physicsPageCalls[0]!.cardContent['flash-back']!
+        // Render the children subtree under a router so the Link resolves.
+        const { container } = render(
+            <MemoryRouter>{back.children as React.ReactNode}</MemoryRouter>,
+        )
+        const link = container.querySelector('a[href="/stuff/flash"]')
+        expect(link).toBeTruthy()
+        expect(link!.textContent).toMatch(/← Flash/)
+    })
+})


### PR DESCRIPTION
## Summary

- Adds seven smoke + key-DOM test files for the page-level route components: `Home`, `Stuff`, `NotFound`, `BlogPost`, `BlogPostReader`, `Flash`, `FlashDetail`.
- MDX-backed data modules (`blog/posts`, `stuff/flash/pieces`) and `transitions/PageDefRegistry` are stubbed at the module boundary; the real Vite MDX pipeline is not pulled into the test runtime.
- For `FlashDetail`, `PhysicsPage` is mocked so per-card props (kind, parent, `draggable: false`) can be asserted directly from the props handed to the page renderer, and `RuffleEmbed` is stubbed to a div.

## Notes / deviations

- For `BlogPost`'s `<time>` text assertion, the visible day-of-month depends on the runner's timezone (UTC midnight may render as the previous day in PT). The test asserts the ISO `dateTime` attribute exactly and matches the rendered text with `/May \d{1,2}, 2026/` rather than a fixed day.
- The pre-existing `'test-key'` strings under `api/src/adapters/LastFmAdapter.test.ts` show up in the standard secret scan but are unchanged by this slice (test fixtures, not real secrets).

## Acceptance criteria

- [x] One test file per route component (7 files).
- [x] Each route test asserts no-throw render + its distinctive DOM contract.
- [x] `Flash.test.tsx` covers `buildFlashIndex` purity (empty, sorted, parent chain, anchor math) in addition to the smoke render.
- [x] `FlashDetail.test.tsx` covers the slug-miss → `<Navigate>` fallback (verified via a `useLocation` probe and the index-route landing).
- [x] `npm run typecheck`, `npm run test` (490 tests pass), `npm run build` all pass.
- [x] No production code changed — tests only.

## Test plan

- `cd web && npm run typecheck` — clean.
- `cd web && npm run test` — 62 files / 490 tests pass.
- `cd web && npm run build` — vite-react-ssg prerenders 9 pages; `dist/index.html` contains `data-server-rendered="true"`.
- Spot-check by running individual route files: `npx vitest run src/routes/Home.test.tsx`, etc.

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)