### PR TITLE
Slice 96: canvas glue tests (#96)

### DIFF
--- a/web/src/canvas/BackgroundCanvas.test.tsx
+++ b/web/src/canvas/BackgroundCanvas.test.tsx
@@ -1,0 +1,194 @@
+import { describe, test, expect, beforeEach, vi } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+const STORAGE_KEY = 'chaipalaka.background.activeId'
+
+beforeEach(() => {
+    localStorage.clear()
+    delete (window as unknown as { __setBackground?: unknown }).__setBackground
+    vi.resetModules()
+    vi.restoreAllMocks()
+    vi.useRealTimers()
+})
+
+async function setupFallback() {
+    vi.doMock('./detect-webgl', () => ({ detectWebGL: () => false }))
+    vi.doMock('../lib/usePrefersReducedMotion', () => ({
+        usePrefersReducedMotion: () => false,
+    }))
+    const rtl = await import('@testing-library/react')
+    const { BackgroundCanvas } = await import('./BackgroundCanvas')
+    const { backgroundScenes } = await import('./scenes')
+    return { ...rtl, BackgroundCanvas, backgroundScenes }
+}
+
+async function setupWebGL() {
+    vi.doMock('./detect-webgl', () => ({ detectWebGL: () => true }))
+    vi.doMock('../lib/usePrefersReducedMotion', () => ({
+        usePrefersReducedMotion: () => false,
+    }))
+    const rtl = await import('@testing-library/react')
+    const { BackgroundCanvas } = await import('./BackgroundCanvas')
+    return { ...rtl, BackgroundCanvas }
+}
+
+async function setupReducedMotion() {
+    vi.doMock('./detect-webgl', () => ({ detectWebGL: () => true }))
+    vi.doMock('../lib/usePrefersReducedMotion', () => ({
+        usePrefersReducedMotion: () => true,
+    }))
+    const rtl = await import('@testing-library/react')
+    const { BackgroundCanvas } = await import('./BackgroundCanvas')
+    return { ...rtl, BackgroundCanvas }
+}
+
+describe('BackgroundCanvas — initial render before post-mount effect', () => {
+    test('returns null on first render (mode is pending)', async () => {
+        // renderToStaticMarkup does not run effects, so we observe the
+        // pre-effect render path: useState('pending') → return null.
+        vi.doMock('./detect-webgl', () => ({ detectWebGL: () => false }))
+        vi.doMock('../lib/usePrefersReducedMotion', () => ({
+            usePrefersReducedMotion: () => false,
+        }))
+        const { BackgroundCanvas } = await import('./BackgroundCanvas')
+        const html = renderToStaticMarkup(<BackgroundCanvas />)
+        expect(html).toBe('')
+    })
+})
+
+describe('BackgroundCanvas — fallback path', () => {
+    test('renders the fallback img wrapper after mount when detectWebGL is false', async () => {
+        const { render, BackgroundCanvas, backgroundScenes } =
+            await setupFallback()
+        const { container } = render(<BackgroundCanvas />)
+
+        const outer = container.querySelector(
+            'div.background-canvas-layer[aria-hidden="true"]',
+        )
+        expect(outer).toBeTruthy()
+
+        const inner = outer!.querySelector('div.background-canvas-layer__layer')
+        expect(inner).toBeTruthy()
+
+        const img = inner!.querySelector('img.background-canvas-fallback')
+        expect(img).toBeTruthy()
+
+        const defaultScene = backgroundScenes.find((s) => s.id === 'flow-shader')
+        expect(img!.getAttribute('src')).toBe(defaultScene!.fallbackPng)
+        expect(img!.getAttribute('alt')).toBe('')
+    })
+})
+
+describe('BackgroundCanvas — WebGL path', () => {
+    test('does not render the fallback img when detectWebGL is true', async () => {
+        // <Canvas> tries to create a real WebGL context. Under happy-dom it
+        // logs errors; suppress them for the duration of this test only.
+        const errSpy = vi
+            .spyOn(console, 'error')
+            .mockImplementation(() => {})
+
+        const { render, BackgroundCanvas } = await setupWebGL()
+        const { container } = render(<BackgroundCanvas />)
+
+        const outer = container.querySelector(
+            'div.background-canvas-layer[aria-hidden="true"]',
+        )
+        expect(outer).toBeTruthy()
+
+        // The defining assertion: in webgl mode, no fallback image is rendered.
+        const fallback = container.querySelector('img.background-canvas-fallback')
+        expect(fallback).toBeNull()
+
+        errSpy.mockRestore()
+    })
+})
+
+describe('BackgroundCanvas — reduced motion override', () => {
+    test('forces fallback img even when detectWebGL is true', async () => {
+        const { render, BackgroundCanvas } = await setupReducedMotion()
+        const { container } = render(<BackgroundCanvas />)
+
+        const fallback = container.querySelector('img.background-canvas-fallback')
+        expect(fallback).toBeTruthy()
+    })
+})
+
+describe('BackgroundCanvas — cross-fade between scenes', () => {
+    test('shows two layers during fade window, then collapses after 300ms', async () => {
+        vi.useFakeTimers()
+        const { render, act, BackgroundCanvas, backgroundScenes } =
+            await setupFallback()
+        const { container } = render(<BackgroundCanvas />)
+
+        // Sanity: one layer initially.
+        let layers = container.querySelectorAll(
+            'div.background-canvas-layer__layer',
+        )
+        expect(layers).toHaveLength(1)
+
+        // Drive the gallery to a different scene via the debug hook installed
+        // by useGallery's effect after mount.
+        const otherId = backgroundScenes.find((s) => s.id !== 'flow-shader')!.id
+        act(() => {
+            window.__setBackground(otherId)
+        })
+
+        // During the fade window: outgoing + current both mounted.
+        layers = container.querySelectorAll(
+            'div.background-canvas-layer__layer',
+        )
+        expect(layers).toHaveLength(2)
+        const fadingOut = container.querySelectorAll(
+            'div.background-canvas-layer__layer[data-fading="out"]',
+        )
+        expect(fadingOut).toHaveLength(1)
+
+        // After the 300ms timer fires, the outgoing layer is unmounted.
+        act(() => {
+            vi.advanceTimersByTime(350)
+        })
+
+        layers = container.querySelectorAll(
+            'div.background-canvas-layer__layer',
+        )
+        expect(layers).toHaveLength(1)
+        expect(
+            container.querySelector(
+                'div.background-canvas-layer__layer[data-fading="out"]',
+            ),
+        ).toBeNull()
+    })
+})
+
+describe('BackgroundCanvas — getLazyScene', () => {
+    test('returns the same lazy wrapper for the same scene id (cached)', async () => {
+        const { getLazyScene } = await import('./BackgroundCanvas')
+        const { backgroundScenes } = await import('./scenes')
+        const scene = backgroundScenes[0]!
+        const a = getLazyScene(scene)
+        const b = getLazyScene(scene)
+        expect(a).toBe(b)
+    })
+
+    test('throws when scene.id is not in sceneLoaders', async () => {
+        const { getLazyScene } = await import('./BackgroundCanvas')
+        const fakeScene = {
+            id: 'does-not-exist',
+            Component: () => null,
+            accentColor: '#000',
+            fallbackColors: ['#000', '#000'] as const,
+            fallbackPng: '/fake.png',
+        }
+        expect(() => getLazyScene(fakeScene)).toThrow(/does-not-exist/)
+    })
+})
+
+describe('BackgroundCanvas — WebGL context lost', () => {
+    // happy-dom cannot mount @react-three/fiber's <Canvas> (no real WebGL
+    // context). We cannot synthesise a 'webglcontextlost' event on a canvas
+    // that never mounted, so this branch is covered by visual/manual QA only.
+    test.skip('synthesised webglcontextlost switches to fallback (skipped: needs real WebGL)', () => {})
+})
+
+// Use STORAGE_KEY to keep TS happy while keeping the constant nearby for future tests.
+void STORAGE_KEY

--- a/web/src/canvas/BackgroundCanvas.tsx
+++ b/web/src/canvas/BackgroundCanvas.tsx
@@ -25,7 +25,8 @@ const sceneLazyCache = new Map<
     React.LazyExoticComponent<() => React.ReactElement | null>
 >()
 
-function getLazyScene(scene: BackgroundScene) {
+/** @internal — exported for tests; not part of the public API. */
+export function getLazyScene(scene: BackgroundScene) {
     if (!sceneLazyCache.has(scene.id)) {
         const loader = sceneLoaders[scene.id]
         if (!loader) throw new Error(`No loader for scene: ${scene.id}`)

--- a/web/src/canvas/useMinimizedRegistry.test.ts
+++ b/web/src/canvas/useMinimizedRegistry.test.ts
@@ -1,0 +1,136 @@
+import { describe, test, expect, beforeEach, vi } from 'vitest'
+
+beforeEach(() => {
+    vi.resetModules()
+    vi.restoreAllMocks()
+})
+
+async function setup() {
+    const rtl = await import('@testing-library/react')
+    const hooks = await import('./useMinimizedRegistry')
+    return { ...rtl, ...hooks }
+}
+
+describe('useMinimizedRegistry — singleton identity', () => {
+    test('returns the same registry instance across hook invocations', async () => {
+        const { renderHook, useMinimizedRegistry } = await setup()
+        const { result: a } = renderHook(() => useMinimizedRegistry())
+        const { result: b } = renderHook(() => useMinimizedRegistry())
+        expect(a.current).toBe(b.current)
+    })
+})
+
+describe('useMinimizedEntries — initial state', () => {
+    test('returns an empty array when nothing is minimized', async () => {
+        const { renderHook, useMinimizedEntries } = await setup()
+        const { result } = renderHook(() => useMinimizedEntries())
+        expect(result.current).toEqual([])
+    })
+})
+
+describe('useMinimizedEntries — cross-component subscription', () => {
+    test('two consumers both re-render when registry.minimize is called', async () => {
+        const {
+            renderHook,
+            act,
+            useMinimizedEntries,
+            useMinimizedRegistry,
+        } = await setup()
+
+        const reg = renderHook(() => useMinimizedRegistry()).result.current
+        const { result: a } = renderHook(() => useMinimizedEntries())
+        const { result: b } = renderHook(() => useMinimizedEntries())
+
+        expect(a.current).toEqual([])
+        expect(b.current).toEqual([])
+
+        act(() => {
+            reg.minimize('card-1', { label: 'One', kind: 'card' })
+        })
+
+        expect(a.current).toHaveLength(1)
+        expect(b.current).toHaveLength(1)
+        expect(a.current[0]?.id).toBe('card-1')
+        expect(b.current[0]?.id).toBe('card-1')
+    })
+})
+
+describe('useIsMinimized', () => {
+    test('returns true when the id is in a minimized entry’s members', async () => {
+        const {
+            renderHook,
+            act,
+            useIsMinimized,
+            useMinimizedRegistry,
+        } = await setup()
+
+        const reg = renderHook(() => useMinimizedRegistry()).result.current
+        const { result } = renderHook(() => useIsMinimized('card-1'))
+
+        expect(result.current).toBe(false)
+
+        act(() => {
+            reg.minimize('card-1', { label: 'One', kind: 'card' })
+        })
+
+        expect(result.current).toBe(true)
+    })
+
+    test('returns false when only other ids are minimized', async () => {
+        const {
+            renderHook,
+            act,
+            useIsMinimized,
+            useMinimizedRegistry,
+        } = await setup()
+
+        const reg = renderHook(() => useMinimizedRegistry()).result.current
+        const { result } = renderHook(() => useIsMinimized('card-a'))
+
+        act(() => {
+            reg.minimize('card-b', { label: 'B', kind: 'card' })
+        })
+
+        expect(result.current).toBe(false)
+    })
+
+    test('returns false for undefined id regardless of registry state', async () => {
+        const {
+            renderHook,
+            act,
+            useIsMinimized,
+            useMinimizedRegistry,
+        } = await setup()
+
+        const reg = renderHook(() => useMinimizedRegistry()).result.current
+        const { result } = renderHook(() => useIsMinimized(undefined))
+
+        expect(result.current).toBe(false)
+
+        act(() => {
+            reg.minimize('card-1', { label: 'One', kind: 'card' })
+        })
+
+        expect(result.current).toBe(false)
+    })
+})
+
+describe('useMinimizedEntries — cleanup on unmount', () => {
+    test('subscribe’s returned unsubscribe is called when the hook unmounts', async () => {
+        const { renderHook, useMinimizedEntries, useMinimizedRegistry } =
+            await setup()
+
+        const reg = renderHook(() => useMinimizedRegistry()).result.current
+
+        const unsubscribeSpy = vi.fn()
+        const subscribeSpy = vi
+            .spyOn(reg, 'subscribe')
+            .mockImplementation(() => unsubscribeSpy)
+
+        const { unmount } = renderHook(() => useMinimizedEntries())
+        expect(subscribeSpy).toHaveBeenCalledTimes(1)
+
+        unmount()
+        expect(unsubscribeSpy).toHaveBeenCalledTimes(1)
+    })
+})


### PR DESCRIPTION
## Summary

- Adds `BackgroundCanvas.test.tsx` covering the pending-render guard, fallback DOM shape, WebGL path (no fallback img), reduced-motion override, the 300ms cross-fade window, and `getLazyScene` cache + unknown-id error.
- Adds `useMinimizedRegistry.test.ts` covering singleton identity, initial empty state, cross-component re-render, `useIsMinimized` truthy/falsy/undefined cases, and subscription cleanup on unmount.
- One-line production change: re-exports `getLazyScene` from `BackgroundCanvas.tsx` with an `@internal` JSDoc tag so the cache / error tests can drive it directly. No other production behaviour changes.

## Notes / deviations

- The `webglcontextlost` → fallback recovery path is left as a documented `test.skip`. `@react-three/fiber`'s `<Canvas>` requires a real WebGL context, so under happy-dom the canvas element never mounts and a synthesised `webglcontextlost` event has nothing to fire on. The issue body explicitly authorises this as a documented skip.
- The first-render (`mode === 'pending'`) case is asserted by `renderToStaticMarkup(<BackgroundCanvas />)` returning `''`, which proves the pre-effect render path returns `null` (testing-library's `render()` flushes the post-mount effect synchronously, so it can't observe this state).
- The WebGL-path test suppresses `console.error` for its duration since `<Canvas>` logs context-creation failures under happy-dom; the assertion is on the absence of the fallback `<img>`, not on a successful canvas mount.

## Acceptance criteria

- [x] `src/canvas/BackgroundCanvas.test.tsx` covers pending-render, fallback path, reduced-motion override, cross-fade timing, getLazyScene caching + error, context-lost handler (documented skip).
- [x] `src/canvas/useMinimizedRegistry.test.ts` covers singleton identity, initial state, cross-component re-render, `useIsMinimized` true/false/undefined cases, cleanup.
- [x] `getLazyScene` exported with `@internal` JSDoc tag — no other production change.
- [x] `npm run typecheck`, `npm run test`, `npm run build` all pass locally.

## Test plan

```sh
cd web
npm run typecheck
npm run test -- --run src/canvas/BackgroundCanvas.test.tsx src/canvas/useMinimizedRegistry.test.ts
npm run test -- --run    # full suite — 504 passing, 1 skipped (the documented context-lost skip)
npm run build            # confirms vite-react-ssg prerender still works
```

Closes #96