### PR TITLE
Slice 97: canvas scene module-shape smokes (#97)

### DIFF
--- a/web/src/canvas/scenes/scenes.test.ts
+++ b/web/src/canvas/scenes/scenes.test.ts
@@ -1,0 +1,100 @@
+import { describe, test, expect } from 'vitest'
+import type { BackgroundScene } from '../types'
+import { getLazyScene } from '../BackgroundCanvas'
+import manifest from './manifest.json'
+
+const HEX6 = /^#[0-9a-fA-F]{6}$/
+
+const SCENES: ReadonlyArray<{ id: string; loader: () => Promise<unknown> }> = [
+    { id: 'particles-flow', loader: () => import('./particles-flow') },
+    { id: 'particles-boids', loader: () => import('./particles-boids') },
+    { id: 'particles-cursor', loader: () => import('./particles-cursor') },
+    { id: 'particles-starfield', loader: () => import('./particles-starfield') },
+    { id: 'geometric-voronoi', loader: () => import('./geometric-voronoi') },
+    { id: 'geometric-subdivision', loader: () => import('./geometric-subdivision') },
+    { id: 'geometric-reaction-diffusion', loader: () => import('./geometric-reaction-diffusion') },
+    { id: 'flow-shader', loader: () => import('./flow-shader') },
+    { id: 'audio-reactive', loader: () => import('./audio-reactive') },
+]
+
+function findSceneExport(
+    mod: Record<string, unknown>,
+    expectedId: string,
+): BackgroundScene | undefined {
+    return Object.values(mod).find(
+        (v): v is BackgroundScene =>
+            typeof v === 'object' &&
+            v !== null &&
+            'id' in v &&
+            'Component' in v &&
+            (v as { id: unknown }).id === expectedId,
+    )
+}
+
+describe('canvas scenes — module shape', () => {
+    for (const { id, loader } of SCENES) {
+        describe(id, () => {
+            test('imports without throwing and exports a BackgroundScene with the expected id', async () => {
+                const mod = (await loader()) as Record<string, unknown>
+                const entry = findSceneExport(mod, id)
+                expect(entry, `expected an exported BackgroundScene with id "${id}"`).toBeDefined()
+                expect(entry!.id).toBe(id)
+            })
+
+            test('Component is a function (not invoked)', async () => {
+                const mod = (await loader()) as Record<string, unknown>
+                const entry = findSceneExport(mod, id)!
+                expect(typeof entry.Component).toBe('function')
+            })
+
+            test('fallbackPng is a non-empty string', async () => {
+                const mod = (await loader()) as Record<string, unknown>
+                const entry = findSceneExport(mod, id)!
+                expect(typeof entry.fallbackPng).toBe('string')
+                expect(entry.fallbackPng.length).toBeGreaterThan(0)
+            })
+
+            test('accentColor is a 6-digit hex string', async () => {
+                const mod = (await loader()) as Record<string, unknown>
+                const entry = findSceneExport(mod, id)!
+                expect(entry.accentColor).toMatch(HEX6)
+            })
+
+            test('fallbackColors is a tuple of two 6-digit hex strings', async () => {
+                const mod = (await loader()) as Record<string, unknown>
+                const entry = findSceneExport(mod, id)!
+                expect(Array.isArray(entry.fallbackColors)).toBe(true)
+                expect(entry.fallbackColors).toHaveLength(2)
+                expect(entry.fallbackColors[0]).toMatch(HEX6)
+                expect(entry.fallbackColors[1]).toMatch(HEX6)
+            })
+        })
+    }
+})
+
+describe('manifest.json', () => {
+    const expectedIds = SCENES.map((s) => s.id).sort()
+
+    test('contains exactly 9 entries', () => {
+        expect(manifest).toHaveLength(9)
+    })
+
+    test('every manifest id matches a known scene (no extras, no missing)', () => {
+        const manifestIds = manifest.map((m) => m.id).sort()
+        expect(manifestIds).toEqual(expectedIds)
+    })
+
+    test('every manifest entry has a corresponding loader in BackgroundCanvas sceneLoaders', () => {
+        // getLazyScene throws synchronously if no loader exists for the id.
+        for (const entry of manifest) {
+            const scene: BackgroundScene = {
+                id: entry.id,
+                accentColor: entry.accentColor,
+                fallbackColors: entry.fallbackColors as unknown as readonly [string, string],
+                fallbackPng: entry.fallbackPng,
+                Component: () => null,
+            }
+            expect(() => getLazyScene(scene)).not.toThrow()
+        }
+    })
+})


### PR DESCRIPTION
## Summary

- Adds `web/src/canvas/scenes/scenes.test.ts` — a single consolidated suite covering all 9 canvas scenes (`particles-flow`, `particles-boids`, `particles-cursor`, `particles-starfield`, `geometric-voronoi`, `geometric-subdivision`, `geometric-reaction-diffusion`, `flow-shader`, `audio-reactive`).
- For each scene: import without throwing, exported `BackgroundScene` has the expected id, `Component` is a function (typeof only — not invoked), `fallbackPng` is non-empty, `accentColor` matches `/^#[0-9a-fA-F]{6}$/`, `fallbackColors` is a 2-tuple of hex strings.
- Manifest assertions: `manifest.json` has exactly 9 entries; ids match the scene table exactly; every manifest id has a corresponding loader in `BackgroundCanvas.tsx`'s `sceneLoaders` map (verified via the `@internal`-exported `getLazyScene`, which throws synchronously when a loader is missing).
- 48 new tests, all passing. Production code untouched.

## Notes / deviations

- **Consolidated single file**, per the issue's recommendation — keeps assertion logic deduped and each scene's coverage to ~5 short tests.
- **Loader-coverage check is not redundant with `src/__tests__/bundle-splitting.test.ts`**. That test verifies chunk-marker presence/absence across plain-mode vs. canvas-mode HTML; it does not iterate manifest ids against `sceneLoaders`. The two tests catch different regressions, so no dedupe needed.
- **No render smoke for scenes.** Scene `Component`s use `useFrame` and construct `three` objects, which throw outside a `<Canvas>` provider. A render smoke would need Playwright with a real browser — out of scope for this slice. The issue called this out explicitly.
- A harmless `THREE.WARNING: Multiple instances of Three.js being imported` log appears once when the first scene module is imported in the test run. It's stderr noise from `three` (no test failure), already present in other suites that import scene modules. Not chasing here.

## Acceptance criteria

- [x] `src/canvas/scenes/scenes.test.ts` covers each scene's module shape per the bullets in the issue.
- [x] Manifest assertions: 9 entries; each id maps to a loader in `BackgroundCanvas`.
- [x] `npm run typecheck`, `npm run test`, `npm run build` all pass (552/553; 1 pre-existing skip).
- [x] No production code changed — tests only.

## Test plan

- `cd web && npm run typecheck` — clean.
- `cd web && npm run test -- --run src/canvas/scenes/scenes.test.ts` — 48 passing.
- `cd web && npm run test` — full suite 552 passed, 1 skipped (pre-existing).
- `cd web && npm run build` — SSG build succeeds, all 9 routes prerender.

Closes #97