### PR TITLE
docs: add CardLifecycle / Director / Primitive / Armed vocab to CONTEXT.md

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -63,6 +63,51 @@ layout anchor, optional `parent` (another `cardId` or `'ceiling'` /
 `'floor'`), and content.
 _Avoid_: card config, card data.
 
+### Card lifecycle
+
+The three states below combine orthogonally with **Strung** / **Detached**
+— a **Card** has both a lifecycle state and a tether state at all times.
+
+**Spawning** (lifecycle):
+A **Card** state from `register` until first activation. The body exists
+in the **PhysicsWorld** but its position is not yet authoritative, and
+the rendered article is hidden (`visibility:hidden`). Two paths out:
+either the **Director** calls `activate(id)` after a transition
+**Primitive** has positioned the body, or — when the registry is not
+**Armed** — its default policy schedules `activate(id)` on the next
+microtask.
+_Avoid_: loading, pending, hidden (hidden is a render consequence of
+the state, not the state itself).
+
+**Active** (lifecycle):
+A **Card** state where the body is autonomous in the **PhysicsWorld**
+(subject to gravity, **Tether** forces, drag input) and the rendered
+article is visible. The default state after **Spawning** resolves.
+_Avoid_: mounted, alive.
+
+**Exiting** (lifecycle):
+A **Card** state set by the **Director** when a route transition begins.
+The card survives its React component's unmount: the registry refuses
+to delete an **Exiting** card until the **Director** explicitly calls
+`release(id)`. Visible and still in the **PhysicsWorld** throughout.
+_Avoid_: leaving, unmounting.
+
+**CardLifecycle**:
+The three-state machine `spawning → active → exiting → (released)`.
+State transitions are owned by the **Director** and the registry alone;
+routes and components do not set lifecycle states directly. Illegal
+transitions (e.g. `active → spawning`, double-activate) throw.
+_Avoid_: card phase, card mode.
+
+**Armed** (registry state):
+The registry is **Armed** from when the **Director** calls `arm()` at the
+start of a route transition until it calls `disarm()` after releasing
+exiting cards. While **Armed**, the registry does *not* auto-activate
+**Spawning** cards — the **Director** owns activation timing via
+**Primitive**s. While not **Armed**, `register()` schedules `activate(id)`
+on the next microtask (default policy, used on initial page load).
+_Avoid_: in-transition (drift), busy.
+
 ### Architecture
 
 **BodyForceSource**:
@@ -74,6 +119,25 @@ bodies during route transitions.
 _Avoid_: BodyDriver (reserve that name for the primitives-side superset
 when it grows mutators like `setDragging`/`setPosition`), engine adapter.
 
+**Director**:
+The single coordinator that arms route transitions on navigation,
+advances **Card**s through their **CardLifecycle**, dispatches
+**Primitive**s, and releases exiting cards. Today: `TransitionDirector.tsx`.
+The **Director** is the only thing that drives lifecycle transitions
+other than the registry's default-policy auto-activate on initial mount.
+_Avoid_: transition manager (drift), router controller (routing belongs
+to react-router-dom; the **Director** consumes location changes, doesn't
+own routing).
+
+**Primitive**:
+A named animation step that drives bodies during a route transition.
+Examples: `pour-in-drop`, `string-cut-drop`, `anchor-slide`,
+`cross-fade`. Each **Primitive** is a `PrimitiveStep` — a per-tick
+function returning whether it has completed. Composed by the
+**Director** per the route's **PageDef**.
+_Avoid_: step (too generic), animation (used for non-route animations
+like FrameBar idle).
+
 ## Relationships
 
 - A **Card** has at most one **Tether** to a parent; multiple **Card**s can
@@ -84,6 +148,27 @@ when it grows mutators like `setDragging`/`setPosition`), engine adapter.
   **Tether** topology for its route — neither is mutated at runtime.
 - **Tether** depends on **BodyForceSource**; `PhysicsWorld` satisfies that
   interface.
+- A **Card**'s **CardLifecycle** (Spawning / Active / Exiting) is
+  orthogonal to its tether state (**Strung** / **Detached**). Both apply
+  at all times. A card can be `Spawning + Strung`, `Active + Detached`,
+  etc.
+- The **Director** owns **CardLifecycle** transitions: `register →
+  spawning` by default; `activate(id)` for `spawning → active`;
+  `markExiting(id)` for `active → exiting`; `release(id)` for `exiting →
+  (deleted)`. The registry rejects `requestUnregister` on **Exiting**
+  cards — only `release(id)` deletes them. This is what lets cards
+  survive their route's React unmount.
+
+## Load-bearing invariants
+
+- **I-1: a Spawning Card never paints.** The renderer marks **Spawning**
+  cards `visibility:hidden`. The **Director** must position the body
+  before calling `activate(id)`. Was previously enforced by RAF ordering
+  and a prose comment in `PhysicsCardImpl`; now a property of the
+  lifecycle state and asserted directly in tests.
+- **I-2: Exiting survives unmount.** When a route navigates away, the
+  **Director** marks every **Active** **Card** as **Exiting** *before*
+  React commits the unmount (`useLayoutEffect`, not `useEffect`).
 
 ## Example dialogue
 


### PR DESCRIPTION
## Summary

- Extends [CONTEXT.md](CONTEXT.md) with the domain vocabulary that crystallised during the `/improve-codebase-architecture` grill of Candidate 2 in `docs/architecture-deepening.md` (2026-05-13 session).
- New terms: **Spawning**, **Active**, **Exiting**, **CardLifecycle**, **Armed**, **Director**, **Primitive**.
- New "Load-bearing invariants" section names the two contracts that previously lived only in RAF call ordering and a prose comment in `PhysicsCardImpl`: **I-1** (a Spawning Card never paints) and **I-2** (Exiting survives unmount).
- No code changes. The slice that implements the shape these terms describe is tracked in #111.

## Notes / deviations

- Lifecycle terms are introduced as a new `### Card lifecycle` subsection under "Foreground physics" (next to **Card** itself). They combine orthogonally with the tether-state terms (**Strung** / **Detached**) — a card has both a lifecycle state and a tether state at all times. The Relationships section calls out this orthogonality.
- `Director` and `Primitive` go under "Architecture" because they're module-level roles, not foreground-physics concepts. Today: `Director` ≡ `TransitionDirector.tsx`.
- The CardLifecycle definition records the rule that illegal transitions throw — pinned during grilling so future drift doesn't quietly reintroduce silent no-ops.

## Acceptance criteria

(Copied from the conversational close-out, not from an issue — no acceptance checklist exists upstream for this docs-only change.)

- [x] Lifecycle terms named with definitions, `_Avoid_` aliases, and orthogonality note.
- [x] `Armed` named as the registry-state that gates default-policy auto-activate.
- [x] `Director` and `Primitive` added with the working code identifier called out.
- [x] Both load-bearing invariants (I-1, I-2) named with the mechanism that currently enforces them and the mechanism that will enforce them after #111.
- [x] No code changes; pure docs.

## Test plan

- [ ] Read [CONTEXT.md](CONTEXT.md) end-to-end and confirm the new section reads cleanly alongside the existing terms.
- [ ] Open #111 and confirm the issue body's references to CONTEXT.md vocabulary line up with what's actually there.
- [ ] Confirm no production / test files were touched: `git diff main..HEAD --stat` should show only `CONTEXT.md`.

Refs #111