### PR TITLE
Extract Tether module + narrow PhysicsWorld surface (#108)

### DIFF
--- a/web/src/canvas/StringLayer.tsx
+++ b/web/src/canvas/StringLayer.tsx
@@ -8,12 +8,13 @@ export function StringLayer() {
     const pathRefs = useRef<Map<string, SVGPathElement>>(new Map())
 
     // Re-render only when the SET of tethers changes (mount/unmount of strung cards).
-    // Use getTetherList() (cached, stable reference) — getTethers() builds a fresh array
-    // each call and would cause an infinite useSyncExternalStore re-render loop.
-    const tetherList = useSyncExternalStore(
-        (cb) => world.subscribeTetherSetChange(cb),
-        () => world.getTetherList(),
-        () => world.getTetherList(),
+    // records() returns a cached frozen array — stable reference until add/remove,
+    // safe for useSyncExternalStore. list() (called per-RAF below) returns fresh
+    // positions and would cause an infinite re-render loop here.
+    const records = useSyncExternalStore(
+        (cb) => world.tether.subscribeChange(cb),
+        () => world.tether.records(),
+        () => world.tether.records(),
     )
 
     // Per-frame mutation of path `d` attributes — no React re-renders
@@ -29,7 +30,7 @@ export function StringLayer() {
             const gx = gLen > 0 ? g.x / gLen : 0
             const gy = gLen > 0 ? g.y / gLen : 1
 
-            const views = world.getTethers()
+            const views = world.tether.list()
             for (let i = 0; i < views.length; i++) {
                 const v = views[i]!
                 const key = String(i)
@@ -55,13 +56,13 @@ export function StringLayer() {
         }
         raf = requestAnimationFrame(frame)
         return () => cancelAnimationFrame(raf)
-    }, [world, tetherList])
+    }, [world, records])
 
     return (
         <svg ref={svgRef} className="string-layer" aria-hidden="true">
-            {tetherList.map((handle, i) => (
+            {records.map((rec, i) => (
                 <path
-                    key={handle}
+                    key={rec.handle}
                     ref={(el) => {
                         if (el) pathRefs.current.set(String(i), el)
                         else pathRefs.current.delete(String(i))

--- a/web/src/physics/BodyForceSource.ts
+++ b/web/src/physics/BodyForceSource.ts
@@ -1,0 +1,8 @@
+import type { PhysicsHandle, Vec2 } from './PhysicsWorld'
+
+export interface BodyForceSource {
+    getPosition(h: PhysicsHandle): Vec2
+    getMass(h: PhysicsHandle): number
+    isStatic(h: PhysicsHandle): boolean
+    applyForce(h: PhysicsHandle, force: Vec2): void
+}

--- a/web/src/physics/PhysicsCard.test.tsx
+++ b/web/src/physics/PhysicsCard.test.tsx
@@ -11,8 +11,10 @@ afterEach(() => {
 })
 
 function fireRealPointerDown(el: Element) {
-    const ev = new Event('pointerdown', { bubbles: true, cancelable: true }) as Event &
-        { clientX: number; clientY: number; pointerId: number }
+    const ev = new Event('pointerdown', {
+        bubbles: true,
+        cancelable: true,
+    }) as Event & { clientX: number; clientY: number; pointerId: number }
     ev.clientX = 50
     ev.clientY = 50
     ev.pointerId = 1
@@ -41,7 +43,9 @@ describe('PhysicsCard — draggable prop', () => {
                 anchor={{ x: 100, y: 100 }}
             />,
         )
-        const article = container.querySelector('article.physics-card') as HTMLElement
+        const article = container.querySelector(
+            'article.physics-card',
+        ) as HTMLElement
         expect(article).toBeTruthy()
         article.setPointerCapture = () => {}
         fireRealPointerDown(article)
@@ -76,14 +80,12 @@ describe('PhysicsCard — draggable prop', () => {
             await new Promise((r) => requestAnimationFrame(() => r(null)))
         })
         const world = captured! as PhysicsWorld
-        const records = world.listTetherRecords()
+        const records = world.tether.records()
         // One tether to ceiling, one to floor — both share the same child
         // body but use different parents.
         expect(records).toHaveLength(2)
         const parents = records.map((r) => r.parent).sort()
-        expect(parents).toEqual(
-            [world.ceilingHandle, world.floorHandle].sort(),
-        )
+        expect(parents).toEqual([world.ceilingHandle, world.floorHandle].sort())
     })
 
     test('draggable={false} does NOT set cursor to grabbing on pointerdown', () => {
@@ -97,7 +99,9 @@ describe('PhysicsCard — draggable prop', () => {
                 draggable={false}
             />,
         )
-        const article = container.querySelector('article.physics-card') as HTMLElement
+        const article = container.querySelector(
+            'article.physics-card',
+        ) as HTMLElement
         expect(article).toBeTruthy()
         article.setPointerCapture = () => {}
         fireRealPointerDown(article)

--- a/web/src/physics/PhysicsCard.tsx
+++ b/web/src/physics/PhysicsCard.tsx
@@ -1,11 +1,7 @@
 import { useEffect, useId, useMemo } from 'react'
 import { useCardRegistry } from '../transitions/CardRegistry'
-import type {
-    PhysicsHandle,
-    PhysicsWorld,
-    TetherHandle,
-    Vec2,
-} from './PhysicsWorld'
+import type { PhysicsHandle, PhysicsWorld, Vec2 } from './PhysicsWorld'
+import type { TetherHandle } from './Tether'
 import type { Buoyancy, ParentRef } from './PageDef'
 
 type ParentKind = 'ceiling' | 'floor' | 'card'
@@ -23,7 +19,7 @@ export function wireTetherFor(
             childAnchor.x - parentBodyPos.x,
             childAnchor.y - parentBodyPos.y,
         )
-        return world.tether(parentHandle, childHandle, length)
+        return world.tether.add(parentHandle, childHandle, length)
     }
     const parentAnchor = world.getAnchor(parentHandle)
     const anchorA = {
@@ -31,7 +27,7 @@ export function wireTetherFor(
         y: parentAnchor.y - parentBodyPos.y,
     }
     const length = Math.abs(childAnchor.y - parentAnchor.y)
-    return world.tether(parentHandle, childHandle, length, anchorA)
+    return world.tether.add(parentHandle, childHandle, length, anchorA)
 }
 
 export interface PhysicsCardProps {

--- a/web/src/physics/PhysicsPage.test.tsx
+++ b/web/src/physics/PhysicsPage.test.tsx
@@ -8,8 +8,18 @@ import type { PageDef } from './PageDef'
 const pageDef: PageDef = {
     gravity: 'down',
     cards: [
-        { id: 'parent-card', kind: 'headline', parent: 'ceiling', anchor: () => ({ x: 200, y: 100 }) },
-        { id: 'child-card', kind: 'note', parent: 'parent-card', anchor: () => ({ x: 200, y: 300 }) },
+        {
+            id: 'parent-card',
+            kind: 'headline',
+            parent: 'ceiling',
+            anchor: () => ({ x: 200, y: 100 }),
+        },
+        {
+            id: 'child-card',
+            kind: 'note',
+            parent: 'parent-card',
+            anchor: () => ({ x: 200, y: 300 }),
+        },
     ],
 }
 

--- a/web/src/physics/PhysicsWorld.test.ts
+++ b/web/src/physics/PhysicsWorld.test.ts
@@ -8,7 +8,8 @@ describe('PhysicsWorld registration', () => {
         const world = new PhysicsWorld({
             viewport: { width: 800, height: 600 },
         })
-        const handle = world.register(
+        const handle = world.registerById(
+            'a',
             { x: 100, y: 100 },
             { width: 200, height: 80 },
         )
@@ -24,7 +25,8 @@ describe('PhysicsWorld dynamics', () => {
         const world = new PhysicsWorld({
             viewport: { width: 800, height: 600 },
         })
-        const handle = world.register(
+        const handle = world.registerById(
+            'a',
             { x: 250, y: 175 },
             { width: 100, height: 50 },
         )
@@ -33,15 +35,16 @@ describe('PhysicsWorld dynamics', () => {
         expect(pos.y).toBeCloseTo(175, 5)
     })
 
-    test('applyImpulse moves the body in the impulse direction on the next tick', () => {
+    test('setVelocity moves the body in the velocity direction on the next tick', () => {
         const world = new PhysicsWorld({
             viewport: { width: 800, height: 600 },
         })
-        const handle = world.register(
+        const handle = world.registerById(
+            'a',
             { x: 100, y: 100 },
             { width: 100, height: 50 },
         )
-        world.applyImpulse(handle, { x: 5, y: 0 })
+        world.setVelocity(handle, { x: 5, y: 0 })
         world.tick(FIXED_DT_MS)
         const pos = world.getPosition(handle)
         expect(pos.x).toBeGreaterThan(100)
@@ -54,7 +57,8 @@ describe('PhysicsWorld gravity', () => {
         const world = new PhysicsWorld({
             viewport: { width: 800, height: 600 },
         })
-        const handle = world.register(
+        const handle = world.registerById(
+            'a',
             { x: 100, y: 100 },
             { width: 100, height: 50 },
         )
@@ -66,7 +70,8 @@ describe('PhysicsWorld gravity', () => {
     test('floor catches a falling body', () => {
         const viewport = { width: 800, height: 400 }
         const world = new PhysicsWorld({ viewport })
-        const handle = world.register(
+        const handle = world.registerById(
+            'a',
             { x: 100, y: 50 },
             { width: 100, height: 50 },
         )
@@ -78,39 +83,65 @@ describe('PhysicsWorld gravity', () => {
 
 describe('PhysicsWorld gravity direction', () => {
     test('setGravityDirection("down") makes a body fall in positive y', () => {
-        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
-        const handle = world.register({ x: 400, y: 200 }, { width: 80, height: 40 })
+        const world = new PhysicsWorld({
+            viewport: { width: 800, height: 600 },
+        })
+        const handle = world.registerById(
+            'a',
+            { x: 400, y: 200 },
+            { width: 80, height: 40 },
+        )
         world.setGravityDirection('down')
         for (let i = 0; i < 30; i++) world.tick(FIXED_DT_MS)
         expect(world.getPosition(handle).y).toBeGreaterThan(200)
     })
 
     test('setGravityDirection("up") makes a body rise in negative y', () => {
-        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
-        const handle = world.register({ x: 400, y: 400 }, { width: 80, height: 40 })
+        const world = new PhysicsWorld({
+            viewport: { width: 800, height: 600 },
+        })
+        const handle = world.registerById(
+            'a',
+            { x: 400, y: 400 },
+            { width: 80, height: 40 },
+        )
         world.setGravityDirection('up')
         for (let i = 0; i < 30; i++) world.tick(FIXED_DT_MS)
         expect(world.getPosition(handle).y).toBeLessThan(400)
     })
 
     test('setGravityDirection("left") makes a body drift in negative x', () => {
-        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
-        const handle = world.register({ x: 400, y: 300 }, { width: 80, height: 40 })
+        const world = new PhysicsWorld({
+            viewport: { width: 800, height: 600 },
+        })
+        const handle = world.registerById(
+            'a',
+            { x: 400, y: 300 },
+            { width: 80, height: 40 },
+        )
         world.setGravityDirection('left')
         for (let i = 0; i < 30; i++) world.tick(FIXED_DT_MS)
         expect(world.getPosition(handle).x).toBeLessThan(400)
     })
 
     test('setGravityDirection("right") makes a body drift in positive x', () => {
-        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
-        const handle = world.register({ x: 400, y: 300 }, { width: 80, height: 40 })
+        const world = new PhysicsWorld({
+            viewport: { width: 800, height: 600 },
+        })
+        const handle = world.registerById(
+            'a',
+            { x: 400, y: 300 },
+            { width: 80, height: 40 },
+        )
         world.setGravityDirection('right')
         for (let i = 0; i < 30; i++) world.tick(FIXED_DT_MS)
         expect(world.getPosition(handle).x).toBeGreaterThan(400)
     })
 
     test('getGravityVector returns direction and non-zero magnitude', () => {
-        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
+        const world = new PhysicsWorld({
+            viewport: { width: 800, height: 600 },
+        })
         const down = world.getGravityVector()
         expect(down.x).toBeCloseTo(0)
         expect(down.y).toBeGreaterThan(0)
@@ -125,7 +156,11 @@ describe('PhysicsWorld gravity direction', () => {
     test('ceiling catches a body rising under upward gravity', () => {
         const viewport = { width: 800, height: 600 }
         const world = new PhysicsWorld({ viewport })
-        const handle = world.register({ x: 400, y: 400 }, { width: 80, height: 40 })
+        const handle = world.registerById(
+            'a',
+            { x: 400, y: 400 },
+            { width: 80, height: 40 },
+        )
         world.setGravityDirection('up')
         for (let i = 0; i < 600; i++) world.tick(FIXED_DT_MS)
         const pos = world.getPosition(handle)
@@ -136,8 +171,14 @@ describe('PhysicsWorld gravity direction', () => {
 
 describe('PhysicsWorld setViewport', () => {
     test('setViewport repositions floor so new floor catches a falling body', () => {
-        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
-        const handle = world.register({ x: 400, y: 50 }, { width: 80, height: 40 })
+        const world = new PhysicsWorld({
+            viewport: { width: 800, height: 600 },
+        })
+        const handle = world.registerById(
+            'a',
+            { x: 400, y: 50 },
+            { width: 80, height: 40 },
+        )
         world.setViewport({ width: 800, height: 200 })
         for (let i = 0; i < 600; i++) world.tick(FIXED_DT_MS)
         const pos = world.getPosition(handle)
@@ -145,8 +186,15 @@ describe('PhysicsWorld setViewport', () => {
     })
 
     test('top inset at construction: ceiling stops upward-rising body at or below inset y', () => {
-        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 }, insets: { top: 40, bottom: 0 } })
-        const handle = world.register({ x: 400, y: 400 }, { width: 80, height: 40 })
+        const world = new PhysicsWorld({
+            viewport: { width: 800, height: 600 },
+            insets: { top: 40, bottom: 0 },
+        })
+        const handle = world.registerById(
+            'a',
+            { x: 400, y: 400 },
+            { width: 80, height: 40 },
+        )
         world.setGravityDirection('up')
         for (let i = 0; i < 600; i++) world.tick(FIXED_DT_MS)
         const pos = world.getPosition(handle)
@@ -154,16 +202,29 @@ describe('PhysicsWorld setViewport', () => {
     })
 
     test('bottom inset at construction: floor catches a falling body above viewport bottom', () => {
-        const world = new PhysicsWorld({ viewport: { width: 800, height: 400 }, insets: { top: 0, bottom: 40 } })
-        const handle = world.register({ x: 400, y: 50 }, { width: 80, height: 40 })
+        const world = new PhysicsWorld({
+            viewport: { width: 800, height: 400 },
+            insets: { top: 0, bottom: 40 },
+        })
+        const handle = world.registerById(
+            'a',
+            { x: 400, y: 50 },
+            { width: 80, height: 40 },
+        )
         for (let i = 0; i < 600; i++) world.tick(FIXED_DT_MS)
         const pos = world.getPosition(handle)
         expect(pos.y).toBeLessThanOrEqual(360)
     })
 
     test('setViewport with top inset repositions ceiling so rising body stops at inset y', () => {
-        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
-        const handle = world.register({ x: 400, y: 400 }, { width: 80, height: 40 })
+        const world = new PhysicsWorld({
+            viewport: { width: 800, height: 600 },
+        })
+        const handle = world.registerById(
+            'a',
+            { x: 400, y: 400 },
+            { width: 80, height: 40 },
+        )
         world.setGravityDirection('up')
         world.setViewport({ width: 800, height: 600 }, { top: 40, bottom: 0 })
         for (let i = 0; i < 600; i++) world.tick(FIXED_DT_MS)
@@ -177,11 +238,12 @@ describe('PhysicsWorld drag handles', () => {
         const world = new PhysicsWorld({
             viewport: { width: 800, height: 600 },
         })
-        const handle = world.register(
+        const handle = world.registerById(
+            'a',
             { x: 100, y: 100 },
             { width: 100, height: 50 },
         )
-        world.applyImpulse(handle, { x: 20, y: 0 })
+        world.setVelocity(handle, { x: 20, y: 0 })
         world.setPosition(handle, { x: 300, y: 250 })
         const pos = world.getPosition(handle)
         expect(pos.x).toBeCloseTo(300, 5)
@@ -195,7 +257,8 @@ describe('PhysicsWorld transform callback', () => {
             viewport: { width: 800, height: 600 },
         })
         const states: Array<{ x: number; y: number }> = []
-        world.register(
+        world.registerById(
+            'a',
             { x: 100, y: 100 },
             { width: 100, height: 50 },
             { onTransform: (s) => states.push({ x: s.x, y: s.y }) },
@@ -212,7 +275,8 @@ describe('PhysicsWorld dragging', () => {
         const world = new PhysicsWorld({
             viewport: { width: 800, height: 600 },
         })
-        const handle = world.register(
+        const handle = world.registerById(
+            'a',
             { x: 100, y: 100 },
             { width: 100, height: 50 },
         )
@@ -228,7 +292,8 @@ describe('PhysicsWorld dragging', () => {
         const world = new PhysicsWorld({
             viewport: { width: 800, height: 600 },
         })
-        const handle = world.register(
+        const handle = world.registerById(
+            'a',
             { x: 400, y: 100 },
             { width: 100, height: 50 },
         )
@@ -238,60 +303,94 @@ describe('PhysicsWorld dragging', () => {
         expect(pos.x).toBeGreaterThan(401)
     })
 
-    test('after release, applyImpulse adds velocity to a body that was dragged', () => {
-        const release = (impulseX: number) => {
+    test('after release, setVelocity adds velocity to a body that was dragged', () => {
+        const release = (velX: number) => {
             const world = new PhysicsWorld({
                 viewport: { width: 800, height: 600 },
             })
-            const handle = world.register(
+            const handle = world.registerById(
+                'a',
                 { x: 100, y: 100 },
                 { width: 100, height: 50 },
             )
             world.setDragging(handle, true)
             world.setPosition(handle, { x: 200, y: 100 })
             world.setDragging(handle, false)
-            if (impulseX !== 0)
-                world.applyImpulse(handle, { x: impulseX, y: 0 })
+            if (velX !== 0) world.setVelocity(handle, { x: velX, y: 0 })
             world.tick(FIXED_DT_MS)
             return world.getPosition(handle).x
         }
-        expect(release(100)).toBeGreaterThan(release(0))
+        expect(release(5)).toBeGreaterThan(release(0))
     })
 })
 
 describe('PhysicsWorld registerById', () => {
     test('registerById makes card retrievable by id', () => {
-        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
-        const handle = world.registerById('hero', { x: 100, y: 100 }, { width: 80, height: 40 })
+        const world = new PhysicsWorld({
+            viewport: { width: 800, height: 600 },
+        })
+        const handle = world.registerById(
+            'hero',
+            { x: 100, y: 100 },
+            { width: 80, height: 40 },
+        )
         expect(world.getHandleById('hero')).toBe(handle)
     })
 
     test('registerById with duplicate id throws', () => {
-        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
-        world.registerById('card-1', { x: 100, y: 100 }, { width: 80, height: 40 })
+        const world = new PhysicsWorld({
+            viewport: { width: 800, height: 600 },
+        })
+        world.registerById(
+            'card-1',
+            { x: 100, y: 100 },
+            { width: 80, height: 40 },
+        )
         expect(() =>
-            world.registerById('card-1', { x: 200, y: 200 }, { width: 80, height: 40 })
+            world.registerById(
+                'card-1',
+                { x: 200, y: 200 },
+                { width: 80, height: 40 },
+            ),
         ).toThrow()
     })
 
     test('unregister removes the id from the id map', () => {
-        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
-        const handle = world.registerById('card-1', { x: 100, y: 100 }, { width: 80, height: 40 })
+        const world = new PhysicsWorld({
+            viewport: { width: 800, height: 600 },
+        })
+        const handle = world.registerById(
+            'card-1',
+            { x: 100, y: 100 },
+            { width: 80, height: 40 },
+        )
         world.unregister(handle)
         expect(world.getHandleById('card-1')).toBeUndefined()
     })
 
     test('getHandleById returns undefined for unknown id', () => {
-        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
+        const world = new PhysicsWorld({
+            viewport: { width: 800, height: 600 },
+        })
         expect(world.getHandleById('missing')).toBeUndefined()
     })
 })
 
 describe('PhysicsWorld setBuoyancy', () => {
     test('balloon card is lifted against default downward gravity relative to heavy card', () => {
-        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
-        const heavy = world.register({ x: 400, y: 300 }, { width: 80, height: 40 })
-        const balloon = world.register({ x: 400, y: 300 }, { width: 80, height: 40 })
+        const world = new PhysicsWorld({
+            viewport: { width: 800, height: 600 },
+        })
+        const heavy = world.registerById(
+            'heavy',
+            { x: 400, y: 300 },
+            { width: 80, height: 40 },
+        )
+        const balloon = world.registerById(
+            'balloon',
+            { x: 400, y: 300 },
+            { width: 80, height: 40 },
+        )
         world.setBuoyancy(balloon, 'balloon')
         for (let i = 0; i < 60; i++) world.tick(FIXED_DT_MS)
         const heavyPos = world.getPosition(heavy)
@@ -300,375 +399,110 @@ describe('PhysicsWorld setBuoyancy', () => {
     })
 
     test('setBuoyancy throws for unknown handle', () => {
-        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
+        const world = new PhysicsWorld({
+            viewport: { width: 800, height: 600 },
+        })
         expect(() => world.setBuoyancy(999, 'balloon')).toThrow()
     })
 })
 
-describe('PhysicsWorld setSize', () => {
-    test('setSize throws for unknown handle', () => {
-        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
-        expect(() => world.setSize(999, { width: 100, height: 50 })).toThrow()
-    })
-
+describe('PhysicsWorld getSize', () => {
     test('getSize returns initial registered dimensions', () => {
-        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
-        const handle = world.register(
+        const world = new PhysicsWorld({
+            viewport: { width: 800, height: 600 },
+        })
+        const handle = world.registerById(
+            'sized',
             { x: 200, y: 200 },
             { width: 100, height: 50 },
         )
         expect(world.getSize(handle)).toEqual({ width: 100, height: 50 })
     })
-
-    test('setSize updates the stored dimensions', () => {
-        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
-        const handle = world.register(
-            { x: 200, y: 200 },
-            { width: 100, height: 50 },
-        )
-        world.setSize(handle, { width: 200, height: 100 })
-        expect(world.getSize(handle)).toEqual({ width: 200, height: 100 })
-    })
-
-    test('setSize preserves body center position', () => {
-        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
-        const handle = world.register(
-            { x: 200, y: 200 },
-            { width: 100, height: 50 },
-        )
-        world.setSize(handle, { width: 200, height: 100 })
-        const pos = world.getPosition(handle)
-        expect(pos.x).toBeCloseTo(200, 5)
-        expect(pos.y).toBeCloseTo(200, 5)
-    })
-
-    test('setSize is idempotent for the same dimensions', () => {
-        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
-        const handle = world.register(
-            { x: 200, y: 200 },
-            { width: 100, height: 50 },
-        )
-        world.setSize(handle, { width: 200, height: 100 })
-        world.setSize(handle, { width: 200, height: 100 })
-        expect(world.getSize(handle)).toEqual({ width: 200, height: 100 })
-    })
-
-    test('setSize can grow and then shrink back to the original dimensions', () => {
-        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
-        const handle = world.register(
-            { x: 200, y: 200 },
-            { width: 100, height: 50 },
-        )
-        world.setSize(handle, { width: 200, height: 100 })
-        world.setSize(handle, { width: 100, height: 50 })
-        expect(world.getSize(handle)).toEqual({ width: 100, height: 50 })
-        const pos = world.getPosition(handle)
-        expect(pos.x).toBeCloseTo(200, 5)
-        expect(pos.y).toBeCloseTo(200, 5)
-    })
 })
 
-describe('PhysicsWorld static registration (gravity-exempt)', () => {
-    test('registerStatic returns a handle that can be queried and unregistered', () => {
-        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
-        const handle = world.registerStatic(
-            { x: 200, y: 500 },
-            { width: 120, height: 60 },
-        )
-        expect(handle).toBeDefined()
-        expect(world.has(handle)).toBe(true)
-        world.unregister(handle)
-        expect(world.has(handle)).toBe(false)
-    })
-
-    test('a static body sits at its initial position', () => {
-        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
-        const handle = world.registerStatic(
-            { x: 200, y: 500 },
-            { width: 120, height: 60 },
-        )
-        const pos = world.getPosition(handle)
-        expect(pos.x).toBeCloseTo(200, 5)
-        expect(pos.y).toBeCloseTo(500, 5)
-    })
-
-    test('a static body does not fall under downward gravity', () => {
-        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
-        const handle = world.registerStatic(
-            { x: 200, y: 200 },
-            { width: 120, height: 60 },
-        )
-        for (let i = 0; i < 60; i++) world.tick(FIXED_DT_MS)
-        const pos = world.getPosition(handle)
-        expect(pos.y).toBeCloseTo(200, 1)
-    })
-
-    test('setPosition moves a static body to the target immediately', () => {
-        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
-        const handle = world.registerStatic(
-            { x: 200, y: 500 },
-            { width: 120, height: 60 },
-        )
-        world.setPosition(handle, { x: 400, y: 300 })
-        const pos = world.getPosition(handle)
-        expect(pos.x).toBeCloseTo(400, 5)
-        expect(pos.y).toBeCloseTo(300, 5)
-    })
-
-    test('a static body stays put after setPosition with gravity active', () => {
-        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
-        const handle = world.registerStatic(
-            { x: 200, y: 500 },
-            { width: 120, height: 60 },
-        )
-        world.setPosition(handle, { x: 400, y: 300 })
-        for (let i = 0; i < 120; i++) world.tick(FIXED_DT_MS)
-        const pos = world.getPosition(handle)
-        expect(pos.x).toBeCloseTo(400, 1)
-        expect(pos.y).toBeCloseTo(300, 1)
-    })
-})
-
-describe('PhysicsWorld tether', () => {
-    test('tether returns a numeric handle', () => {
-        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
-        const parent = world.registerStatic({ x: 400, y: 0 }, { width: 40, height: 40 })
-        const child = world.register({ x: 400, y: 200 }, { width: 80, height: 40 })
-        const th = world.tether(parent, child, 200)
-        expect(th).toBeTypeOf('number')
-    })
-
-    test('body within tether length falls freely under gravity (not held)', () => {
-        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
-        const parent = world.registerStatic({ x: 400, y: 0 }, { width: 40, height: 40 })
-        const child = world.register({ x: 400, y: 50 }, { width: 80, height: 40 })
-        world.tether(parent, child, 300)  // child at distance 50, tether length 300 → slack
-        for (let i = 0; i < 30; i++) world.tick(FIXED_DT_MS)
-        expect(world.getPosition(child).y).toBeGreaterThan(50)  // fell under gravity
-    })
-
-    test('body stretched past tether length is pulled back and settles near tether length', () => {
-        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
-        const parent = world.registerStatic({ x: 400, y: 100 }, { width: 40, height: 40 })
-        const child = world.register({ x: 400, y: 300 }, { width: 80, height: 40 })
-        world.tether(parent, child, 50)  // child at distance 200, tether length 50 → stretched
-        for (let i = 0; i < 300; i++) world.tick(FIXED_DT_MS)
-        const pos = world.getPosition(child)
-        const dist = Math.hypot(pos.x - 400, pos.y - 100)
-        expect(dist).toBeLessThan(100)  // settled near tether length of 50
-    })
-
-    test('untether removes the pull-only force so body falls freely', () => {
-        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
-        const parent = world.registerStatic({ x: 400, y: 50 }, { width: 40, height: 40 })
-        const child = world.register({ x: 400, y: 200 }, { width: 80, height: 40 })
-        const th = world.tether(parent, child, 50)
-        world.untether(th)
-        for (let i = 0; i < 600; i++) world.tick(FIXED_DT_MS)
-        const pos = world.getPosition(child)
-        const dist = Math.hypot(pos.x - 400, pos.y - 50)
-        expect(dist).toBeGreaterThan(200)  // fell away to floor
-    })
-
-    test('getTethers returns views with parent/child positions and length', () => {
-        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
-        const parent = world.registerStatic({ x: 400, y: 0 }, { width: 40, height: 40 })
-        const child = world.register({ x: 400, y: 200 }, { width: 80, height: 40 })
-        const th = world.tether(parent, child, 200)
-        const views = world.getTethers()
-        expect(views).toHaveLength(1)
-        expect(views[0]!.length).toBe(200)
-        world.untether(th)
-        expect(world.getTethers()).toHaveLength(0)
-    })
-
-    test('getTetherList returns a stable reference until the tether set changes', () => {
-        // Required by useSyncExternalStore in StringLayer — a new reference on
-        // every call causes an infinite re-render loop ("Maximum update depth exceeded").
-        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
-        const parent = world.registerStatic({ x: 400, y: 0 }, { width: 40, height: 40 })
-        const child = world.register({ x: 400, y: 200 }, { width: 80, height: 40 })
-
-        const empty1 = world.getTetherList()
-        const empty2 = world.getTetherList()
-        expect(empty2).toBe(empty1)
-
-        const th = world.tether(parent, child, 200)
-        const withTether1 = world.getTetherList()
-        expect(withTether1).not.toBe(empty1)
-        expect(withTether1).toHaveLength(1)
-
-        // Stable across calls when the set hasn't changed — even after world.tick advances positions
-        for (let i = 0; i < 10; i++) world.tick(FIXED_DT_MS)
-        const withTether2 = world.getTetherList()
-        expect(withTether2).toBe(withTether1)
-
-        world.untether(th)
-        const afterUntether = world.getTetherList()
-        expect(afterUntether).not.toBe(withTether1)
-        expect(afterUntether).toHaveLength(0)
-    })
-
+describe('PhysicsWorld static anchors', () => {
     test('getAnchor returns the registered surface point for ceiling and floor', () => {
-        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
+        const world = new PhysicsWorld({
+            viewport: { width: 800, height: 600 },
+        })
         // ceiling registered anchor is the top surface (y = 0 with no insets); floor is bottom surface
         const ceiling = world.getAnchor(world.ceilingHandle)
         expect(ceiling).toEqual({ x: 400, y: 0 })
         const floor = world.getAnchor(world.floorHandle)
         expect(floor).toEqual({ x: 400, y: 600 })
     })
+})
 
-    test('tether(..., anchorA) makes getTethers().parentPos reflect bodyPos + anchorA', () => {
-        // The bug fixed by #72: without anchorA, every ceiling tether's parentPos
-        // collapses to the ceiling's body centre. With anchorA, each rope originates
-        // above its own card's x — what StringLayer renders.
-        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
+describe('PhysicsWorld tether integration (rope force end-to-end)', () => {
+    // Unit-level rope-force coverage lives in Tether.test.ts (no matter.js).
+    // These two integration smokes verify the wiring from PhysicsWorld.tick()
+    // → Tether.applyRopeForces() → matter.js solver behaves identically to the
+    // pre-extraction inline loop (settle position + anchorA hold).
+
+    test('body stretched past tether length is pulled back and settles near tether length', () => {
+        const world = new PhysicsWorld({
+            viewport: { width: 800, height: 600 },
+        })
         const ceilingPos = world.getPosition(world.ceilingHandle)
-        const cardA = world.register({ x: 200, y: 150 }, { width: 80, height: 40 })
-        const cardB = world.register({ x: 600, y: 100 }, { width: 80, height: 40 })
-        // Each card's rope hangs straight from (ca.x, 0) — that's anchorA = (ca.x - ceilingBody.x, 0 - ceilingBody.y)
-        world.tether(world.ceilingHandle, cardA, 150, { x: 200 - ceilingPos.x, y: 0 - ceilingPos.y })
-        world.tether(world.ceilingHandle, cardB, 100, { x: 600 - ceilingPos.x, y: 0 - ceilingPos.y })
-        const views = world.getTethers()
-        expect(views).toHaveLength(2)
-        // World-space rope origins are distinct, not collapsed to ceiling centre
-        expect(views[0]!.parentPos.x).toBeCloseTo(200, 5)
-        expect(views[0]!.parentPos.y).toBeCloseTo(0, 5)
-        expect(views[1]!.parentPos.x).toBeCloseTo(600, 5)
-        expect(views[1]!.parentPos.y).toBeCloseTo(0, 5)
-    })
-
-    test('tether without anchorA keeps parentPos at parent body centre (card-to-card behaviour)', () => {
-        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
-        const parent = world.register({ x: 300, y: 200 }, { width: 80, height: 40 })
-        const child = world.register({ x: 300, y: 400 }, { width: 80, height: 40 })
-        world.tether(parent, child, 200)
-        const view = world.getTethers()[0]!
-        expect(view.parentPos.x).toBeCloseTo(300, 5)
-        expect(view.parentPos.y).toBeCloseTo(200, 5)
+        const child = world.registerById(
+            'stretched',
+            { x: 400, y: 300 },
+            { width: 80, height: 40 },
+        )
+        // child is 330 units below ceiling body centre; tether length 50 → heavy stretch
+        world.tether.add(world.ceilingHandle, child, 50, {
+            x: 0,
+            y: 0 - ceilingPos.y,
+        })
+        for (let i = 0; i < 300; i++) world.tick(FIXED_DT_MS)
+        const pos = world.getPosition(child)
+        const dist = Math.hypot(pos.x - 400, pos.y - 0)
+        expect(dist).toBeLessThan(100)
     })
 
     test('tether with anchorA holds the child near the offset world point under gravity', () => {
-        // Pull-only rope: child at (200, 150), pointA at (200, 0), length = 150.
-        // Soft TETHER_STIFFNESS means equilibrium sits at length + small overshoot from gravity.
-        // Without anchorA, the rope would anchor at the ceiling body centre (400, -30) instead —
-        // the child would drift far right toward ~x=400 before the rope caught. This test pins x.
-        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
+        // Without anchorA, the rope anchors at the ceiling body centre (400, -30)
+        // and the child would drift right toward x=400. With anchorA, the rope hangs
+        // straight from (200, 0); x stays near 200.
+        const world = new PhysicsWorld({
+            viewport: { width: 800, height: 600 },
+        })
         const ceilingPos = world.getPosition(world.ceilingHandle)
-        const child = world.register({ x: 200, y: 150 }, { width: 80, height: 40 })
-        world.tether(world.ceilingHandle, child, 150, { x: 200 - ceilingPos.x, y: 0 - ceilingPos.y })
+        const child = world.registerById(
+            'anchored',
+            { x: 200, y: 150 },
+            { width: 80, height: 40 },
+        )
+        world.tether.add(world.ceilingHandle, child, 150, {
+            x: 200 - ceilingPos.x,
+            y: 0 - ceilingPos.y,
+        })
         for (let i = 0; i < 300; i++) world.tick(FIXED_DT_MS)
         const pos = world.getPosition(child)
-        // Without anchorA, horizontal drift would be ~200 (child pulled toward ceiling centre).
-        // With anchorA, rope hangs straight, drift should stay small.
         expect(Math.abs(pos.x - 200)).toBeLessThan(20)
-        // Y settles below 150 due to gravity overshoot; rope keeps it bounded.
         expect(pos.y).toBeGreaterThan(150)
         expect(pos.y).toBeLessThan(220)
     })
 })
 
-describe('PhysicsWorld linkBodies / unlinkBodies', () => {
-    test('linkBodies returns a numeric link handle', () => {
-        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
-        const a = world.register({ x: 100, y: 200 }, { width: 80, height: 40 })
-        const b = world.register({ x: 400, y: 200 }, { width: 80, height: 40 })
-        const link = world.linkBodies(a, b)
-        expect(link).toBeTypeOf('number')
-    })
-
-    test('linkBodies with tight stiffness pulls bodies together over time', () => {
-        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
-        const a = world.register({ x: 100, y: 200 }, { width: 80, height: 40 })
-        const b = world.register({ x: 400, y: 200 }, { width: 80, height: 40 })
-        world.linkBodies(a, b, { length: 0, stiffness: 0.5, damping: 0.5 })
-        for (let i = 0; i < 200; i++) world.tick(FIXED_DT_MS)
-        const posA = world.getPosition(a)
-        const posB = world.getPosition(b)
-        const dist = Math.abs(posA.x - posB.x) + Math.abs(posA.y - posB.y)
-        expect(dist).toBeLessThan(20)
-    })
-
-    test('unlinkBodies removes the constraint so bodies no longer converge', () => {
-        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
-        const a = world.register({ x: 100, y: 200 }, { width: 80, height: 40 })
-        const b = world.register({ x: 400, y: 200 }, { width: 80, height: 40 })
-        const link = world.linkBodies(a, b, { length: 0, stiffness: 0.5, damping: 0.5 })
-        world.unlinkBodies(link)
-        for (let i = 0; i < 200; i++) world.tick(FIXED_DT_MS)
-        const posA = world.getPosition(a)
-        const posB = world.getPosition(b)
-        const dist = Math.abs(posA.x - posB.x) + Math.abs(posA.y - posB.y)
-        expect(dist).toBeGreaterThan(50)
-    })
-
-    test('linkBodies throws for an unknown handle', () => {
-        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
-        const a = world.register({ x: 100, y: 200 }, { width: 80, height: 40 })
-        expect(() => world.linkBodies(a, 999)).toThrow()
-        expect(() => world.linkBodies(999, a)).toThrow()
-    })
-
-    test('linkBodies with no opts does not throw (uses defaults)', () => {
-        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
-        const a = world.register({ x: 100, y: 200 }, { width: 80, height: 40 })
-        const b = world.register({ x: 400, y: 200 }, { width: 80, height: 40 })
-        expect(() => world.linkBodies(a, b)).not.toThrow()
-    })
-})
-
 describe('PhysicsWorld setSensor', () => {
     test('setSensor throws for an unknown handle', () => {
-        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
+        const world = new PhysicsWorld({
+            viewport: { width: 800, height: 600 },
+        })
         expect(() => world.setSensor(999, true)).toThrow()
     })
 
     test('setSensor does not throw for a valid handle', () => {
-        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
-        const handle = world.register({ x: 100, y: 100 }, { width: 80, height: 40 })
+        const world = new PhysicsWorld({
+            viewport: { width: 800, height: 600 },
+        })
+        const handle = world.registerById(
+            'sensor',
+            { x: 100, y: 100 },
+            { width: 80, height: 40 },
+        )
         expect(() => world.setSensor(handle, true)).not.toThrow()
         expect(() => world.setSensor(handle, false)).not.toThrow()
-    })
-})
-
-describe('PhysicsWorld setStatic', () => {
-    test('setStatic throws for an unknown handle', () => {
-        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
-        expect(() => world.setStatic(999, true)).toThrow()
-    })
-
-    test('setStatic(true) pins the body so a large impulse does not move it', () => {
-        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
-        const handle = world.register({ x: 200, y: 200 }, { width: 100, height: 50 })
-        world.setStatic(handle, true)
-        world.applyImpulse(handle, { x: 500, y: 0 })
-        for (let i = 0; i < 60; i++) world.tick(FIXED_DT_MS)
-        const pos = world.getPosition(handle)
-        expect(Math.abs(pos.x - 200)).toBeLessThan(1)
-        expect(Math.abs(pos.y - 200)).toBeLessThan(1)
-    })
-
-    test('setStatic(false) restores normal physics so impulse moves the body', () => {
-        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
-        const handle = world.register({ x: 200, y: 200 }, { width: 100, height: 50 })
-        world.setStatic(handle, true)
-        world.setStatic(handle, false)
-        world.applyImpulse(handle, { x: 50, y: 0 })
-        world.tick(FIXED_DT_MS)
-        const pos = world.getPosition(handle)
-        expect(pos.x).toBeGreaterThan(200)
-    })
-
-    test('setStatic is idempotent across lock/unlock toggles', () => {
-        const world = new PhysicsWorld({ viewport: { width: 800, height: 600 } })
-        const handle = world.register({ x: 200, y: 200 }, { width: 100, height: 50 })
-        world.setStatic(handle, true)
-        world.setStatic(handle, false)
-        world.setStatic(handle, true)
-        world.setStatic(handle, false)
-        world.applyImpulse(handle, { x: 50, y: 0 })
-        world.tick(FIXED_DT_MS)
-        const pos = world.getPosition(handle)
-        expect(pos.x).toBeGreaterThan(200)
     })
 })

--- a/web/src/physics/PhysicsWorld.ts
+++ b/web/src/physics/PhysicsWorld.ts
@@ -1,4 +1,6 @@
 import Matter from 'matter-js'
+import { Tether } from './Tether'
+import type { BodyForceSource } from './BodyForceSource'
 
 export type Cardinal = 'down' | 'up' | 'left' | 'right'
 
@@ -23,8 +25,6 @@ export interface PhysicsWorldOptions {
 }
 
 export type PhysicsHandle = number
-export type LinkHandle = number
-export type TetherHandle = number
 
 export interface BodyState {
     x: number
@@ -34,27 +34,6 @@ export interface BodyState {
 
 export interface RegisterOptions {
     onTransform?: (state: BodyState) => void
-}
-
-export interface LinkOptions {
-    length?: number
-    stiffness?: number
-    damping?: number
-}
-
-export interface TetherView {
-    parentPos: Vec2
-    childPos: Vec2
-    length: number
-    slack: boolean
-}
-
-interface TetherRecord {
-    parent: PhysicsHandle
-    child: PhysicsHandle
-    length: number
-    linkHandle: LinkHandle
-    anchorA?: Vec2
 }
 
 interface Registration {
@@ -71,10 +50,9 @@ interface Registration {
 const GRAVITY_Y = 0.7
 const BODY_FRICTION_AIR = 0.005
 const FLOOR_THICKNESS = 60
-const TETHER_STIFFNESS = 1.75e-5
 const BUOYANCY_GAIN = 1.5
 
-export class PhysicsWorld {
+export class PhysicsWorld implements BodyForceSource {
     private engine: Matter.Engine
     private world: Matter.World
     private _floor: Matter.Body
@@ -84,19 +62,16 @@ export class PhysicsWorld {
     private nextId: PhysicsHandle = 1
     private registrations = new Map<PhysicsHandle, Registration>()
     private byId = new Map<string, PhysicsHandle>()
-    private links = new Map<LinkHandle, Matter.Constraint>()
-    private tethers = new Map<TetherHandle, TetherRecord>()
-    private tetherChangeListeners = new Set<() => void>()
-    private cachedTetherList: ReadonlyArray<TetherHandle> | null = null
 
     readonly floorHandle: PhysicsHandle
     readonly ceilingHandle: PhysicsHandle
+    readonly tether: Tether
 
     constructor(opts: PhysicsWorldOptions) {
         this.engine = Matter.Engine.create()
         this.world = this.engine.world
         this.engine.gravity.x = 0
-        this.engine.gravity.y = GRAVITY_Y  // always on, default down
+        this.engine.gravity.y = GRAVITY_Y // always on, default down
 
         const { width, height } = opts.viewport
         const top = opts.insets?.top ?? 0
@@ -159,9 +134,11 @@ export class PhysicsWorld {
             { isStatic: true },
         )
         Matter.Composite.add(this.world, [this._leftWall, this._rightWall])
+
+        this.tether = new Tether(this)
     }
 
-    register(
+    private register(
         anchor: Vec2,
         size: CardSize,
         opts: RegisterOptions = {},
@@ -206,32 +183,6 @@ export class PhysicsWorld {
         return this.byId.get(cardId)
     }
 
-    registerStatic(
-        position: Vec2,
-        size: CardSize,
-        opts: RegisterOptions = {},
-    ): PhysicsHandle {
-        const body = Matter.Bodies.rectangle(
-            position.x,
-            position.y,
-            size.width,
-            size.height,
-            { isStatic: true },
-        )
-        Matter.Composite.add(this.world, body)
-        const id = this.nextId++
-        this.registrations.set(id, {
-            body,
-            anchor: { ...position },
-            isStatic: true,
-            onTransform: opts.onTransform,
-            width: size.width,
-            height: size.height,
-            buoyancy: 'heavy',
-        })
-        return id
-    }
-
     unregister(handle: PhysicsHandle): void {
         const reg = this.registrations.get(handle)
         if (!reg) return
@@ -258,15 +209,6 @@ export class PhysicsWorld {
         const reg = this.registrations.get(handle)
         if (!reg) throw new Error(`PhysicsWorld: unknown handle ${handle}`)
         return { x: reg.body.velocity.x, y: reg.body.velocity.y }
-    }
-
-    applyImpulse(handle: PhysicsHandle, impulse: Vec2): void {
-        const reg = this.registrations.get(handle)
-        if (!reg) throw new Error(`PhysicsWorld: unknown handle ${handle}`)
-        Matter.Body.setVelocity(reg.body, {
-            x: reg.body.velocity.x + impulse.x / reg.body.mass,
-            y: reg.body.velocity.y + impulse.y / reg.body.mass,
-        })
     }
 
     setPosition(handle: PhysicsHandle, position: Vec2): void {
@@ -305,10 +247,16 @@ export class PhysicsWorld {
         const hw = FLOOR_THICKNESS / 2
         const top = insets?.top ?? 0
         const bottom = insets?.bottom ?? 0
-        Matter.Body.setPosition(this._floor, { x: vp.width / 2, y: vp.height - bottom + hw })
+        Matter.Body.setPosition(this._floor, {
+            x: vp.width / 2,
+            y: vp.height - bottom + hw,
+        })
         Matter.Body.setPosition(this._ceiling, { x: vp.width / 2, y: top - hw })
         Matter.Body.setPosition(this._leftWall, { x: -hw, y: vp.height / 2 })
-        Matter.Body.setPosition(this._rightWall, { x: vp.width + hw, y: vp.height / 2 })
+        Matter.Body.setPosition(this._rightWall, {
+            x: vp.width + hw,
+            y: vp.height / 2,
+        })
     }
 
     setBuoyancy(handle: PhysicsHandle, b: 'heavy' | 'balloon'): void {
@@ -357,152 +305,26 @@ export class PhysicsWorld {
         return { width: reg.width, height: reg.height }
     }
 
-    setSize(handle: PhysicsHandle, size: CardSize): void {
+    getMass(handle: PhysicsHandle): number {
         const reg = this.registrations.get(handle)
         if (!reg) throw new Error(`PhysicsWorld: unknown handle ${handle}`)
-        const sx = size.width / reg.width
-        const sy = size.height / reg.height
-        Matter.Body.scale(reg.body, sx, sy)
-        reg.width = size.width
-        reg.height = size.height
+        return reg.body.mass
     }
 
-    setAngle(handle: PhysicsHandle, angle: number): void {
+    isStatic(handle: PhysicsHandle): boolean {
         const reg = this.registrations.get(handle)
         if (!reg) throw new Error(`PhysicsWorld: unknown handle ${handle}`)
-        Matter.Body.setAngle(reg.body, angle)
-        Matter.Body.setAngularVelocity(reg.body, 0)
+        // The matter.js body's live isStatic flag — true for persistent static bodies
+        // (ceiling/floor/walls) AND for cards currently being dragged. Tether's rope
+        // force uses this to skip force application on bodies that won't integrate,
+        // matching the pre-extraction tick() behaviour exactly.
+        return reg.body.isStatic
     }
 
-    linkBodies(
-        a: PhysicsHandle,
-        b: PhysicsHandle,
-        opts: LinkOptions = {},
-    ): LinkHandle {
-        const regA = this.registrations.get(a)
-        if (!regA) throw new Error(`PhysicsWorld: unknown handle ${a}`)
-        const regB = this.registrations.get(b)
-        if (!regB) throw new Error(`PhysicsWorld: unknown handle ${b}`)
-        const dx = regB.body.position.x - regA.body.position.x
-        const dy = regB.body.position.y - regA.body.position.y
-        const defaultLength = Math.sqrt(dx * dx + dy * dy)
-        const constraint = Matter.Constraint.create({
-            bodyA: regA.body,
-            bodyB: regB.body,
-            length: opts.length ?? defaultLength,
-            stiffness: opts.stiffness ?? 0.05,
-            damping: opts.damping ?? 0.1,
-        })
-        Matter.Composite.add(this.world, constraint)
-        const id = this.nextId++
-        this.links.set(id, constraint)
-        return id
-    }
-
-    unlinkBodies(link: LinkHandle): void {
-        const constraint = this.links.get(link)
-        if (!constraint) return
-        Matter.Composite.remove(this.world, constraint)
-        this.links.delete(link)
-    }
-
-    tether(parent: PhysicsHandle, child: PhysicsHandle, length: number, anchorA?: Vec2): TetherHandle {
-        const regP = this.registrations.get(parent)
-        if (!regP) throw new Error(`PhysicsWorld: unknown handle ${parent}`)
-        const regC = this.registrations.get(child)
-        if (!regC) throw new Error(`PhysicsWorld: unknown handle ${child}`)
-        // Construct the constraint directly so we can pass body-local pointA when supplied.
-        // stiffness ~0 because the pull-only rope force is applied in tick(), not by matter.js.
-        const constraint = Matter.Constraint.create({
-            bodyA: regP.body,
-            bodyB: regC.body,
-            length,
-            stiffness: 1e-9,
-            damping: 0,
-            ...(anchorA ? { pointA: { ...anchorA } } : {}),
-        })
-        Matter.Composite.add(this.world, constraint)
-        const lh = this.nextId++
-        this.links.set(lh, constraint)
-        const th = this.nextId++
-        this.tethers.set(th, {
-            parent,
-            child,
-            length,
-            linkHandle: lh,
-            ...(anchorA ? { anchorA: { ...anchorA } } : {}),
-        })
-        this.cachedTetherList = null
-        for (const cb of this.tetherChangeListeners) cb()
-        return th
-    }
-
-    untether(th: TetherHandle): void {
-        const rec = this.tethers.get(th)
-        if (!rec) return
-        this.unlinkBodies(rec.linkHandle)
-        this.tethers.delete(th)
-        this.cachedTetherList = null
-        for (const cb of this.tetherChangeListeners) cb()
-    }
-
-    getTethers(): TetherView[] {
-        const views: TetherView[] = []
-        for (const rec of this.tethers.values()) {
-            const regP = this.registrations.get(rec.parent)
-            const regC = this.registrations.get(rec.child)
-            if (!regP || !regC) continue
-            // World-space rope origin is the constraint's pointA. For static ceiling/floor (angle = 0)
-            // and dynamic parents with zero rotation, this is parentBodyCentre + anchorA.
-            const bodyPos = regP.body.position
-            const parentPos: Vec2 = rec.anchorA
-                ? { x: bodyPos.x + rec.anchorA.x, y: bodyPos.y + rec.anchorA.y }
-                : { x: bodyPos.x, y: bodyPos.y }
-            const childPos = { x: regC.body.position.x, y: regC.body.position.y }
-            const d = Math.hypot(childPos.x - parentPos.x, childPos.y - parentPos.y)
-            views.push({ parentPos, childPos, length: rec.length, slack: d < rec.length * 0.98 })
-        }
-        return views
-    }
-
-    // Stable-identity snapshot for useSyncExternalStore consumers. Reference only changes
-    // when the tether set changes (mount/unmount), not on every call.
-    getTetherList(): ReadonlyArray<TetherHandle> {
-        if (!this.cachedTetherList) {
-            this.cachedTetherList = Object.freeze(Array.from(this.tethers.keys()))
-        }
-        return this.cachedTetherList
-    }
-
-    subscribeTetherSetChange(cb: () => void): () => void {
-        this.tetherChangeListeners.add(cb)
-        return () => this.tetherChangeListeners.delete(cb)
-    }
-
-    listTetherRecords(): Array<{
-        handle: TetherHandle
-        parent: PhysicsHandle
-        child: PhysicsHandle
-        length: number
-        anchorA?: Vec2
-    }> {
-        const out: Array<{
-            handle: TetherHandle
-            parent: PhysicsHandle
-            child: PhysicsHandle
-            length: number
-            anchorA?: Vec2
-        }> = []
-        for (const [handle, rec] of this.tethers) {
-            out.push({
-                handle,
-                parent: rec.parent,
-                child: rec.child,
-                length: rec.length,
-                ...(rec.anchorA ? { anchorA: { ...rec.anchorA } } : {}),
-            })
-        }
-        return out
+    applyForce(handle: PhysicsHandle, force: Vec2): void {
+        const reg = this.registrations.get(handle)
+        if (!reg) throw new Error(`PhysicsWorld: unknown handle ${handle}`)
+        Matter.Body.applyForce(reg.body, reg.body.position, force)
     }
 
     setSensor(handle: PhysicsHandle, isSensor: boolean): void {
@@ -517,17 +339,11 @@ export class PhysicsWorld {
         return reg.body.isSensor
     }
 
-    setStatic(handle: PhysicsHandle, isStatic: boolean): void {
-        const reg = this.registrations.get(handle)
-        if (!reg) throw new Error(`PhysicsWorld: unknown handle ${handle}`)
-        if (reg.isStatic) return
-        Matter.Body.setStatic(reg.body, isStatic)
-    }
-
     tick(dtMs: number): void {
         // 1. Apply balloon buoyancy — per-tick force opposing gravity, scaled to match gravity force units
         const g = this.getGravityVector()
-        const gravScale: number = (this.engine.gravity as { scale?: number }).scale ?? 0.001
+        const gravScale: number =
+            (this.engine.gravity as { scale?: number }).scale ?? 0.001
         for (const reg of this.registrations.values()) {
             if (reg.isStatic || reg.buoyancy !== 'balloon') continue
             Matter.Body.applyForce(reg.body, reg.body.position, {
@@ -536,31 +352,8 @@ export class PhysicsWorld {
             })
         }
 
-        // 2. Apply pull-only tether forces (rope semantics).
-        // Force is measured from the world-space rope origin (parent body centre + anchorA),
-        // not the parent body centre alone — otherwise a string anchored above a card's x
-        // would let the card drift to the parent body centre's x before the rope catches.
-        for (const rec of this.tethers.values()) {
-            const regP = this.registrations.get(rec.parent)
-            const regC = this.registrations.get(rec.child)
-            if (!regP || !regC) continue
-            const parentX = regP.body.position.x + (rec.anchorA?.x ?? 0)
-            const parentY = regP.body.position.y + (rec.anchorA?.y ?? 0)
-            const dx = parentX - regC.body.position.x
-            const dy = parentY - regC.body.position.y
-            const d = Math.hypot(dx, dy)
-            if (d <= rec.length || d === 0) continue
-            const overshoot = d - rec.length
-            const nx = dx / d
-            const ny = dy / d
-            const a = overshoot * TETHER_STIFFNESS  // acceleration-scale; multiply by mass → force
-            if (!regC.body.isStatic) {
-                Matter.Body.applyForce(regC.body, regC.body.position, { x: nx * a * regC.body.mass, y: ny * a * regC.body.mass })
-            }
-            if (!regP.body.isStatic) {
-                Matter.Body.applyForce(regP.body, regP.body.position, { x: -nx * a * regP.body.mass, y: -ny * a * regP.body.mass })
-            }
-        }
+        // 2. Apply pull-only tether forces (rope semantics) via the Tether module.
+        this.tether.applyRopeForces()
 
         // 3. Advance the physics engine
         Matter.Engine.update(this.engine, dtMs)

--- a/web/src/physics/Tether.test.ts
+++ b/web/src/physics/Tether.test.ts
@@ -1,0 +1,316 @@
+import { describe, test, expect } from 'vitest'
+import { TETHER_STIFFNESS, Tether } from './Tether'
+import type { BodyForceSource } from './BodyForceSource'
+import type { PhysicsHandle, Vec2 } from './PhysicsWorld'
+
+class FakeBodyForceSource implements BodyForceSource {
+    private bodies = new Map<
+        PhysicsHandle,
+        { pos: Vec2; mass: number; isStatic: boolean }
+    >()
+    forces: Array<{ h: PhysicsHandle; force: Vec2 }> = []
+
+    setBody(h: PhysicsHandle, pos: Vec2, mass: number, isStatic = false) {
+        this.bodies.set(h, { pos: { ...pos }, mass, isStatic })
+    }
+    setPosition(h: PhysicsHandle, pos: Vec2) {
+        const b = this.bodies.get(h)
+        if (b) b.pos = { ...pos }
+    }
+    getPosition(h: PhysicsHandle): Vec2 {
+        const b = this.bodies.get(h)
+        if (!b) throw new Error(`FakeBodyForceSource: unknown handle ${h}`)
+        return { ...b.pos }
+    }
+    getMass(h: PhysicsHandle): number {
+        const b = this.bodies.get(h)
+        if (!b) throw new Error(`FakeBodyForceSource: unknown handle ${h}`)
+        return b.mass
+    }
+    isStatic(h: PhysicsHandle): boolean {
+        const b = this.bodies.get(h)
+        if (!b) throw new Error(`FakeBodyForceSource: unknown handle ${h}`)
+        return b.isStatic
+    }
+    applyForce(h: PhysicsHandle, force: Vec2): void {
+        this.forces.push({ h, force: { ...force } })
+    }
+
+    totalForceOn(h: PhysicsHandle): Vec2 {
+        let x = 0
+        let y = 0
+        for (const f of this.forces) {
+            if (f.h !== h) continue
+            x += f.force.x
+            y += f.force.y
+        }
+        return { x, y }
+    }
+}
+
+describe('Tether add/remove', () => {
+    test('add returns a numeric handle', () => {
+        const src = new FakeBodyForceSource()
+        src.setBody(1, { x: 0, y: 0 }, 1, true)
+        src.setBody(2, { x: 0, y: 100 }, 1)
+        const tether = new Tether(src)
+        const h = tether.add(1, 2, 100)
+        expect(typeof h).toBe('number')
+    })
+
+    test('remove deletes the tether from records', () => {
+        const src = new FakeBodyForceSource()
+        src.setBody(1, { x: 0, y: 0 }, 1, true)
+        src.setBody(2, { x: 0, y: 100 }, 1)
+        const tether = new Tether(src)
+        const h = tether.add(1, 2, 100)
+        expect(tether.records()).toHaveLength(1)
+        tether.remove(h)
+        expect(tether.records()).toHaveLength(0)
+    })
+
+    test('remove of an unknown handle is a no-op', () => {
+        const src = new FakeBodyForceSource()
+        const tether = new Tether(src)
+        expect(() => tether.remove(999)).not.toThrow()
+    })
+})
+
+describe('Tether subscribeChange', () => {
+    test('callback fires on add', () => {
+        const src = new FakeBodyForceSource()
+        src.setBody(1, { x: 0, y: 0 }, 1, true)
+        src.setBody(2, { x: 0, y: 100 }, 1)
+        const tether = new Tether(src)
+        let fired = 0
+        tether.subscribeChange(() => {
+            fired++
+        })
+        tether.add(1, 2, 100)
+        expect(fired).toBe(1)
+    })
+
+    test('callback fires on remove', () => {
+        const src = new FakeBodyForceSource()
+        src.setBody(1, { x: 0, y: 0 }, 1, true)
+        src.setBody(2, { x: 0, y: 100 }, 1)
+        const tether = new Tether(src)
+        const h = tether.add(1, 2, 100)
+        let fired = 0
+        tether.subscribeChange(() => {
+            fired++
+        })
+        tether.remove(h)
+        expect(fired).toBe(1)
+    })
+
+    test('unsubscribe stops further callbacks', () => {
+        const src = new FakeBodyForceSource()
+        src.setBody(1, { x: 0, y: 0 }, 1, true)
+        src.setBody(2, { x: 0, y: 100 }, 1)
+        const tether = new Tether(src)
+        let fired = 0
+        const unsub = tether.subscribeChange(() => {
+            fired++
+        })
+        unsub()
+        tether.add(1, 2, 100)
+        expect(fired).toBe(0)
+    })
+})
+
+describe('Tether records()', () => {
+    test('returns a stable reference until the set changes', () => {
+        const src = new FakeBodyForceSource()
+        src.setBody(1, { x: 0, y: 0 }, 1, true)
+        src.setBody(2, { x: 0, y: 100 }, 1)
+        const tether = new Tether(src)
+        const r1 = tether.records()
+        const r2 = tether.records()
+        expect(r2).toBe(r1)
+        tether.add(1, 2, 100)
+        const r3 = tether.records()
+        expect(r3).not.toBe(r1)
+        const r4 = tether.records()
+        expect(r4).toBe(r3)
+    })
+
+    test('returns a new reference after remove', () => {
+        const src = new FakeBodyForceSource()
+        src.setBody(1, { x: 0, y: 0 }, 1, true)
+        src.setBody(2, { x: 0, y: 100 }, 1)
+        const tether = new Tether(src)
+        const h = tether.add(1, 2, 100)
+        const r1 = tether.records()
+        tether.remove(h)
+        const r2 = tether.records()
+        expect(r2).not.toBe(r1)
+        expect(r2).toHaveLength(0)
+    })
+
+    test('record contents include handle, parent, child, length, anchorA', () => {
+        const src = new FakeBodyForceSource()
+        src.setBody(1, { x: 0, y: 0 }, 1, true)
+        src.setBody(2, { x: 50, y: 100 }, 1)
+        const tether = new Tether(src)
+        const h = tether.add(1, 2, 100, { x: 50, y: 0 })
+        const rec = tether.records()[0]!
+        expect(rec.handle).toBe(h)
+        expect(rec.parent).toBe(1)
+        expect(rec.child).toBe(2)
+        expect(rec.length).toBe(100)
+        expect(rec.anchorA).toEqual({ x: 50, y: 0 })
+    })
+
+    test('record omits anchorA when not provided', () => {
+        const src = new FakeBodyForceSource()
+        src.setBody(1, { x: 0, y: 0 }, 1, true)
+        src.setBody(2, { x: 0, y: 100 }, 1)
+        const tether = new Tether(src)
+        tether.add(1, 2, 100)
+        const rec = tether.records()[0]!
+        expect(rec.anchorA).toBeUndefined()
+    })
+})
+
+describe('Tether list()', () => {
+    test('parentPos and childPos are read live from BodyForceSource', () => {
+        const src = new FakeBodyForceSource()
+        src.setBody(1, { x: 0, y: 0 }, 1, true)
+        src.setBody(2, { x: 0, y: 100 }, 1)
+        const tether = new Tether(src)
+        tether.add(1, 2, 100)
+        const v1 = tether.list()[0]!
+        expect(v1.parentPos).toEqual({ x: 0, y: 0 })
+        expect(v1.childPos).toEqual({ x: 0, y: 100 })
+        src.setPosition(2, { x: 0, y: 150 })
+        const v2 = tether.list()[0]!
+        expect(v2.childPos).toEqual({ x: 0, y: 150 })
+    })
+
+    test('parentPos = parentBodyPos + anchorA when anchorA is provided', () => {
+        const src = new FakeBodyForceSource()
+        src.setBody(1, { x: 400, y: -30 }, 1, true)
+        src.setBody(2, { x: 200, y: 100 }, 1)
+        const tether = new Tether(src)
+        tether.add(1, 2, 150, { x: -200, y: 30 })
+        const v = tether.list()[0]!
+        expect(v.parentPos.x).toBeCloseTo(200, 5)
+        expect(v.parentPos.y).toBeCloseTo(0, 5)
+    })
+
+    test('slack is true when distance < length * 0.98', () => {
+        const src = new FakeBodyForceSource()
+        src.setBody(1, { x: 0, y: 0 }, 1, true)
+        src.setBody(2, { x: 0, y: 50 }, 1)
+        const tether = new Tether(src)
+        tether.add(1, 2, 100)
+        expect(tether.list()[0]!.slack).toBe(true)
+    })
+
+    test('slack is false when distance >= length * 0.98', () => {
+        const src = new FakeBodyForceSource()
+        src.setBody(1, { x: 0, y: 0 }, 1, true)
+        src.setBody(2, { x: 0, y: 99 }, 1)
+        const tether = new Tether(src)
+        tether.add(1, 2, 100)
+        expect(tether.list()[0]!.slack).toBe(false)
+    })
+})
+
+describe('Tether applyRopeForces', () => {
+    test('applies no force when child is within tether length (slack)', () => {
+        const src = new FakeBodyForceSource()
+        src.setBody(1, { x: 0, y: 0 }, 1, true)
+        src.setBody(2, { x: 0, y: 50 }, 1)
+        const tether = new Tether(src)
+        tether.add(1, 2, 100)
+        tether.applyRopeForces()
+        expect(src.forces).toHaveLength(0)
+    })
+
+    test('applies no force when distance exactly equals length', () => {
+        const src = new FakeBodyForceSource()
+        src.setBody(1, { x: 0, y: 0 }, 1, true)
+        src.setBody(2, { x: 0, y: 100 }, 1)
+        const tether = new Tether(src)
+        tether.add(1, 2, 100)
+        tether.applyRopeForces()
+        expect(src.forces).toHaveLength(0)
+    })
+
+    test('applies pull-only force when child is past tether length', () => {
+        const src = new FakeBodyForceSource()
+        src.setBody(1, { x: 0, y: 0 }, 1, true)
+        src.setBody(2, { x: 0, y: 200 }, 5)
+        const tether = new Tether(src)
+        tether.add(1, 2, 100)
+        tether.applyRopeForces()
+        const f = src.totalForceOn(2)
+        expect(f.x).toBeCloseTo(0, 10)
+        expect(f.y).toBeCloseTo(-100 * TETHER_STIFFNESS * 5, 10)
+    })
+
+    test('force direction: child pulled toward parent, parent pulled toward child', () => {
+        const src = new FakeBodyForceSource()
+        src.setBody(1, { x: 0, y: 0 }, 2)
+        src.setBody(2, { x: 0, y: 150 }, 5)
+        const tether = new Tether(src)
+        tether.add(1, 2, 50)
+        tether.applyRopeForces()
+        const fc = src.totalForceOn(2)
+        const fp = src.totalForceOn(1)
+        expect(fc.y).toBeLessThan(0)
+        expect(fp.y).toBeGreaterThan(0)
+    })
+
+    test('does not apply force to a static parent', () => {
+        const src = new FakeBodyForceSource()
+        src.setBody(1, { x: 0, y: 0 }, 1, true)
+        src.setBody(2, { x: 0, y: 200 }, 5)
+        const tether = new Tether(src)
+        tether.add(1, 2, 100)
+        tether.applyRopeForces()
+        const fp = src.totalForceOn(1)
+        expect(fp.x).toBe(0)
+        expect(fp.y).toBe(0)
+    })
+
+    test('does not apply force to a static child', () => {
+        const src = new FakeBodyForceSource()
+        src.setBody(1, { x: 0, y: 0 }, 1)
+        src.setBody(2, { x: 0, y: 200 }, 5, true)
+        const tether = new Tether(src)
+        tether.add(1, 2, 100)
+        tether.applyRopeForces()
+        const fc = src.totalForceOn(2)
+        expect(fc.x).toBe(0)
+        expect(fc.y).toBe(0)
+    })
+
+    test('anchorA shifts the rope origin to parentBodyPos + anchorA', () => {
+        const src = new FakeBodyForceSource()
+        src.setBody(1, { x: 400, y: -30 }, 1, true)
+        src.setBody(2, { x: 200, y: 150 }, 5)
+        const tether = new Tether(src)
+        tether.add(1, 2, 100, { x: -200, y: 30 })
+        tether.applyRopeForces()
+        const f = src.totalForceOn(2)
+        expect(f.x).toBeCloseTo(0, 10)
+        expect(f.y).toBeCloseTo(-50 * TETHER_STIFFNESS * 5, 10)
+    })
+
+    test('multiple tethers apply independently', () => {
+        const src = new FakeBodyForceSource()
+        src.setBody(1, { x: 0, y: 0 }, 1, true)
+        src.setBody(2, { x: 0, y: 200 }, 5)
+        src.setBody(3, { x: 100, y: 0 }, 1, true)
+        src.setBody(4, { x: 100, y: 200 }, 5)
+        const tether = new Tether(src)
+        tether.add(1, 2, 100)
+        tether.add(3, 4, 50)
+        tether.applyRopeForces()
+        expect(src.totalForceOn(2).y).toBeLessThan(0)
+        expect(src.totalForceOn(4).y).toBeLessThan(0)
+    })
+})

--- a/web/src/physics/Tether.ts
+++ b/web/src/physics/Tether.ts
@@ -1,0 +1,148 @@
+import type { BodyForceSource } from './BodyForceSource'
+import type { PhysicsHandle, Vec2 } from './PhysicsWorld'
+
+export type TetherHandle = number
+
+export interface TetherView {
+    parentPos: Vec2
+    childPos: Vec2
+    length: number
+    slack: boolean
+}
+
+export interface TetherRecord {
+    handle: TetherHandle
+    parent: PhysicsHandle
+    child: PhysicsHandle
+    length: number
+    anchorA?: Vec2
+}
+
+// Per-tick "acceleration scale" used to convert tether overshoot into a force
+// (multiplied by body mass at the apply site). The 1e-9-stiffness matter.js
+// constraint that used to back the tether was vestigial — issue #108 cut it,
+// so this number alone now drives rope physics. The value is hand-tuned to
+// match the behaviour cards exhibited in May 2026; do not change without a
+// matching pendulum-settle regression review.
+export const TETHER_STIFFNESS = 1.75e-5
+
+const SLACK_FACTOR = 0.98
+
+export class Tether {
+    private readonly bodies: BodyForceSource
+    private nextHandle: TetherHandle = 1
+    private readonly records_ = new Map<TetherHandle, TetherRecord>()
+    private cachedRecords: readonly TetherRecord[] | null = null
+    private readonly listeners = new Set<() => void>()
+
+    constructor(bodies: BodyForceSource) {
+        this.bodies = bodies
+    }
+
+    add(
+        parent: PhysicsHandle,
+        child: PhysicsHandle,
+        length: number,
+        anchorA?: Vec2,
+    ): TetherHandle {
+        const handle = this.nextHandle++
+        const rec: TetherRecord = {
+            handle,
+            parent,
+            child,
+            length,
+            ...(anchorA ? { anchorA: { ...anchorA } } : {}),
+        }
+        this.records_.set(handle, rec)
+        this.invalidate()
+        return handle
+    }
+
+    remove(handle: TetherHandle): void {
+        if (!this.records_.delete(handle)) return
+        this.invalidate()
+    }
+
+    records(): readonly TetherRecord[] {
+        if (!this.cachedRecords) {
+            this.cachedRecords = Object.freeze(
+                Array.from(this.records_.values()).map((r) => ({
+                    handle: r.handle,
+                    parent: r.parent,
+                    child: r.child,
+                    length: r.length,
+                    ...(r.anchorA ? { anchorA: { ...r.anchorA } } : {}),
+                })),
+            )
+        }
+        return this.cachedRecords
+    }
+
+    list(): readonly TetherView[] {
+        const views: TetherView[] = []
+        for (const rec of this.records_.values()) {
+            const parentBody = this.bodies.getPosition(rec.parent)
+            const childPos = this.bodies.getPosition(rec.child)
+            const parentPos: Vec2 = rec.anchorA
+                ? {
+                      x: parentBody.x + rec.anchorA.x,
+                      y: parentBody.y + rec.anchorA.y,
+                  }
+                : parentBody
+            const dist = Math.hypot(
+                childPos.x - parentPos.x,
+                childPos.y - parentPos.y,
+            )
+            views.push({
+                parentPos,
+                childPos,
+                length: rec.length,
+                slack: dist < rec.length * SLACK_FACTOR,
+            })
+        }
+        return views
+    }
+
+    subscribeChange(cb: () => void): () => void {
+        this.listeners.add(cb)
+        return () => {
+            this.listeners.delete(cb)
+        }
+    }
+
+    applyRopeForces(): void {
+        for (const rec of this.records_.values()) {
+            const parentBody = this.bodies.getPosition(rec.parent)
+            const childPos = this.bodies.getPosition(rec.child)
+            const parentX = parentBody.x + (rec.anchorA?.x ?? 0)
+            const parentY = parentBody.y + (rec.anchorA?.y ?? 0)
+            const dx = parentX - childPos.x
+            const dy = parentY - childPos.y
+            const d = Math.hypot(dx, dy)
+            if (d <= rec.length || d === 0) continue
+            const overshoot = d - rec.length
+            const nx = dx / d
+            const ny = dy / d
+            const a = overshoot * TETHER_STIFFNESS
+            if (!this.bodies.isStatic(rec.child)) {
+                const m = this.bodies.getMass(rec.child)
+                this.bodies.applyForce(rec.child, {
+                    x: nx * a * m,
+                    y: ny * a * m,
+                })
+            }
+            if (!this.bodies.isStatic(rec.parent)) {
+                const m = this.bodies.getMass(rec.parent)
+                this.bodies.applyForce(rec.parent, {
+                    x: -nx * a * m,
+                    y: -ny * a * m,
+                })
+            }
+        }
+    }
+
+    private invalidate(): void {
+        this.cachedRecords = null
+        for (const cb of this.listeners) cb()
+    }
+}

--- a/web/src/routes/Lifelog.test.ts
+++ b/web/src/routes/Lifelog.test.ts
@@ -1,5 +1,10 @@
 import { describe, test, expect } from 'vitest'
-import { booksAnchor, nowPlayingAnchor, filmsAnchor, activityAnchor } from './Lifelog'
+import {
+    booksAnchor,
+    nowPlayingAnchor,
+    filmsAnchor,
+    activityAnchor,
+} from './Lifelog'
 import { PhysicsWorld } from '../physics/PhysicsWorld'
 import { wireTetherFor } from '../physics/PhysicsCard'
 
@@ -24,16 +29,28 @@ describe('Lifelog ceiling tethers — issue #72 regression', () => {
     test('each ceiling-strung card has a distinct rope origin matching its own anchor.x', () => {
         const world = new PhysicsWorld({ viewport })
         const cards = [
-            { anchor: booksAnchor(viewport), size: { width: 320, height: 280 } },
-            { anchor: nowPlayingAnchor(viewport), size: { width: 280, height: 180 } },
-            { anchor: filmsAnchor(viewport), size: { width: 320, height: 320 } },
-            { anchor: activityAnchor(viewport), size: { width: 280, height: 360 } },
+            {
+                anchor: booksAnchor(viewport),
+                size: { width: 320, height: 280 },
+            },
+            {
+                anchor: nowPlayingAnchor(viewport),
+                size: { width: 280, height: 180 },
+            },
+            {
+                anchor: filmsAnchor(viewport),
+                size: { width: 320, height: 320 },
+            },
+            {
+                anchor: activityAnchor(viewport),
+                size: { width: 280, height: 360 },
+            },
         ]
-        for (const c of cards) {
-            const h = world.register(c.anchor, c.size)
+        cards.forEach((c, i) => {
+            const h = world.registerById(`card-${i}`, c.anchor, c.size)
             wireTetherFor(world, world.ceilingHandle, 'ceiling', h, c.anchor)
-        }
-        const views = world.getTethers()
+        })
+        const views = world.tether.list()
         expect(views).toHaveLength(4)
         // Each rope origin sits at (cardAnchor.x, 0) — distinct x per card, all at the ceiling surface.
         for (let i = 0; i < views.length; i++) {

--- a/web/src/transitions/PhysicsCardImpl.test.tsx
+++ b/web/src/transitions/PhysicsCardImpl.test.tsx
@@ -16,7 +16,9 @@ vi.mock('../canvas/flip', () => ({
 import { flipMorph } from '../canvas/flip'
 
 // Helper: build a PhysicsCardEntry with sensible defaults.
-function makeEntry(overrides: Partial<PhysicsCardEntry> = {}): PhysicsCardEntry {
+function makeEntry(
+    overrides: Partial<PhysicsCardEntry> = {},
+): PhysicsCardEntry {
     return {
         id: overrides.id ?? 'card-1',
         parent: overrides.parent ?? null,
@@ -35,8 +37,14 @@ function makeEntry(overrides: Partial<PhysicsCardEntry> = {}): PhysicsCardEntry 
     }
 }
 
-function fireRealPointerDown(el: Element, opts: { onCardHeader?: boolean } = {}) {
-    const ev = new Event('pointerdown', { bubbles: true, cancelable: true }) as Event & {
+function fireRealPointerDown(
+    el: Element,
+    opts: { onCardHeader?: boolean } = {},
+) {
+    const ev = new Event('pointerdown', {
+        bubbles: true,
+        cancelable: true,
+    }) as Event & {
         clientX: number
         clientY: number
         pointerId: number
@@ -271,8 +279,8 @@ describe('PhysicsCardImpl — parent tether wiring', () => {
         await flushRaf()
         const world = getWorld()
         const childHandle = world.getHandleById('tether-ceil')!
-        const records = world
-            .listTetherRecords()
+        const records = world.tether
+            .records()
             .filter((r) => r.child === childHandle)
         expect(records).toHaveLength(1)
         expect(records[0]!.parent).toBe(world.ceilingHandle)
@@ -284,8 +292,8 @@ describe('PhysicsCardImpl — parent tether wiring', () => {
         await flushRaf()
         const world = getWorld()
         const childHandle = world.getHandleById('tether-floor')!
-        const records = world
-            .listTetherRecords()
+        const records = world.tether
+            .records()
             .filter((r) => r.child === childHandle)
         expect(records).toHaveLength(1)
         expect(records[0]!.parent).toBe(world.floorHandle)
@@ -308,8 +316,8 @@ describe('PhysicsCardImpl — parent tether wiring', () => {
         const world = getWorld()
         const parentHandle = world.getHandleById('parent-card')!
         const childHandle = world.getHandleById('child-card')!
-        const childRecords = world
-            .listTetherRecords()
+        const childRecords = world.tether
+            .records()
             .filter((r) => r.child === childHandle)
         expect(childRecords).toHaveLength(1)
         expect(childRecords[0]!.parent).toBe(parentHandle)
@@ -327,8 +335,8 @@ describe('PhysicsCardImpl — parent tether wiring', () => {
         await flushRaf()
         const world = getWorld()
         const childHandle = world.getHandleById('lonely-child')!
-        const childRecords = world
-            .listTetherRecords()
+        const childRecords = world.tether
+            .records()
             .filter((r) => r.child === childHandle)
         expect(childRecords).toHaveLength(0)
         expect(warnSpy).toHaveBeenCalled()
@@ -345,8 +353,8 @@ describe('PhysicsCardImpl — parent tether wiring', () => {
         await flushRaf()
         const world = getWorld()
         const childHandle = world.getHandleById('dual-tether')!
-        const records = world
-            .listTetherRecords()
+        const records = world.tether
+            .records()
             .filter((r) => r.child === childHandle)
         expect(records).toHaveLength(2)
         const parents = records.map((r) => r.parent).sort()
@@ -383,16 +391,14 @@ describe('PhysicsCardImpl — anchor changes', () => {
         const world = getWorld()
         const setAnchorSpy = vi.spyOn(world, 'setAnchor')
         const childHandle = world.getHandleById('anchor-card')!
-        const recordsBefore = world
-            .listTetherRecords()
+        const recordsBefore = world.tether
+            .records()
             .filter((r) => r.child === childHandle)
         expect(recordsBefore).toHaveLength(1)
         const oldTetherHandle = recordsBefore[0]!.handle
 
         await act(async () => {
-            fireEvent.click(
-                container.querySelector('[data-testid="bump"]')!,
-            )
+            fireEvent.click(container.querySelector('[data-testid="bump"]')!)
         })
         await flushRaf()
 
@@ -400,8 +406,8 @@ describe('PhysicsCardImpl — anchor changes', () => {
             x: 250,
             y: 250,
         })
-        const recordsAfter = world
-            .listTetherRecords()
+        const recordsAfter = world.tether
+            .records()
             .filter((r) => r.child === childHandle)
         // Still exactly one tether to the ceiling, but a new handle (old one
         // was untethered + a fresh one wired).
@@ -436,8 +442,8 @@ describe('PhysicsCardImpl — unmount cleanup', () => {
         await flushRaf()
         expect(world!.getHandleById('unmount-me')).toBeTruthy()
         expect(
-            world!
-                .listTetherRecords()
+            world!.tether
+                .records()
                 .some((r) => r.child === world!.getHandleById('unmount-me')!),
         ).toBe(true)
 
@@ -451,7 +457,7 @@ describe('PhysicsCardImpl — unmount cleanup', () => {
         )
         await flushRaf()
         expect(world!.getHandleById('unmount-me')).toBeUndefined()
-        expect(world!.listTetherRecords()).toHaveLength(0)
+        expect(world!.tether.records()).toHaveLength(0)
     })
 })
 
@@ -516,8 +522,8 @@ describe('PhysicsCardImpl — restore from chip', () => {
         // consumed — advance one frame.
         await flushRaf()
         expect(flipMorph).toHaveBeenCalledTimes(1)
-        const callArgs = (flipMorph as unknown as ReturnType<typeof vi.fn>)
-            .mock.calls[0]!
+        const callArgs = (flipMorph as unknown as ReturnType<typeof vi.fn>).mock
+            .calls[0]!
         expect(callArgs[0]).toBe(fromChipRect)
         expect(callArgs[1]).toBe(article)
         expect(callArgs[2]).toEqual(

--- a/web/src/transitions/PhysicsCardImpl.tsx
+++ b/web/src/transitions/PhysicsCardImpl.tsx
@@ -6,10 +6,8 @@ import {
 } from '../canvas/useMinimizedRegistry'
 import { flipMorph } from '../canvas/flip'
 import { wireTetherFor } from '../physics/PhysicsCard'
-import type {
-    PhysicsHandle,
-    TetherHandle,
-} from '../physics/PhysicsWorld'
+import type { PhysicsHandle } from '../physics/PhysicsWorld'
+import type { TetherHandle } from '../physics/Tether'
 import type { PhysicsCardEntry } from './CardRegistry'
 import '../physics/PhysicsCard.css'
 
@@ -230,11 +228,11 @@ export function PhysicsCardImpl({ entry }: PhysicsCardImplProps) {
             cancelAnimationFrame(rafId)
             cancelAnimationFrame(trailRafId)
             if (tetherHandleRef.current !== null) {
-                world.untether(tetherHandleRef.current)
+                world.tether.remove(tetherHandleRef.current)
                 tetherHandleRef.current = null
             }
             if (trailTetherHandleRef.current !== null) {
-                world.untether(trailTetherHandleRef.current)
+                world.tether.remove(trailTetherHandleRef.current)
                 trailTetherHandleRef.current = null
             }
             world.unregister(handle)
@@ -245,13 +243,23 @@ export function PhysicsCardImpl({ entry }: PhysicsCardImplProps) {
                 window.removeEventListener('pointerup', onPointerUp)
             }
         }
-    }, [world, id, width, height, isMinimized, draggable, parent, trail, buoyancy])
+    }, [
+        world,
+        id,
+        width,
+        height,
+        isMinimized,
+        draggable,
+        parent,
+        trail,
+        buoyancy,
+    ])
 
     useEffect(() => {
         if (handleRef.current === null) return
         world.setAnchor(handleRef.current, anchor)
         if (tetherHandleRef.current !== null && parent) {
-            world.untether(tetherHandleRef.current)
+            world.tether.remove(tetherHandleRef.current)
             tetherHandleRef.current = null
             const resolved = resolveParent(world, parent)
             if (resolved.handle != null) {
@@ -265,7 +273,7 @@ export function PhysicsCardImpl({ entry }: PhysicsCardImplProps) {
             }
         }
         if (trailTetherHandleRef.current !== null && trail) {
-            world.untether(trailTetherHandleRef.current)
+            world.tether.remove(trailTetherHandleRef.current)
             trailTetherHandleRef.current = null
             const resolved = resolveParent(world, trail)
             if (resolved.handle != null) {

--- a/web/src/transitions/primitives/anchorSlide.test.ts
+++ b/web/src/transitions/primitives/anchorSlide.test.ts
@@ -167,9 +167,9 @@ describe('anchorSlide (T3) — horizontal', () => {
             { width: 200, height: 100 },
         )
         const TETHER_LEN = 250
-        world.tether(world.ceilingHandle, b, TETHER_LEN)
+        world.tether.add(world.ceilingHandle, b, TETHER_LEN)
         expect(
-            world.listTetherRecords().filter((t) => t.child === b),
+            world.tether.records().filter((t) => t.child === b),
         ).toHaveLength(1)
 
         const step = anchorSlide(
@@ -187,15 +187,13 @@ describe('anchorSlide (T3) — horizontal', () => {
         // doesn't draw a long diagonal string while the card slides in.
         step(0)
         expect(
-            world.listTetherRecords().filter((t) => t.child === b),
+            world.tether.records().filter((t) => t.child === b),
         ).toHaveLength(0)
 
         // After completion, the tether should be re-attached with the
         // original length so the card resumes hanging at its layout anchor.
         step(700)
-        const restored = world
-            .listTetherRecords()
-            .filter((t) => t.child === b)
+        const restored = world.tether.records().filter((t) => t.child === b)
         expect(restored).toHaveLength(1)
         expect(restored[0]!.length).toBe(TETHER_LEN)
         expect(restored[0]!.parent).toBe(world.ceilingHandle)
@@ -287,11 +285,7 @@ describe('anchorSlide (T3) — horizontal', () => {
     test('sensorEdges: ceiling — toggles ceiling sensor on init, restores at end', () => {
         const viewport = { width: 800, height: 600 }
         const world = new PhysicsWorld({ viewport })
-        world.registerById(
-            'a',
-            { x: 400, y: 300 },
-            { width: 200, height: 100 },
-        )
+        world.registerById('a', { x: 400, y: 300 }, { width: 200, height: 100 })
 
         expect(world.isSensor(world.ceilingHandle)).toBe(false)
 
@@ -317,11 +311,7 @@ describe('anchorSlide (T3) — horizontal', () => {
     test('sensorEdges: floor — toggles floor sensor (back/T4-back direction)', () => {
         const viewport = { width: 800, height: 600 }
         const world = new PhysicsWorld({ viewport })
-        world.registerById(
-            'a',
-            { x: 400, y: 300 },
-            { width: 200, height: 100 },
-        )
+        world.registerById('a', { x: 400, y: 300 }, { width: 200, height: 100 })
 
         const step = anchorSlide(
             world,
@@ -346,11 +336,7 @@ describe('anchorSlide (T3) — horizontal', () => {
     test('sensorEdges omitted — neither edge is toggled', () => {
         const viewport = { width: 800, height: 600 }
         const world = new PhysicsWorld({ viewport })
-        world.registerById(
-            'a',
-            { x: 400, y: 300 },
-            { width: 200, height: 100 },
-        )
+        world.registerById('a', { x: 400, y: 300 }, { width: 200, height: 100 })
 
         const step = anchorSlide(
             world,
@@ -379,9 +365,9 @@ describe('anchorSlide (T3) — horizontal', () => {
             { x: 400, y: 300 },
             { width: 200, height: 100 },
         )
-        world.tether(world.ceilingHandle, a, 250)
+        world.tether.add(world.ceilingHandle, a, 250)
         expect(
-            world.listTetherRecords().filter((t) => t.child === a),
+            world.tether.records().filter((t) => t.child === a),
         ).toHaveLength(1)
 
         const step = anchorSlide(
@@ -397,13 +383,13 @@ describe('anchorSlide (T3) — horizontal', () => {
 
         step(0)
         expect(
-            world.listTetherRecords().filter((t) => t.child === a),
+            world.tether.records().filter((t) => t.child === a),
         ).toHaveLength(0)
 
         step(700)
         // From-card stays untethered — TransitionDirector releases it next.
         expect(
-            world.listTetherRecords().filter((t) => t.child === a),
+            world.tether.records().filter((t) => t.child === a),
         ).toHaveLength(0)
     })
 })

--- a/web/src/transitions/primitives/anchorSlide.ts
+++ b/web/src/transitions/primitives/anchorSlide.ts
@@ -47,14 +47,14 @@ function captureAndUntether(
     world: PhysicsWorld,
     handle: PhysicsHandle,
 ): CapturedTether | undefined {
-    for (const t of world.listTetherRecords()) {
+    for (const t of world.tether.records()) {
         if (t.child !== handle) continue
         const captured: CapturedTether = {
             parent: t.parent,
             length: t.length,
             ...(t.anchorA ? { anchorA: { ...t.anchorA } } : {}),
         }
-        world.untether(t.handle)
+        world.tether.remove(t.handle)
         return captured
     }
     return undefined
@@ -109,7 +109,7 @@ export function anchorSlide(
                 const start = { x: pos.x, y: pos.y }
                 fromInitial.set(id, start)
                 // From-card exits in axis × -sign direction
-                const exitOffset = offsetFor((-sign) as -1 | 1)
+                const exitOffset = offsetFor(-sign as -1 | 1)
                 fromFinal.set(id, {
                     x: start.x + exitOffset.x,
                     y: start.y + exitOffset.y,
@@ -181,7 +181,7 @@ export function anchorSlide(
                 world.setVelocity(handle, { x: 0, y: 0 })
                 const captured = toCaptured.get(id)
                 if (captured) {
-                    world.tether(
+                    world.tether.add(
                         captured.parent,
                         handle,
                         captured.length,

--- a/web/src/transitions/primitives/pourInDrop.test.ts
+++ b/web/src/transitions/primitives/pourInDrop.test.ts
@@ -24,8 +24,18 @@ describe('pourInDrop (T2 — kinematic tween)', () => {
         const step = pourInDrop(
             world,
             [
-                { id: 'a', layoutAnchor: { x: 200, y: 200 }, height: 120, staggerMs: 0 },
-                { id: 'b', layoutAnchor: { x: 500, y: 300 }, height: 120, staggerMs: 1000 },
+                {
+                    id: 'a',
+                    layoutAnchor: { x: 200, y: 200 },
+                    height: 120,
+                    staggerMs: 0,
+                },
+                {
+                    id: 'b',
+                    layoutAnchor: { x: 500, y: 300 },
+                    height: 120,
+                    staggerMs: 1000,
+                },
             ],
             { viewport, hardCeilingMs: 5000 },
         )
@@ -54,8 +64,18 @@ describe('pourInDrop (T2 — kinematic tween)', () => {
         const step = pourInDrop(
             world,
             [
-                { id: 'a', layoutAnchor: { x: 200, y: 200 }, height: 120, staggerMs: 0 },
-                { id: 'b', layoutAnchor: { x: 500, y: 300 }, height: 120, staggerMs: 200 },
+                {
+                    id: 'a',
+                    layoutAnchor: { x: 200, y: 200 },
+                    height: 120,
+                    staggerMs: 0,
+                },
+                {
+                    id: 'b',
+                    layoutAnchor: { x: 500, y: 300 },
+                    height: 120,
+                    staggerMs: 200,
+                },
             ],
             { viewport, hardCeilingMs: 5000 },
         )
@@ -85,7 +105,14 @@ describe('pourInDrop (T2 — kinematic tween)', () => {
         const tweenDurationMs = 600
         const step = pourInDrop(
             world,
-            [{ id: 'a', layoutAnchor: { x: 200, y: 200 }, height: 120, staggerMs: 0 }],
+            [
+                {
+                    id: 'a',
+                    layoutAnchor: { x: 200, y: 200 },
+                    height: 120,
+                    staggerMs: 0,
+                },
+            ],
             { viewport, tweenDurationMs, hardCeilingMs: 5000 },
         )
 
@@ -116,24 +143,31 @@ describe('pourInDrop (T2 — kinematic tween)', () => {
             { x: 200, y: 200 },
             { width: 240, height: 120 },
         )
-        world.tether(world.ceilingHandle, a, 200, { x: 200, y: 0 })
-        expect(world.listTetherRecords()).toHaveLength(1)
+        world.tether.add(world.ceilingHandle, a, 200, { x: 200, y: 0 })
+        expect(world.tether.records()).toHaveLength(1)
 
         const tweenDurationMs = 200
         const step = pourInDrop(
             world,
-            [{ id: 'a', layoutAnchor: { x: 200, y: 200 }, height: 120, staggerMs: 0 }],
+            [
+                {
+                    id: 'a',
+                    layoutAnchor: { x: 200, y: 200 },
+                    height: 120,
+                    staggerMs: 0,
+                },
+            ],
             { viewport, tweenDurationMs, hardCeilingMs: 5000 },
         )
 
         // Start: tether is untethered for the duration of the tween.
         step(0)
-        expect(world.listTetherRecords()).toHaveLength(0)
+        expect(world.tether.records()).toHaveLength(0)
 
         // Finish the tween.
         step(tweenDurationMs)
         // Body is at its anchor, velocity zero, tether re-wired with same params.
-        const after = world.listTetherRecords()
+        const after = world.tether.records()
         expect(after).toHaveLength(1)
         expect(after[0]?.parent).toBe(world.ceilingHandle)
         expect(after[0]?.child).toBe(a)
@@ -149,7 +183,14 @@ describe('pourInDrop (T2 — kinematic tween)', () => {
 
         const step = pourInDrop(
             world,
-            [{ id: 'a', layoutAnchor: { x: 200, y: 200 }, height: 120, staggerMs: 0 }],
+            [
+                {
+                    id: 'a',
+                    layoutAnchor: { x: 200, y: 200 },
+                    height: 120,
+                    staggerMs: 0,
+                },
+            ],
             { viewport, hardCeilingMs: 100 },
         )
 
@@ -171,14 +212,21 @@ describe('pourInDrop (T2 — kinematic tween)', () => {
             { x: 200, y: 200 },
             { width: 240, height: 120 },
         )
-        world.tether(world.ceilingHandle, a, 200, { x: 200, y: 0 })
+        world.tether.add(world.ceilingHandle, a, 200, { x: 200, y: 0 })
 
         // staggerMs is past the hard ceiling — the entry should never start
         // its tween, but the primitive must still leave the world in a valid
         // state (tether intact, body unstuck).
         const step = pourInDrop(
             world,
-            [{ id: 'a', layoutAnchor: { x: 200, y: 200 }, height: 120, staggerMs: 500 }],
+            [
+                {
+                    id: 'a',
+                    layoutAnchor: { x: 200, y: 200 },
+                    height: 120,
+                    staggerMs: 500,
+                },
+            ],
             { viewport, hardCeilingMs: 100 },
         )
 
@@ -190,6 +238,6 @@ describe('pourInDrop (T2 — kinematic tween)', () => {
         }
         expect(done).toBe(true)
         // Tether should still be there (or have been re-wired).
-        expect(world.listTetherRecords()).toHaveLength(1)
+        expect(world.tether.records()).toHaveLength(1)
     })
 })

--- a/web/src/transitions/primitives/pourInDrop.ts
+++ b/web/src/transitions/primitives/pourInDrop.ts
@@ -89,14 +89,14 @@ export function pourInDrop(
             if (handle === undefined) continue
 
             let captured: CapturedTether | undefined
-            for (const t of world.listTetherRecords()) {
+            for (const t of world.tether.records()) {
                 if (t.child !== handle) continue
                 captured = {
                     parent: t.parent,
                     length: t.length,
                     ...(t.anchorA ? { anchorA: { ...t.anchorA } } : {}),
                 }
-                world.untether(t.handle)
+                world.tether.remove(t.handle)
                 break
             }
 
@@ -127,7 +127,7 @@ export function pourInDrop(
         world.setDragging(s.handle, false)
         world.setVelocity(s.handle, { x: 0, y: 0 })
         if (s.captured) {
-            world.tether(
+            world.tether.add(
                 s.captured.parent,
                 s.handle,
                 s.captured.length,
@@ -151,10 +151,7 @@ export function pourInDrop(
             if (elapsedMs < entry.staggerMs) return
             s.tweenStartMs = entry.staggerMs
         }
-        const t = Math.min(
-            (elapsedMs - s.tweenStartMs) / tweenDurationMs,
-            1,
-        )
+        const t = Math.min((elapsedMs - s.tweenStartMs) / tweenDurationMs, 1)
         if (t >= 1) {
             finalize(entry, s)
             return

--- a/web/src/transitions/primitives/stringCutDrop.test.ts
+++ b/web/src/transitions/primitives/stringCutDrop.test.ts
@@ -24,14 +24,14 @@ describe('stringCutDrop (T1)', () => {
             { x: 400, y: 200 },
             { width: 200, height: 100 },
         )
-        world.tether(world.ceilingHandle, card, 150, { x: 0, y: 0 })
-        expect(world.listTetherRecords()).toHaveLength(1)
+        world.tether.add(world.ceilingHandle, card, 150, { x: 0, y: 0 })
+        expect(world.tether.records()).toHaveLength(1)
 
         const step = stringCutDrop(world, ['a'], { viewport })
 
         // First step performs setup (cuts tether)
         step(0)
-        expect(world.listTetherRecords()).toHaveLength(0)
+        expect(world.tether.records()).toHaveLength(0)
 
         const { done } = runUntil(step, world)
         expect(done).toBe(true)
@@ -52,13 +52,13 @@ describe('stringCutDrop (T1)', () => {
             { x: 400, y: 360 },
             { width: 200, height: 100 },
         )
-        world.tether(world.ceilingHandle, parent, 150, { x: 0, y: 0 })
-        world.tether(parent, child, 160)
-        expect(world.listTetherRecords()).toHaveLength(2)
+        world.tether.add(world.ceilingHandle, parent, 150, { x: 0, y: 0 })
+        world.tether.add(parent, child, 160)
+        expect(world.tether.records()).toHaveLength(2)
 
         const step = stringCutDrop(world, ['p', 'c'], { viewport })
         step(0)
-        const remaining = world.listTetherRecords()
+        const remaining = world.tether.records()
         expect(remaining).toHaveLength(1)
         expect(remaining[0]?.parent).toBe(parent)
         expect(remaining[0]?.child).toBe(child)
@@ -73,12 +73,15 @@ describe('stringCutDrop (T1)', () => {
             { width: 200, height: 100 },
         )
         world.setBuoyancy(balloon, 'balloon')
-        world.tether(world.floorHandle, balloon, 150, { x: 0, y: 0 })
+        world.tether.add(world.floorHandle, balloon, 150, { x: 0, y: 0 })
         const startY = world.getPosition(balloon).y
 
-        const step = stringCutDrop(world, ['b'], { viewport, hardCeilingMs: 5000 })
+        const step = stringCutDrop(world, ['b'], {
+            viewport,
+            hardCeilingMs: 5000,
+        })
         step(0)
-        expect(world.listTetherRecords()).toHaveLength(0)
+        expect(world.tether.records()).toHaveLength(0)
 
         const { done } = runUntil(step, world)
         expect(done).toBe(true)
@@ -142,13 +145,13 @@ describe('stringCutDrop (T1)', () => {
             { x: 600, y: 200 },
             { width: 200, height: 100 },
         )
-        world.tether(world.ceilingHandle, exiting, 150, { x: 0, y: 0 })
-        world.tether(world.ceilingHandle, incoming, 150, { x: 0, y: 0 })
+        world.tether.add(world.ceilingHandle, exiting, 150, { x: 0, y: 0 })
+        world.tether.add(world.ceilingHandle, incoming, 150, { x: 0, y: 0 })
 
         const step = stringCutDrop(world, ['old'], { viewport })
         step(0)
 
-        const remaining = world.listTetherRecords()
+        const remaining = world.tether.records()
         expect(remaining).toHaveLength(1)
         expect(remaining[0]?.child).toBe(incoming)
     })
@@ -167,8 +170,8 @@ describe('stringCutDrop (T1)', () => {
             { width: 200, height: 100 },
         )
         world.setBuoyancy(balloon, 'balloon')
-        world.tether(world.ceilingHandle, heavy, 150, { x: 0, y: 0 })
-        world.tether(world.floorHandle, balloon, 150, { x: 0, y: 0 })
+        world.tether.add(world.ceilingHandle, heavy, 150, { x: 0, y: 0 })
+        world.tether.add(world.floorHandle, balloon, 150, { x: 0, y: 0 })
 
         const step = stringCutDrop(world, ['h', 'b'], { viewport })
         step(0)

--- a/web/src/transitions/primitives/stringCutDrop.ts
+++ b/web/src/transitions/primitives/stringCutDrop.ts
@@ -1,4 +1,9 @@
-import type { PhysicsHandle, PhysicsWorld, Vec2, Viewport } from '../../physics/PhysicsWorld'
+import type {
+    PhysicsHandle,
+    PhysicsWorld,
+    Vec2,
+    Viewport,
+} from '../../physics/PhysicsWorld'
 import type { PrimitiveStep } from './types'
 
 export interface StringCutDropOpts {
@@ -49,13 +54,13 @@ export function stringCutDrop(
             // Cut only tethers belonging to *exiting* cards whose parent is the
             // ceiling or floor. Leaves new (incoming) cards' tethers intact so
             // they remain strung during the transition.
-            for (const t of world.listTetherRecords()) {
+            for (const t of world.tether.records()) {
                 if (
                     (t.parent === world.ceilingHandle ||
                         t.parent === world.floorHandle) &&
                     exitingHandles.has(t.child)
                 ) {
-                    world.untether(t.handle)
+                    world.tether.remove(t.handle)
                 }
             }
             // Phantom floor: push beyond viewport so exiting cards can fall


### PR DESCRIPTION
## Summary

- New `Tether` module behind a 4-method `BodyForceSource` interface — engine-neutral, end-to-end. `Tether.test.ts` runs without `matter-js`.
- `PhysicsWorld` `implements BodyForceSource`; holds `readonly tether: Tether`; `tick()` calls `this.tether.applyRopeForces()`.
- 14 entries removed from the public surface: 6 tether forwarders (`tether/untether/getTethers/getTetherList/subscribeTetherSetChange/listTetherRecords`) + 8 test-only methods (`register` → private, `registerStatic/applyImpulse/setSize/setAngle/setStatic/linkBodies/unlinkBodies`).
- Vestigial `Matter.Constraint` inside `tether()` deleted — Tether has zero `matter-js` dependency.
- `PhysicsWorld.ts`: 578 → 364 LOC.

## Notes / deviations

- **Scope widened to migrate three transition primitives.** Issue 108 enumerated three production consumers (`PhysicsCard`, `PhysicsCardImpl`, `StringLayer`) but `stringCutDrop`, `pourInDrop`, and `anchorSlide` also called the deprecated forwarders. Migrating only the named three would have left the forwarders in place, contradicting the "narrow surface" criterion. All six call sites are now on `world.tether.*` (mechanical rename only).
- **Public-surface count.** Issue projected "≤22 entries"; lands at **~24 methods + 3 readonly fields**. The gap is the three new `BodyForceSource` methods (`getMass`/`isStatic`/`applyForce`) that the `implements BodyForceSource` criterion requires PhysicsWorld to expose. Direction is the win (down from ~35), and the new surface is sharper — every method has a real production caller.
- **Read-side shape.** Tether's `records()` returns a cached frozen `ReadonlyArray<TetherRecord>` with stable identity until the set changes. Replaces both `getTetherList` (handles snapshot, used by `useSyncExternalStore`) and `listTetherRecords` (record contents) with one method. `StringLayer` now uses `records()` for both the React keys and the subscribe-store snapshot.
- **Vestigial constraint** deleted per Issue 108 §6 verification path. Test suite (561 passed) + the two retained integration smokes ("stretched body settles near tether length", "anchorA holds child near offset world point") confirm no regression. The dev-server visual smoke (pendulum settle on Lifelog, strings render, cascade-minimize) is left for the human reviewer.
- **ADR-0001 untouched.** This is internal-shape; the behaviour spec is unchanged. **CONTEXT.md unchanged** — the `Tether`/`BodyForceSource` vocabulary was already documented during the 2026-05-13 grill.

## Acceptance criteria

- [x] `web/src/physics/BodyForceSource.ts` exists as a type-only module.
- [x] `web/src/physics/Tether.ts` exists; owns the rope-force math.
- [x] `PhysicsWorld implements BodyForceSource`.
- [x] `PhysicsWorld.ts` outward public surface ≤ 22 entries → actually 24 methods + 3 readonly fields; see Notes for the gap explanation.
- [x] `PhysicsWorld.ts` LOC drops by ≥ 80 lines → dropped 214 (578 → 364).
- [x] `Tether.test.ts` runs without instantiating `PhysicsWorld` or importing `matter-js` (verified by grep).
- [x] All three production consumers (`PhysicsCard`, `PhysicsCardImpl`, `StringLayer`) migrated to the new seam — plus the three transition primitives noted in Deviations.
- [x] Vestigial-constraint check performed; result recorded: **deleted** (test suite + integration smokes pass).
- [ ] `CONTEXT.md` updated if any term sharpens during implementation — N/A (no term sharpened; both Tether and BodyForceSource entries already match the implementation).
- [ ] No production behaviour change verifiable on the Lifelog route — **left for the human reviewer** (sandbox blocks `npm run dev` on port 5173 in this session).

## Test plan

1. `cd web && npm run typecheck && npm run test && npm run build` — all green locally (561 tests passing, 1 pre-existing skip unrelated to this PR).
2. `npm run dev` → Lifelog route. Drag a strung note card; release; confirm pendulum settle is identical to pre-refactor. Confirm strings render. **(Human reviewer step.)**
3. `/sandbox/strings` if still present — all four scenarios behave as before. **(Human reviewer step.)**
4. Spot-check `<StringLayer>` re-renders correctly when a tether is added or removed (e.g., during a route transition that cuts tethers). **(Human reviewer step.)**
5. Smoke a route transition that uses `stringCutDrop` — confirm the primitive still functions after the seam migration. **(Human reviewer step.)**

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)