### PR TITLE
Slice 98: lib hooks + utils test coverage (#98)

### DIFF
--- a/web/src/lib/canvas-only-marker.test.ts
+++ b/web/src/lib/canvas-only-marker.test.ts
@@ -1,0 +1,17 @@
+import { describe, test, expect } from 'vitest'
+import { CANVAS_ONLY_BUNDLE_MARKER } from './canvas-only-marker'
+
+describe('CANVAS_ONLY_BUNDLE_MARKER', () => {
+    test('is exported as a string', () => {
+        expect(typeof CANVAS_ONLY_BUNDLE_MARKER).toBe('string')
+    })
+
+    // The exact value is consumed by src/__tests__/bundle-splitting.test.ts
+    // to detect canvas-only code leaking into plain-mode chunks. Changing
+    // it would silently break that invariant — pin it here.
+    test('has the exact pinned value', () => {
+        expect(CANVAS_ONLY_BUNDLE_MARKER).toBe(
+            '__CHAIPALAKA_CANVAS_ONLY_BUNDLE_MARKER_4f7c2b9a__',
+        )
+    })
+})

--- a/web/src/lib/usePrefersReducedMotion.test.tsx
+++ b/web/src/lib/usePrefersReducedMotion.test.tsx
@@ -1,0 +1,89 @@
+import { describe, test, expect, afterEach, vi } from 'vitest'
+import { act, renderHook } from '@testing-library/react'
+import { usePrefersReducedMotion } from './usePrefersReducedMotion'
+
+type ChangeHandler = (e: MediaQueryListEvent) => void
+
+interface FakeMQL {
+    matches: boolean
+    addEventListener: ReturnType<typeof vi.fn>
+    removeEventListener: ReturnType<typeof vi.fn>
+}
+
+function makeFakeMQL(matches: boolean): FakeMQL {
+    return {
+        matches,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+    }
+}
+
+afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+})
+
+describe('usePrefersReducedMotion', () => {
+    test('returns false when matchMedia reports matches: false', () => {
+        const mq = makeFakeMQL(false)
+        vi.spyOn(window, 'matchMedia').mockReturnValue(
+            mq as unknown as MediaQueryList,
+        )
+        const { result } = renderHook(() => usePrefersReducedMotion())
+        expect(result.current).toBe(false)
+    })
+
+    test('returns true after mount when matchMedia reports matches: true', () => {
+        const mq = makeFakeMQL(true)
+        vi.spyOn(window, 'matchMedia').mockReturnValue(
+            mq as unknown as MediaQueryList,
+        )
+        const { result } = renderHook(() => usePrefersReducedMotion())
+        expect(result.current).toBe(true)
+    })
+
+    test('re-renders when the change handler fires with a new matches value', () => {
+        const mq = makeFakeMQL(false)
+        vi.spyOn(window, 'matchMedia').mockReturnValue(
+            mq as unknown as MediaQueryList,
+        )
+        const { result } = renderHook(() => usePrefersReducedMotion())
+        expect(result.current).toBe(false)
+
+        const handler = mq.addEventListener.mock.calls[0]?.[1] as
+            | ChangeHandler
+            | undefined
+        expect(typeof handler).toBe('function')
+
+        act(() => {
+            handler!({ matches: true } as MediaQueryListEvent)
+        })
+        expect(result.current).toBe(true)
+
+        act(() => {
+            handler!({ matches: false } as MediaQueryListEvent)
+        })
+        expect(result.current).toBe(false)
+    })
+
+    test('removes the change listener on unmount', () => {
+        const mq = makeFakeMQL(false)
+        vi.spyOn(window, 'matchMedia').mockReturnValue(
+            mq as unknown as MediaQueryList,
+        )
+        const { unmount } = renderHook(() => usePrefersReducedMotion())
+        const handler = mq.addEventListener.mock.calls[0]?.[1] as ChangeHandler
+        expect(mq.removeEventListener).not.toHaveBeenCalled()
+
+        unmount()
+
+        expect(mq.removeEventListener).toHaveBeenCalledTimes(1)
+        expect(mq.removeEventListener).toHaveBeenCalledWith('change', handler)
+    })
+
+    test('returns false and does not throw when window.matchMedia is undefined', () => {
+        vi.stubGlobal('matchMedia', undefined)
+        const { result } = renderHook(() => usePrefersReducedMotion())
+        expect(result.current).toBe(false)
+    })
+})

--- a/web/src/text/registry.test.ts
+++ b/web/src/text/registry.test.ts
@@ -1,0 +1,38 @@
+import { describe, test, expect } from 'vitest'
+import { registry } from './registry'
+import { PretextRegistry } from './PretextRegistry'
+
+describe('text/registry', () => {
+    test('exports a PretextRegistry instance', () => {
+        expect(registry).toBeInstanceOf(PretextRegistry)
+    })
+
+    test('registers body, mono, and card-title keys', () => {
+        expect(() => registry.getFont('body')).not.toThrow()
+        expect(() => registry.getFont('mono')).not.toThrow()
+        expect(() => registry.getFont('card-title')).not.toThrow()
+    })
+
+    test('throws on an unregistered key (no accidental fallback)', () => {
+        expect(() => registry.getFont('does-not-exist')).toThrow(/unknown/i)
+    })
+
+    test('body font spec is pinned: 400 16px Newsreader Variable, lh 1.6', () => {
+        expect(registry.getFont('body')).toBe('400 16px Newsreader Variable')
+        expect(registry.getLineHeight('body')).toBeCloseTo(25.6)
+    })
+
+    test('mono font spec is pinned: 400 14px JetBrains Mono Variable, lh 1.6', () => {
+        expect(registry.getFont('mono')).toBe(
+            '400 14px JetBrains Mono Variable',
+        )
+        expect(registry.getLineHeight('mono')).toBeCloseTo(22.4)
+    })
+
+    test('card-title font spec is pinned: 600 36px Newsreader Variable, lh 1.15', () => {
+        expect(registry.getFont('card-title')).toBe(
+            '600 36px Newsreader Variable',
+        )
+        expect(registry.getLineHeight('card-title')).toBeCloseTo(41.4)
+    })
+})


### PR DESCRIPTION
## Summary

- Adds `web/src/lib/usePrefersReducedMotion.test.tsx` — covers default value, `matchMedia` `matches: true`, `change`-event re-render, unmount listener cleanup, and undefined-`matchMedia` safety. Uses `vi.spyOn(window, 'matchMedia')` with a fake `MediaQueryList` and `vi.stubGlobal` for the undefined-safety case.
- Adds `web/src/lib/canvas-only-marker.test.ts` — pins the exact string `__CHAIPALAKA_CANVAS_ONLY_BUNDLE_MARKER_4f7c2b9a__` that `src/__tests__/bundle-splitting.test.ts` consumes as its canvas-leak detector.
- Adds `web/src/text/registry.test.ts` — asserts `registry` is a `PretextRegistry` instance, that `body`/`mono`/`card-title` are registered with exact font strings (`getFont`) and line-heights (`getLineHeight`), and that an unknown key throws.
- Tests-only — no production code touched.

## Notes / deviations

- `PretextRegistry` does not expose a way to read back the original `FontMetrics` for a key; the test verifies the pinned specs via the public `getFont` (returns `"<weight> <size>px <family>"`) and `getLineHeight` (returns `size * lineHeight`) accessors. This still pins all four fields per key and matches the access pattern used in production callers.

## Acceptance criteria

- [x] `usePrefersReducedMotion.test.tsx` covers default, matchMedia true, change event update, unmount cleanup, undefined-matchMedia safety
- [x] `canvas-only-marker.test.ts` pins the marker value
- [x] `registry.test.ts` covers instance type, registered keys, exact font specs
- [x] `npm run typecheck`, `npm run test`, `npm run build` all pass
- [x] No production code changed — tests only

## Test plan

```sh
cd web
npm run typecheck
npm run test -- usePrefersReducedMotion canvas-only-marker registry
npm run test         # full suite — 68 files, 565 passed (1 skipped)
npm run build
```

Closes #98