### PR TITLE
Slice 111: CardLifecycle spawning state (#111)

### DIFF
--- a/web/src/physics/PhysicsWorld.ts
+++ b/web/src/physics/PhysicsWorld.ts
@@ -216,6 +216,18 @@ export class PhysicsWorld implements BodyForceSource {
         if (!reg) throw new Error(`PhysicsWorld: unknown handle ${handle}`)
         Matter.Body.setPosition(reg.body, position)
         Matter.Body.setVelocity(reg.body, { x: 0, y: 0 })
+        // Synchronously notify the renderer so el.style.transform reflects
+        // the new position before any state change that would unhide the
+        // article. Without this, the next world.tick lags one frame and
+        // pour-in's activate fires while the DOM transform still points at
+        // the previous (layout-anchor) position.
+        if (reg.onTransform) {
+            reg.onTransform({
+                x: reg.body.position.x,
+                y: reg.body.position.y,
+                rotation: reg.body.angle,
+            })
+        }
     }
 
     setGravityDirection(dir: Cardinal): void {

--- a/web/src/transitions/CardRegistry.test.tsx
+++ b/web/src/transitions/CardRegistry.test.tsx
@@ -27,11 +27,12 @@ const entryB: RegisterArgs = {
 }
 
 describe('CardRegistry', () => {
-    test('register adds an entry visible in snapshot', () => {
+    test('register adds an entry visible in snapshot', async () => {
         const { result } = renderHook(() => useCardRegistry(), { wrapper })
 
-        act(() => {
+        await act(async () => {
             result.current.register(entryA)
+            await Promise.resolve()
         })
 
         const entries = result.current.snapshot()

--- a/web/src/transitions/CardRegistry.tsx
+++ b/web/src/transitions/CardRegistry.tsx
@@ -8,7 +8,7 @@ import {
 import type { Buoyancy, ParentRef } from '../physics/PageDef'
 import type { CardContent } from '../physics/PhysicsPage'
 
-export type CardLifecycle = 'active' | 'exiting'
+export type CardLifecycle = 'spawning' | 'active' | 'exiting'
 
 export interface PhysicsCardEntry {
     id: string
@@ -27,15 +27,19 @@ export interface CardRegistryAPI {
     register(entry: RegisterArgs): void
     requestUnregister(id: string): void
     markExiting(id: string): void
+    activate(id: string): void
+    arm(): void
+    disarm(): void
     release(id: string): void
     snapshot(): readonly PhysicsCardEntry[]
     subscribe(cb: () => void): () => void
 }
 
-class CardRegistryStore {
+export class CardRegistryStore {
     private entries = new Map<string, PhysicsCardEntry>()
     private listeners = new Set<() => void>()
     private cachedSnapshot: readonly PhysicsCardEntry[] | null = null
+    private armed = false
 
     subscribe = (cb: () => void): (() => void) => {
         this.listeners.add(cb)
@@ -53,8 +57,38 @@ class CardRegistryStore {
 
     register = (args: RegisterArgs): void => {
         const existing = this.entries.get(args.id)
-        const state: CardLifecycle = existing?.state ?? 'active'
+        const state: CardLifecycle = existing?.state ?? 'spawning'
         this.entries.set(args.id, { ...args, state })
+        this.invalidate()
+        if (!existing && !this.armed) {
+            queueMicrotask(() => {
+                const e = this.entries.get(args.id)
+                if (e?.state === 'spawning') this.activate(args.id)
+            })
+        }
+    }
+
+    arm = (): void => {
+        this.armed = true
+    }
+
+    disarm = (): void => {
+        this.armed = false
+    }
+
+    activate = (id: string): void => {
+        const e = this.entries.get(id)
+        if (!e) {
+            throw new Error(
+                `CardRegistry.activate: no entry for id "${id}"`,
+            )
+        }
+        if (e.state !== 'spawning') {
+            throw new Error(
+                `CardRegistry.activate: illegal transition ${e.state} → active for id "${id}"`,
+            )
+        }
+        this.entries.set(id, { ...e, state: 'active' })
         this.invalidate()
     }
 

--- a/web/src/transitions/CardRegistry.tsx
+++ b/web/src/transitions/CardRegistry.tsx
@@ -77,6 +77,13 @@ export class CardRegistryStore {
 
     disarm = (): void => {
         this.armed = false
+        // Sweep any cards left in 'spawning' that the active transition's
+        // primitive didn't activate (typical for routes whose card set
+        // materialises asynchronously after the Director has already
+        // dispatched). Without this, they render visibility:hidden forever.
+        for (const [id, e] of this.entries) {
+            if (e.state === 'spawning') this.activate(id)
+        }
     }
 
     activate = (id: string): void => {

--- a/web/src/transitions/CardRegistry.tsx
+++ b/web/src/transitions/CardRegistry.tsx
@@ -23,11 +23,14 @@ export interface PhysicsCardEntry {
 
 export type RegisterArgs = Omit<PhysicsCardEntry, 'state'>
 
-export interface CardRegistryAPI {
+export interface CardActivator {
+    activate(id: string): void
+}
+
+export interface CardRegistryAPI extends CardActivator {
     register(entry: RegisterArgs): void
     requestUnregister(id: string): void
     markExiting(id: string): void
-    activate(id: string): void
     arm(): void
     disarm(): void
     release(id: string): void

--- a/web/src/transitions/CardRegistryStore.test.ts
+++ b/web/src/transitions/CardRegistryStore.test.ts
@@ -99,6 +99,27 @@ describe('CardRegistryStore state machine', () => {
         expect(store.snapshot()).toHaveLength(0)
     })
 
+    test('disarm() activates EVERY card left spawning (chain coverage)', () => {
+        const store = new CardRegistryStore()
+        store.arm()
+        const idsList = ['a', 'b', 'c', 'd', 'e'] as const
+        for (const id of idsList) {
+            store.register({ ...entryA, id })
+        }
+        // All armed → all spawning.
+        for (const id of idsList) {
+            expect(
+                store.snapshot().find((e) => e.id === id)?.state,
+            ).toBe('spawning')
+        }
+        store.disarm()
+        for (const id of idsList) {
+            expect(
+                store.snapshot().find((e) => e.id === id)?.state,
+            ).toBe('active')
+        }
+    })
+
     test('disarm() activates any cards left spawning by the primitive', () => {
         // Covers the case where a card registers WHILE armed (transition in
         // flight) but the primitive that owns activation never sees it —

--- a/web/src/transitions/CardRegistryStore.test.ts
+++ b/web/src/transitions/CardRegistryStore.test.ts
@@ -1,0 +1,101 @@
+import { describe, test, expect } from 'vitest'
+import { CardRegistryStore } from './CardRegistry'
+import type { RegisterArgs } from './CardRegistry'
+
+const entryA: RegisterArgs = {
+    id: 'a',
+    parent: 'ceiling',
+    kind: 'headline',
+    buoyancy: 'heavy',
+    anchor: { x: 100, y: 100 },
+    content: { text: 'hello', width: 200, height: 100 },
+}
+
+describe('CardRegistryStore state machine', () => {
+    test('register enters a new card in spawning state', () => {
+        const store = new CardRegistryStore()
+        store.arm()
+        store.register(entryA)
+        expect(store.snapshot()[0]?.state).toBe('spawning')
+    })
+
+    test('register without arm auto-activates via microtask', async () => {
+        const store = new CardRegistryStore()
+        store.register(entryA)
+        expect(store.snapshot()[0]?.state).toBe('spawning')
+        await Promise.resolve()
+        expect(store.snapshot()[0]?.state).toBe('active')
+    })
+
+    test('arm() suppresses auto-activate', async () => {
+        const store = new CardRegistryStore()
+        store.arm()
+        store.register(entryA)
+        await Promise.resolve()
+        expect(store.snapshot()[0]?.state).toBe('spawning')
+    })
+
+    test('disarm() restores auto-activate for subsequent registers', async () => {
+        const store = new CardRegistryStore()
+        store.arm()
+        store.disarm()
+        store.register(entryA)
+        await Promise.resolve()
+        expect(store.snapshot()[0]?.state).toBe('active')
+    })
+
+    test('activate() promotes spawning → active', () => {
+        const store = new CardRegistryStore()
+        store.arm()
+        store.register(entryA)
+        store.activate('a')
+        expect(store.snapshot()[0]?.state).toBe('active')
+    })
+
+    test('activate() throws on missing id', () => {
+        const store = new CardRegistryStore()
+        expect(() => store.activate('nope')).toThrow(/nope/)
+    })
+
+    test('activate() throws on already-active card', () => {
+        const store = new CardRegistryStore()
+        store.arm()
+        store.register(entryA)
+        store.activate('a')
+        expect(() => store.activate('a')).toThrow(/active.*active|illegal.*active/i)
+    })
+
+    test('activate() throws on exiting card', () => {
+        const store = new CardRegistryStore()
+        store.arm()
+        store.register(entryA)
+        store.markExiting('a')
+        expect(() => store.activate('a')).toThrow(/exiting.*active|illegal.*active/i)
+    })
+
+    test('markExiting accepts a spawning card', () => {
+        const store = new CardRegistryStore()
+        store.arm()
+        store.register(entryA)
+        store.markExiting('a')
+        expect(store.snapshot()[0]?.state).toBe('exiting')
+    })
+
+    test('auto-activate microtask is a no-op when card was marked exiting first', async () => {
+        const store = new CardRegistryStore()
+        store.register(entryA)
+        store.markExiting('a')
+        expect(store.snapshot()[0]?.state).toBe('exiting')
+        await Promise.resolve()
+        expect(store.snapshot()[0]?.state).toBe('exiting')
+    })
+
+    test('release on exiting card removes it', () => {
+        const store = new CardRegistryStore()
+        store.arm()
+        store.register(entryA)
+        store.markExiting('a')
+        store.release('a')
+        expect(store.snapshot()).toHaveLength(0)
+    })
+})

--- a/web/src/transitions/CardRegistryStore.test.ts
+++ b/web/src/transitions/CardRegistryStore.test.ts
@@ -98,4 +98,19 @@ describe('CardRegistryStore state machine', () => {
         store.release('a')
         expect(store.snapshot()).toHaveLength(0)
     })
+
+    test('disarm() activates any cards left spawning by the primitive', () => {
+        // Covers the case where a card registers WHILE armed (transition in
+        // flight) but the primitive that owns activation never sees it —
+        // e.g. routes whose card set materialises asynchronously after the
+        // Director has already snapshotted the registry. On disarm, these
+        // orphans must be promoted so they don't render visibility:hidden
+        // forever.
+        const store = new CardRegistryStore()
+        store.arm()
+        store.register(entryA)
+        expect(store.snapshot()[0]?.state).toBe('spawning')
+        store.disarm()
+        expect(store.snapshot()[0]?.state).toBe('active')
+    })
 })

--- a/web/src/transitions/PhysicsCardImpl.test.tsx
+++ b/web/src/transitions/PhysicsCardImpl.test.tsx
@@ -33,7 +33,7 @@ function makeEntry(
             variant: 'default',
             ...(overrides.content ?? {}),
         },
-        state: 'active',
+        state: overrides.state ?? 'active',
     }
 }
 
@@ -115,9 +115,9 @@ describe('PhysicsCardImpl — article shape & data attrs', () => {
     })
 })
 
-describe('PhysicsCardImpl — first-paint reveal gate', () => {
-    test('article is rendered with visibility: hidden inline before the first RAF', () => {
-        const entry = makeEntry({ id: 'reveal-1' })
+describe('PhysicsCardImpl — lifecycle visibility (I-1)', () => {
+    test('article has visibility: hidden while entry.state === "spawning"', () => {
+        const entry = makeEntry({ id: 'spawning-1', state: 'spawning' })
         const { container } = renderWith(<PhysicsCardImpl entry={entry} />)
         const article = container.querySelector(
             'article.physics-card',
@@ -126,10 +126,9 @@ describe('PhysicsCardImpl — first-paint reveal gate', () => {
         expect(article.style.visibility).toBe('hidden')
     })
 
-    test('after one RAF the visibility override is cleared', async () => {
-        const entry = makeEntry({ id: 'reveal-2' })
+    test('article visibility is not hidden when entry.state === "active"', () => {
+        const entry = makeEntry({ id: 'active-1', state: 'active' })
         const { container } = renderWith(<PhysicsCardImpl entry={entry} />)
-        await flushRaf()
         const article = container.querySelector(
             'article.physics-card',
         ) as HTMLElement

--- a/web/src/transitions/PhysicsCardImpl.tsx
+++ b/web/src/transitions/PhysicsCardImpl.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef } from 'react'
 import { usePhysicsWorld } from '../physics/PhysicsContext'
 import {
     useIsMinimized,
@@ -48,22 +48,6 @@ export function PhysicsCardImpl({ entry }: PhysicsCardImplProps) {
 
     const registry = useMinimizedRegistry()
     const isMinimized = useIsMinimized(minimizable ? id : undefined)
-
-    // Hide the article for the first frame after mount. If this card is the
-    // incoming side of a pour-in transition, the pour-in primitive's RAF
-    // (scheduled in TransitionDirector's useEffect *before* this impl mounts
-    // in the deferred PhysicsLayer re-render) fires first and teleports the
-    // body above the viewport. By the time we flip `revealed` true on the
-    // next frame, the body is already in its pre-spawn position and the
-    // user never sees a paint at the layout anchor. For non-transition
-    // mounts (initial page load, post-resize) the cost is one frame of
-    // invisibility — imperceptible.
-    const [revealed, setRevealed] = useState(false)
-    useEffect(() => {
-        if (revealed) return
-        const raf = requestAnimationFrame(() => setRevealed(true))
-        return () => cancelAnimationFrame(raf)
-    }, [revealed])
 
     useEffect(() => {
         if (isMinimized) return
@@ -294,9 +278,6 @@ export function PhysicsCardImpl({ entry }: PhysicsCardImplProps) {
         if (!el) return
         const fromChipRect = registry.consumeRestoreRect(id)
         if (!fromChipRect) return
-        // Restore-from-chip needs the article visible so flipMorph animates
-        // an actual painted element. Bypass the first-frame reveal gate.
-        setRevealed(true)
         const endTransform = el.style.transform
         requestAnimationFrame(() => {
             flipMorph(fromChipRect, el, { opacityFrom: 0.5, endTransform })
@@ -323,7 +304,11 @@ export function PhysicsCardImpl({ entry }: PhysicsCardImplProps) {
             className={cls}
             data-variant={variant}
             data-card-id={id}
-            style={revealed ? style : { ...style, visibility: 'hidden' }}
+            style={
+                entry.state === 'spawning'
+                    ? { ...style, visibility: 'hidden' }
+                    : style
+            }
         >
             {showHeader ? (
                 <div data-card-header>

--- a/web/src/transitions/TransitionDirector.test.tsx
+++ b/web/src/transitions/TransitionDirector.test.tsx
@@ -119,32 +119,36 @@ describe('TransitionDirector — orphan card survival', () => {
     })
 })
 
-describe('TransitionDirector — lifecycle arming', () => {
-    test('newly-registered cards remain spawning across a microtask flush during a transition', async () => {
-        const { container, getByTestId } = render(<Harness />)
+async function flushRafs(count: number) {
+    for (let i = 0; i < count; i++) {
+        await act(async () => {
+            await new Promise<void>((r) =>
+                requestAnimationFrame(() => r(undefined)),
+            )
+        })
+    }
+}
 
-        // Let card-a's initial auto-activate microtask settle.
+describe('TransitionDirector — lifecycle arming', () => {
+    test('after the transition primitive runs, entering cards are no longer hidden', async () => {
+        const { container, getByTestId } = render(<Harness />)
         await act(async () => {
             await Promise.resolve()
         })
 
-        act(() => {
+        await act(async () => {
             getByTestId('go-b').click()
         })
-
-        // Flush microtasks — without arm(), card-b's default-policy
-        // auto-activate would fire here and the article would become
-        // visible. With arm() in the director's Phase-1 effect, the
-        // registry suppresses the microtask and card-b stays spawning.
-        await act(async () => {
-            await Promise.resolve()
-        })
+        // Drive enough RAFs for the transition primitive to step through
+        // its activate path. anchorSlide / pourInDrop call activate on
+        // first tick; the run-loop wraps each step in a RAF.
+        await flushRafs(4)
 
         const cardB = container.querySelector(
             '[data-card-id="card-b"]',
         ) as HTMLElement
         expect(cardB).toBeTruthy()
-        expect(cardB.style.visibility).toBe('hidden')
+        expect(cardB.style.visibility).not.toBe('hidden')
     })
 })
 

--- a/web/src/transitions/TransitionDirector.test.tsx
+++ b/web/src/transitions/TransitionDirector.test.tsx
@@ -119,6 +119,35 @@ describe('TransitionDirector — orphan card survival', () => {
     })
 })
 
+describe('TransitionDirector — lifecycle arming', () => {
+    test('newly-registered cards remain spawning across a microtask flush during a transition', async () => {
+        const { container, getByTestId } = render(<Harness />)
+
+        // Let card-a's initial auto-activate microtask settle.
+        await act(async () => {
+            await Promise.resolve()
+        })
+
+        act(() => {
+            getByTestId('go-b').click()
+        })
+
+        // Flush microtasks — without arm(), card-b's default-policy
+        // auto-activate would fire here and the article would become
+        // visible. With arm() in the director's Phase-1 effect, the
+        // registry suppresses the microtask and card-b stays spawning.
+        await act(async () => {
+            await Promise.resolve()
+        })
+
+        const cardB = container.querySelector(
+            '[data-card-id="card-b"]',
+        ) as HTMLElement
+        expect(cardB).toBeTruthy()
+        expect(cardB.style.visibility).toBe('hidden')
+    })
+})
+
 describe('TransitionDirector — provider mount', () => {
     test('mounts and unmounts without throwing', () => {
         function Inner() {

--- a/web/src/transitions/TransitionDirector.test.tsx
+++ b/web/src/transitions/TransitionDirector.test.tsx
@@ -1,6 +1,6 @@
 import { describe, test, expect, afterEach } from 'vitest'
 import { render, cleanup, act } from '@testing-library/react'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { MemoryRouter, Routes, Route, useNavigate } from 'react-router-dom'
 import { PhysicsProvider } from '../physics/PhysicsContext'
 import { TransitionDirector } from './TransitionDirector'
@@ -68,6 +68,35 @@ function RouteB() {
     )
 }
 
+// Mimics BlogIndex: starts with zero cards, populates a chain in useEffect.
+function RouteBlogLike() {
+    const [chain, setChain] = useState<
+        Array<{ id: string; parent: string | null }>
+    >([])
+    useEffect(() => {
+        setChain([
+            { id: 'chain-1', parent: 'ceiling' },
+            { id: 'chain-2', parent: 'chain-1' },
+            { id: 'chain-3', parent: 'chain-2' },
+        ])
+    }, [])
+    return (
+        <>
+            {chain.map((card, i) => (
+                <PhysicsCard
+                    key={card.id}
+                    id={card.id}
+                    text={`chain ${i}`}
+                    width={200}
+                    height={100}
+                    anchor={{ x: 200, y: 100 + i * 150 }}
+                    parent={card.parent ?? undefined}
+                />
+            ))}
+        </>
+    )
+}
+
 function NavigateButton({ to, label }: { to: string; label: string }) {
     const nav = useNavigate()
     return (
@@ -86,9 +115,11 @@ function Harness() {
                         <PhysicsLayer />
                         <NavigateButton to="/a" label="go-a" />
                         <NavigateButton to="/b" label="go-b" />
+                        <NavigateButton to="/blog" label="go-blog" />
                         <Routes>
                             <Route path="/a" element={<RouteA />} />
                             <Route path="/b" element={<RouteB />} />
+                            <Route path="/blog" element={<RouteBlogLike />} />
                         </Routes>
                     </TransitionDirector>
                 </PageDefRegistryProvider>
@@ -130,6 +161,43 @@ async function flushRafs(count: number) {
 }
 
 describe('TransitionDirector — lifecycle arming', () => {
+    test('chain cards mount + auto-activate when no transition is in flight', async () => {
+        // Render harness starting directly at /blog so no transition fires.
+        // Cards register unarmed → microtask → activate.
+        function BlogHarness() {
+            return (
+                <MemoryRouter initialEntries={['/blog']}>
+                    <PhysicsProvider>
+                        <PageDefRegistryProvider>
+                            <TransitionDirector pageDefs={pageDefs}>
+                                <PhysicsLayer />
+                                <Routes>
+                                    <Route path="/blog" element={<RouteBlogLike />} />
+                                </Routes>
+                            </TransitionDirector>
+                        </PageDefRegistryProvider>
+                    </PhysicsProvider>
+                </MemoryRouter>
+            )
+        }
+        const { container } = render(<BlogHarness />)
+        await act(async () => {
+            await Promise.resolve()
+        })
+        await flushRafs(2)
+
+        for (const id of ['chain-1', 'chain-2', 'chain-3']) {
+            const el = container.querySelector(
+                `[data-card-id="${id}"]`,
+            ) as HTMLElement | null
+            expect(el, `card ${id} should be in DOM`).toBeTruthy()
+            expect(
+                el?.style.visibility,
+                `card ${id} should not be visibility:hidden`,
+            ).not.toBe('hidden')
+        }
+    })
+
     test('after the transition primitive runs, entering cards are no longer hidden', async () => {
         const { container, getByTestId } = render(<Harness />)
         await act(async () => {

--- a/web/src/transitions/TransitionDirector.tsx
+++ b/web/src/transitions/TransitionDirector.tsx
@@ -9,7 +9,11 @@ import {
 } from 'react'
 import { useLocation, useNavigationType, type Location } from 'react-router-dom'
 import { usePhysicsWorld } from '../physics/PhysicsContext'
-import { useCardRegistry, type PhysicsCardEntry } from './CardRegistry'
+import {
+    useCardRegistry,
+    type CardActivator,
+    type PhysicsCardEntry,
+} from './CardRegistry'
 import { classifyDirection, type NavigationType } from './classifyDirection'
 import {
     dispatch,
@@ -131,7 +135,11 @@ export function TransitionDirector({
                 releaseFromIds()
                 const layerEl = findPhysicsLayerElement()
                 if (layerEl) {
-                    await runStep(crossFade(layerEl, { durationMs: REDUCED_MOTION_MS }))
+                    await runStep(
+                        crossFade(layerEl, registry, toIds, {
+                            durationMs: REDUCED_MOTION_MS,
+                        }),
+                    )
                 }
                 return
             }
@@ -139,6 +147,7 @@ export function TransitionDirector({
             if (plan.kind === 'coupled') {
                 const step = anchorSlide(
                     world,
+                    registry,
                     { fromIds, toIds },
                     { ...plan.config, viewport },
                 )
@@ -151,6 +160,7 @@ export function TransitionDirector({
             const exitStep = buildPrimitive(
                 plan.exit,
                 world,
+                registry,
                 viewport,
                 fromIds,
                 pourEntries,
@@ -158,6 +168,7 @@ export function TransitionDirector({
             const enterStep = buildPrimitive(
                 plan.enter,
                 world,
+                registry,
                 viewport,
                 fromIds,
                 pourEntries,
@@ -268,22 +279,22 @@ export function TransitionDirector({
 function buildPrimitive(
     id: TransitionId,
     world: ReturnType<typeof usePhysicsWorld>,
+    activator: CardActivator,
     viewport: Viewport,
     fromIds: readonly string[],
     toEntries: readonly PourInDropEntry[],
 ): PrimitiveStep {
+    const toIds = toEntries.map((e) => e.id)
     switch (id) {
         case 'string-cut-drop':
             return stringCutDrop(world, fromIds, { viewport })
         case 'pour-in-drop':
-            return pourInDrop(world, toEntries, { viewport })
+            return pourInDrop(world, activator, toEntries, { viewport })
         case 'anchor-slide':
             return anchorSlide(
                 world,
-                {
-                    fromIds,
-                    toIds: toEntries.map((e) => e.id),
-                },
+                activator,
+                { fromIds, toIds },
                 {
                     axis: 'horizontal',
                     sign: 1,
@@ -294,7 +305,9 @@ function buildPrimitive(
         case 'cross-fade': {
             const el = findPhysicsLayerElement()
             if (!el) return () => true
-            return crossFade(el, { durationMs: REDUCED_MOTION_MS })
+            return crossFade(el, activator, toIds, {
+                durationMs: REDUCED_MOTION_MS,
+            })
         }
     }
 }

--- a/web/src/transitions/TransitionDirector.tsx
+++ b/web/src/transitions/TransitionDirector.tsx
@@ -228,7 +228,7 @@ export function TransitionDirector({
         const { trigger } = isTransitionTrigger(prev, location)
         if (!trigger) return
         for (const entry of registry.snapshot()) {
-            if (entry.state === 'active') registry.markExiting(entry.id)
+            if (entry.state !== 'exiting') registry.markExiting(entry.id)
         }
     }, [location, registry, isTransitionTrigger])
 

--- a/web/src/transitions/TransitionDirector.tsx
+++ b/web/src/transitions/TransitionDirector.tsx
@@ -115,16 +115,22 @@ export function TransitionDirector({
     const executeTransition = useCallback(
         async (_fromPath: string, _toPath: string, plan: TransitionPlan) => {
             // Source of truth is the registry: cards marked `exiting` belong
-            // to the outgoing route; cards still `active` are the incoming
-            // ones registered by the newly-mounted route's <PhysicsCard>s.
+            // to the outgoing route; cards still `spawning` are the incoming
+            // ones registered by the newly-mounted route's <PhysicsCard>s
+            // (Director Armed before they registered, so default-policy
+            // auto-activate is suppressed and the primitive owns activation).
             // This lets routes that aren't listed in `pageDefs` (e.g. /blog,
             // dynamic slug pages) participate in the standard transition.
             const snapshot = registry.snapshot()
             const exitingEntries = snapshot.filter((e) => e.state === 'exiting')
-            const activeEntries = snapshot.filter((e) => e.state === 'active')
+            const enteringEntries = snapshot.filter(
+                (e) => e.state === 'spawning',
+            )
             const fromIds = exitingEntries.map((e) => e.id)
-            const toIds = activeEntries.map((e) => e.id)
-            const pourEntries = activeEntries.map((e, i) => makePourEntry(e, i))
+            const toIds = enteringEntries.map((e) => e.id)
+            const pourEntries = enteringEntries.map((e, i) =>
+                makePourEntry(e, i),
+            )
             const viewport = getViewport()
 
             const releaseFromIds = () => {

--- a/web/src/transitions/TransitionDirector.tsx
+++ b/web/src/transitions/TransitionDirector.tsx
@@ -129,6 +129,7 @@ export function TransitionDirector({
 
             const releaseFromIds = () => {
                 for (const id of fromIds) registry.release(id)
+                registry.disarm()
             }
 
             if (reducedRef.current) {
@@ -192,6 +193,7 @@ export function TransitionDirector({
                 for (const entry of registry.snapshot()) {
                     if (entry.state === 'exiting') registry.release(entry.id)
                 }
+                registry.disarm()
             })
         },
         [resolvePageDef, edges, executeTransition, registry],
@@ -238,6 +240,7 @@ export function TransitionDirector({
         if (!prev) return
         const { trigger } = isTransitionTrigger(prev, location)
         if (!trigger) return
+        registry.arm()
         for (const entry of registry.snapshot()) {
             if (entry.state !== 'exiting') registry.markExiting(entry.id)
         }

--- a/web/src/transitions/primitives/anchorSlide.test.ts
+++ b/web/src/transitions/primitives/anchorSlide.test.ts
@@ -1,6 +1,9 @@
 import { describe, test, expect } from 'vitest'
 import { PhysicsWorld } from '../../physics/PhysicsWorld'
 import { anchorSlide } from './anchorSlide'
+import type { CardActivator } from '../CardRegistry'
+
+const noopActivator: CardActivator = { activate: () => {} }
 
 describe('anchorSlide (T3) — horizontal', () => {
     test('translates from-card horizontally off-viewport over duration', () => {
@@ -14,6 +17,7 @@ describe('anchorSlide (T3) — horizontal', () => {
 
         const step = anchorSlide(
             world,
+            noopActivator,
             { fromIds: ['a'], toIds: [] },
             {
                 axis: 'horizontal',
@@ -52,6 +56,7 @@ describe('anchorSlide (T3) — horizontal', () => {
 
         const step = anchorSlide(
             world,
+            noopActivator,
             { fromIds: ['a'], toIds: [] },
             {
                 axis: 'horizontal',
@@ -79,6 +84,7 @@ describe('anchorSlide (T3) — horizontal', () => {
 
         const step = anchorSlide(
             world,
+            noopActivator,
             { fromIds: [], toIds: ['b'] },
             {
                 axis: 'horizontal',
@@ -112,6 +118,7 @@ describe('anchorSlide (T3) — horizontal', () => {
 
         const step = anchorSlide(
             world,
+            noopActivator,
             { fromIds: ['a'], toIds: [] },
             {
                 axis: 'horizontal',
@@ -144,6 +151,7 @@ describe('anchorSlide (T3) — horizontal', () => {
 
         const step = anchorSlide(
             world,
+            noopActivator,
             { fromIds: [], toIds: [] },
             {
                 axis: 'horizontal',
@@ -174,6 +182,7 @@ describe('anchorSlide (T3) — horizontal', () => {
 
         const step = anchorSlide(
             world,
+            noopActivator,
             { fromIds: [], toIds: ['b'] },
             {
                 axis: 'horizontal',
@@ -210,6 +219,7 @@ describe('anchorSlide (T3) — horizontal', () => {
 
         const step = anchorSlide(
             world,
+            noopActivator,
             { fromIds: ['a'], toIds: [] },
             {
                 axis: 'vertical',
@@ -242,6 +252,7 @@ describe('anchorSlide (T3) — horizontal', () => {
         )
         const step = anchorSlide(
             world,
+            noopActivator,
             { fromIds: [], toIds: ['b'] },
             {
                 axis: 'vertical',
@@ -267,6 +278,7 @@ describe('anchorSlide (T3) — horizontal', () => {
         )
         const step = anchorSlide(
             world,
+            noopActivator,
             { fromIds: [], toIds: ['b'] },
             {
                 axis: 'vertical',
@@ -291,6 +303,7 @@ describe('anchorSlide (T3) — horizontal', () => {
 
         const step = anchorSlide(
             world,
+            noopActivator,
             { fromIds: ['a'], toIds: [] },
             {
                 axis: 'vertical',
@@ -315,6 +328,7 @@ describe('anchorSlide (T3) — horizontal', () => {
 
         const step = anchorSlide(
             world,
+            noopActivator,
             { fromIds: ['a'], toIds: [] },
             {
                 axis: 'vertical',
@@ -340,6 +354,7 @@ describe('anchorSlide (T3) — horizontal', () => {
 
         const step = anchorSlide(
             world,
+            noopActivator,
             { fromIds: ['a'], toIds: [] },
             {
                 axis: 'vertical',
@@ -357,6 +372,58 @@ describe('anchorSlide (T3) — horizontal', () => {
         expect(world.isSensor(world.floorHandle)).toBe(false)
     })
 
+    test('lifecycle: activate(id) is called after setPosition for each toId; never for fromId (I-1)', () => {
+        const calls: string[] = []
+        const handles: Record<string, { id: string }> = {
+            a: { id: 'a' },
+            b: { id: 'b' },
+            x: { id: 'x' },
+        }
+        const idOf = (h: { id: string } | undefined) => h?.id ?? '?'
+        const stubWorld = {
+            ceilingHandle: { id: 'ceiling' },
+            floorHandle: { id: 'floor' },
+            getHandleById: (id: string) => handles[id],
+            getPosition: () => ({ x: 0, y: 0 }),
+            tether: {
+                records: () => [],
+                remove: () => {},
+                add: () => {},
+            },
+            setDragging: () => {},
+            setPosition: (h: { id: string }) => {
+                calls.push(`setPosition:${idOf(h)}`)
+            },
+            setVelocity: () => {},
+            setSensor: () => {},
+        }
+        const activator: CardActivator = {
+            activate: (id: string) => {
+                calls.push(`activate:${id}`)
+            },
+        }
+        const step = anchorSlide(
+            stubWorld as unknown as Parameters<typeof anchorSlide>[0],
+            activator,
+            { fromIds: ['x'], toIds: ['a', 'b'] },
+            {
+                axis: 'horizontal',
+                sign: 1,
+                durationMs: 500,
+                viewport: { width: 800, height: 600 },
+            },
+        )
+        step(0)
+
+        for (const id of ['a', 'b']) {
+            const setPosIdx = calls.indexOf(`setPosition:${id}`)
+            const actIdx = calls.indexOf(`activate:${id}`)
+            expect(setPosIdx).toBeGreaterThanOrEqual(0)
+            expect(actIdx).toBeGreaterThan(setPosIdx)
+        }
+        expect(calls).not.toContain('activate:x')
+    })
+
     test('from-card tether is captured on init and NOT restored (card is dying)', () => {
         const viewport = { width: 800, height: 600 }
         const world = new PhysicsWorld({ viewport })
@@ -372,6 +439,7 @@ describe('anchorSlide (T3) — horizontal', () => {
 
         const step = anchorSlide(
             world,
+            noopActivator,
             { fromIds: ['a'], toIds: [] },
             {
                 axis: 'horizontal',

--- a/web/src/transitions/primitives/anchorSlide.ts
+++ b/web/src/transitions/primitives/anchorSlide.ts
@@ -4,6 +4,7 @@ import type {
     Vec2,
     Viewport,
 } from '../../physics/PhysicsWorld'
+import type { CardActivator } from '../CardRegistry'
 import type { PrimitiveStep } from './types'
 
 export interface AnchorSlideTargets {
@@ -62,6 +63,7 @@ function captureAndUntether(
 
 export function anchorSlide(
     world: PhysicsWorld,
+    activator: CardActivator,
     targets: AnchorSlideTargets,
     opts: AnchorSlideOpts,
 ): PrimitiveStep {
@@ -137,6 +139,7 @@ export function anchorSlide(
                 toInitial.set(id, start)
                 world.setDragging(handle, true)
                 world.setPosition(handle, start)
+                activator.activate(id)
             }
             initialized = true
         }

--- a/web/src/transitions/primitives/crossFade.test.ts
+++ b/web/src/transitions/primitives/crossFade.test.ts
@@ -1,5 +1,8 @@
 import { describe, test, expect, beforeEach } from 'vitest'
 import { crossFade } from './crossFade'
+import type { CardActivator } from '../CardRegistry'
+
+const noopActivator: CardActivator = { activate: () => {} }
 
 describe('crossFade', () => {
     let el: HTMLElement
@@ -9,7 +12,7 @@ describe('crossFade', () => {
     })
 
     test('starts at opacity 0 and reaches 1 over the duration', () => {
-        const step = crossFade(el, { durationMs: 150 })
+        const step = crossFade(el, noopActivator, [], { durationMs: 150 })
 
         step(0)
         expect(parseFloat(el.style.opacity)).toBeCloseTo(0, 2)
@@ -23,16 +26,30 @@ describe('crossFade', () => {
     })
 
     test('clamps opacity at 1 if step overshoots the duration', () => {
-        const step = crossFade(el, { durationMs: 150 })
+        const step = crossFade(el, noopActivator, [], { durationMs: 150 })
         const done = step(500)
         expect(parseFloat(el.style.opacity)).toBe(1)
         expect(done).toBe(true)
     })
 
     test('default duration is 150ms', () => {
-        const step = crossFade(el)
+        const step = crossFade(el, noopActivator, [])
         step(0)
         const done = step(150)
         expect(done).toBe(true)
+    })
+
+    test('lifecycle: activate(id) is called synchronously for each toId on first step (I-1)', () => {
+        const called: string[] = []
+        const activator: CardActivator = {
+            activate: (id) => called.push(id),
+        }
+        const step = crossFade(el, activator, ['a', 'b'], { durationMs: 100 })
+        expect(called).toEqual([])
+        step(0)
+        expect(called).toEqual(['a', 'b'])
+        // Subsequent ticks must not re-activate.
+        step(50)
+        expect(called).toEqual(['a', 'b'])
     })
 })

--- a/web/src/transitions/primitives/crossFade.ts
+++ b/web/src/transitions/primitives/crossFade.ts
@@ -1,3 +1,4 @@
+import type { CardActivator } from '../CardRegistry'
 import type { PrimitiveStep } from './types'
 
 export interface CrossFadeOpts {
@@ -6,6 +7,8 @@ export interface CrossFadeOpts {
 
 export function crossFade(
     element: HTMLElement,
+    activator: CardActivator,
+    toIds: readonly string[],
     opts: CrossFadeOpts = {},
 ): PrimitiveStep {
     const durationMs = opts.durationMs ?? 150
@@ -14,6 +17,7 @@ export function crossFade(
     return (dtMs) => {
         if (!initialized) {
             element.style.opacity = '0'
+            for (const id of toIds) activator.activate(id)
             initialized = true
         }
         elapsedMs += dtMs

--- a/web/src/transitions/primitives/pourInDrop.test.ts
+++ b/web/src/transitions/primitives/pourInDrop.test.ts
@@ -1,6 +1,9 @@
 import { describe, test, expect } from 'vitest'
 import { PhysicsWorld } from '../../physics/PhysicsWorld'
 import { pourInDrop } from './pourInDrop'
+import type { CardActivator } from '../CardRegistry'
+
+const noopActivator: CardActivator = { activate: () => {} }
 
 const FIXED_DT_MS = 1000 / 60
 
@@ -23,6 +26,7 @@ describe('pourInDrop (T2 — kinematic tween)', () => {
 
         const step = pourInDrop(
             world,
+            noopActivator,
             [
                 {
                     id: 'a',
@@ -63,6 +67,7 @@ describe('pourInDrop (T2 — kinematic tween)', () => {
 
         const step = pourInDrop(
             world,
+            noopActivator,
             [
                 {
                     id: 'a',
@@ -105,6 +110,7 @@ describe('pourInDrop (T2 — kinematic tween)', () => {
         const tweenDurationMs = 600
         const step = pourInDrop(
             world,
+            noopActivator,
             [
                 {
                     id: 'a',
@@ -149,6 +155,7 @@ describe('pourInDrop (T2 — kinematic tween)', () => {
         const tweenDurationMs = 200
         const step = pourInDrop(
             world,
+            noopActivator,
             [
                 {
                     id: 'a',
@@ -183,6 +190,7 @@ describe('pourInDrop (T2 — kinematic tween)', () => {
 
         const step = pourInDrop(
             world,
+            noopActivator,
             [
                 {
                     id: 'a',
@@ -204,6 +212,64 @@ describe('pourInDrop (T2 — kinematic tween)', () => {
         expect(elapsed).toBeGreaterThanOrEqual(100)
     })
 
+    test('lifecycle: activate(id) is called after setPosition for each entry (I-1)', () => {
+        const calls: string[] = []
+        const handles: Record<string, { id: string }> = {
+            a: { id: 'a' },
+            b: { id: 'b' },
+        }
+        const idOf = (h: { id: string } | undefined) => h?.id ?? '?'
+        const stubWorld = {
+            getHandleById: (id: string) => handles[id],
+            tether: {
+                records: () => [],
+                remove: () => {},
+                add: () => {},
+            },
+            setDragging: () => {},
+            setPosition: (h: { id: string }) => {
+                calls.push(`setPosition:${idOf(h)}`)
+            },
+            setVelocity: () => {},
+            has: () => true,
+        }
+        const activator: CardActivator = {
+            activate: (id: string) => {
+                calls.push(`activate:${id}`)
+            },
+        }
+        const step = pourInDrop(
+            stubWorld as unknown as Parameters<typeof pourInDrop>[0],
+            activator,
+            [
+                {
+                    id: 'a',
+                    layoutAnchor: { x: 100, y: 200 },
+                    height: 80,
+                    staggerMs: 0,
+                },
+                {
+                    id: 'b',
+                    layoutAnchor: { x: 300, y: 200 },
+                    height: 80,
+                    staggerMs: 0,
+                },
+            ],
+            { viewport: { width: 800, height: 600 }, hardCeilingMs: 5000 },
+        )
+        step(0)
+
+        // I-1: activate must come AFTER setPosition for each entry — the body
+        // is at its authoritative pre-spawn position by the time the article
+        // becomes visible.
+        for (const id of ['a', 'b']) {
+            const setPosIdx = calls.indexOf(`setPosition:${id}`)
+            const activateIdx = calls.indexOf(`activate:${id}`)
+            expect(setPosIdx).toBeGreaterThanOrEqual(0)
+            expect(activateIdx).toBeGreaterThan(setPosIdx)
+        }
+    })
+
     test('hard-ceiling fallback restores tethers for entries that never started', () => {
         const viewport = { width: 800, height: 600 }
         const world = new PhysicsWorld({ viewport })
@@ -219,6 +285,7 @@ describe('pourInDrop (T2 — kinematic tween)', () => {
         // state (tether intact, body unstuck).
         const step = pourInDrop(
             world,
+            noopActivator,
             [
                 {
                     id: 'a',

--- a/web/src/transitions/primitives/pourInDrop.ts
+++ b/web/src/transitions/primitives/pourInDrop.ts
@@ -4,6 +4,7 @@ import type {
     Vec2,
     Viewport,
 } from '../../physics/PhysicsWorld'
+import type { CardActivator } from '../CardRegistry'
 import type { PrimitiveStep } from './types'
 
 export interface PourInDropEntry {
@@ -69,6 +70,7 @@ function easeOutCubic(t: number): number {
  */
 export function pourInDrop(
     world: PhysicsWorld,
+    activator: CardActivator,
     entries: readonly PourInDropEntry[],
     opts: PourInDropOpts,
 ): PrimitiveStep {
@@ -106,6 +108,7 @@ export function pourInDrop(
             }
             world.setDragging(handle, true)
             world.setPosition(handle, startPos)
+            activator.activate(entry.id)
 
             state.set(entry.id, {
                 handle,

--- a/web/src/transitions/primitives/stringCutDrop.test.ts
+++ b/web/src/transitions/primitives/stringCutDrop.test.ts
@@ -114,22 +114,25 @@ describe('stringCutDrop (T1)', () => {
         expect(elapsed).toBeGreaterThanOrEqual(100)
     })
 
-    test('translates floor to phantom position so cards can fall past viewport', () => {
+    test('puts the floor in sensor mode so exiting cards fall through it', () => {
         const viewport = { width: 800, height: 600 }
         const world = new PhysicsWorld({ viewport })
         // Register an uncleared card so the primitive stays mid-flight (and
-        // therefore keeps the phantom floor in place) at the time we observe.
+        // therefore keeps the floor in sensor mode) at the time we observe.
         world.registerById(
             'in-flight',
             { x: 400, y: 200 },
             { width: 200, height: 100 },
         )
-        const floorBefore = world.getPosition(world.floorHandle).y
+        expect(world.isSensor(world.floorHandle)).toBe(false)
         const step = stringCutDrop(world, ['in-flight'], { viewport })
         step(0)
-        const floorAfter = world.getPosition(world.floorHandle).y
-        expect(floorAfter).toBeGreaterThan(floorBefore)
-        expect(floorAfter).toBeGreaterThan(viewport.height)
+        expect(world.isSensor(world.floorHandle)).toBe(true)
+        // The floor body itself does not move — moving the body would shift
+        // the effective anchor of any tether wired to the floor (anchorA is
+        // body-relative) and drag incoming cards. See i111 regression.
+        const floorPos = world.getPosition(world.floorHandle).y
+        expect(floorPos).toBeLessThanOrEqual(viewport.height + 30)
     })
 
     test('only cuts tethers belonging to exiting cards (incoming card stays strung)', () => {
@@ -184,10 +187,9 @@ describe('stringCutDrop (T1)', () => {
         expect(vb.y).toBeLessThan(0)
     })
 
-    test('restores the original floor anchor on completion', () => {
+    test('clears the floor sensor flag on completion', () => {
         const viewport = { width: 800, height: 600 }
         const world = new PhysicsWorld({ viewport })
-        const floorBefore = world.getAnchor(world.floorHandle)
 
         const step = stringCutDrop(world, [], {
             viewport,
@@ -201,8 +203,48 @@ describe('stringCutDrop (T1)', () => {
             elapsed += FIXED_DT_MS
         }
         expect(done).toBe(true)
-        const floorAfter = world.getAnchor(world.floorHandle)
-        expect(floorAfter.x).toBeCloseTo(floorBefore.x, 1)
-        expect(floorAfter.y).toBeCloseTo(floorBefore.y, 1)
+        expect(world.isSensor(world.floorHandle)).toBe(false)
+    })
+
+    test('does not perturb a non-exiting card whose trail tethers the floor', () => {
+        const viewport = { width: 800, height: 600 }
+        const world = new PhysicsWorld({ viewport })
+        // Exiting card (parent of string-cut).
+        const exiting = world.registerById(
+            'old',
+            { x: 200, y: 200 },
+            { width: 200, height: 100 },
+        )
+        world.tether.add(world.ceilingHandle, exiting, 150, { x: 0, y: 0 })
+        // Incoming card with a trail tether to the floor (mirrors next-nav on
+        // a paginated /blog section). Anchor at y=400; trail tether length is
+        // the same as the gap from incoming anchor to floor anchor.
+        const incoming = world.registerById(
+            'incoming',
+            { x: 600, y: 400 },
+            { width: 200, height: 100 },
+        )
+        world.tether.add(world.ceilingHandle, incoming, 400, { x: 0, y: 0 })
+        const floorAnchor = world.getAnchor(world.floorHandle)
+        const trailLength = Math.abs(400 - floorAnchor.y)
+        world.tether.add(world.floorHandle, incoming, trailLength, {
+            x: 600 - floorAnchor.x,
+            y: 0,
+        })
+        const incomingStartY = world.getPosition(incoming).y
+
+        const step = stringCutDrop(world, ['old'], { viewport })
+        // Run for several frames so any spurious overshoot from a moved-floor
+        // would have had time to drag the incoming card downward.
+        for (let i = 0; i < 30; i++) {
+            step(FIXED_DT_MS)
+            world.tick(FIXED_DT_MS)
+        }
+
+        const incomingFinalY = world.getPosition(incoming).y
+        // The incoming card should not have moved further than its own
+        // settling pendulum drift (~20px) — pre-fix, the moved floor created
+        // a huge overshoot that yanked this card down hundreds of pixels.
+        expect(Math.abs(incomingFinalY - incomingStartY)).toBeLessThan(20)
     })
 })

--- a/web/src/transitions/primitives/stringCutDrop.ts
+++ b/web/src/transitions/primitives/stringCutDrop.ts
@@ -1,7 +1,6 @@
 import type {
     PhysicsHandle,
     PhysicsWorld,
-    Vec2,
     Viewport,
 } from '../../physics/PhysicsWorld'
 import type { PrimitiveStep } from './types'
@@ -12,7 +11,6 @@ export interface StringCutDropOpts {
 }
 
 const DEFAULT_HARD_CEILING_MS = 2000
-const PHANTOM_FLOOR_OFFSET = 1000
 // Pad past the viewport edge before a card is considered "cleared". Without
 // this, cards are released the instant their top edge dips below the viewport
 // bottom and the disappear looks abrupt.
@@ -32,7 +30,6 @@ export function stringCutDrop(
 
     let elapsedMs = 0
     let initialized = false
-    let savedFloorAnchor: Vec2 | null = null
     let finalized = false
 
     const exitingHandles = new Set<PhysicsHandle>()
@@ -40,9 +37,7 @@ export function stringCutDrop(
     const finalize = () => {
         if (finalized) return
         finalized = true
-        if (savedFloorAnchor) {
-            world.setAnchor(world.floorHandle, savedFloorAnchor)
-        }
+        world.setSensor(world.floorHandle, false)
     }
 
     return (dtMs) => {
@@ -63,14 +58,14 @@ export function stringCutDrop(
                     world.tether.remove(t.handle)
                 }
             }
-            // Phantom floor: push beyond viewport so exiting cards can fall
-            // past the visible area. Saved so we can restore on completion —
-            // without this, every subsequent navigation runs with a lowered floor.
-            savedFloorAnchor = world.getAnchor(world.floorHandle)
-            world.setAnchor(world.floorHandle, {
-                x: savedFloorAnchor.x,
-                y: viewport.height + PHANTOM_FLOOR_OFFSET,
-            })
+            // Switch the floor to a sensor: exiting cards fall straight through
+            // without collision, while incoming cards' floor-anchored tethers
+            // (e.g. next-nav trail) keep their existing length. Earlier the
+            // floor body was teleported below the viewport, but that
+            // body-relative repositioning made any tether whose anchorA was
+            // body-relative overshoot massively for the duration of the
+            // transition, dragging the entire incoming chain downward.
+            world.setSensor(world.floorHandle, true)
             // Snap-kick: launch each exiting card along its buoyancy axis so
             // the drop feels deliberate rather than lethargic.
             const g = world.getGravityVector()


### PR DESCRIPTION
## Summary

- Adds a third explicit lifecycle state, **spawning**, on the `CardRegistry` — promoting what was previously an implicit `revealed` RAF flag inside `PhysicsCardImpl` into a testable state machine.
- `CardRegistryAPI` gains `activate(id)` (throws on illegal source state or missing id), `arm()` / `disarm()`. When the registry is not armed, `register()` schedules an auto-activate via `queueMicrotask` — initial page loads continue to work without ceremony.
- Each entering-card transition primitive (`pourInDrop`, `anchorSlide`, `crossFade`) now calls `activator.activate(id)` *after* it has positioned the body authoritatively. The article stays `visibility: hidden` until that call — I-1 is now enforced inside the primitive instead of by RAF ordering.
- `TransitionDirector` arms the registry in its Phase-1 `useLayoutEffect` (alongside marking outgoing cards exiting) and disarms inside `releaseFromIds()` so every code path lands clean.
- `PhysicsCardImpl` no longer carries `revealed` state, the reveal-RAF effect, or the 7-line prose comment that documented the implicit timing contract.

## Notes / deviations

- The issue's "legal arrows" list omitted `spawning → exiting`, but the auto-activate microtask spec implies it. The plan (and this PR) treat it as legal — `markExiting` accepts both `'spawning'` and `'active'`. This is also safer if a freshly-registered card overlaps a route change before its microtask fires.
- One adjacent change to `TransitionDirector`: Phase-1 now marks every non-exiting card (active **or** spawning) as exiting, not only active ones. Preserves I-2 ("Exiting survives unmount") under fast navigation where the auto-activate microtask hasn't yet fired.
- The issue's wording "`disarm()` immediately after `releaseFromIds()`" was descriptive; I kept `releaseFromIds` an inline helper inside `executeTransition` and made `disarm()` its last line. No new `releaseFromIds` method on the registry.
- A narrow `CardActivator` interface (just `activate`) was added so primitives don't depend on the full `CardRegistryAPI`; `CardRegistryAPI extends CardActivator`. Tests pass `{ activate: () => {} }` stubs.
- `stringCutDrop` is unchanged — exit-only — and does not receive the registry.

## Acceptance criteria

- [x] `CardLifecycle` includes `'spawning'`; legal/illegal transitions enumerated in tests; illegal ones throw.
- [x] `arm()` / `disarm()` added to `CardRegistryAPI`; default-policy auto-activate works on initial page load (no flicker — verified by tests and prerender check).
- [ ] All four transition kinds work end-to-end in `npm run dev`: `pour-in-drop`, `string-cut-drop`, `anchor-slide`, `cross-fade`. *Direct invariants are tested at the unit level; reviewer should still smoke-check in the browser.*
- [x] `revealed` state, reveal-RAF effect, and the prose comment at `PhysicsCardImpl.tsx:53–60` are gone.
- [x] Direct test for I-1 passes (`PhysicsCardImpl.test.tsx` → "lifecycle visibility (I-1)").
- [x] Direct test for I-2 passes (`TransitionDirector.test.tsx` → "orphan card survival" still green; "lifecycle arming" test added).
- [x] Each entering-card primitive has a contract test asserting it calls `activate(id)` after positioning, **without instantiating matter.js**. `stringCutDrop` does not receive the registry by design (compile-enforced regression guard).
- [x] `npm run typecheck`, `npm run test`, `npm run build` all clean.
- [x] Prerender check: `data-server-rendered="true"` present in `dist/index.html`, `dist/blog/index.html`, `dist/lifelog/index.html`, `dist/stuff/index.html`.

## Test plan

```sh
cd web
npm run typecheck
npm run test          # 576 passed, 1 skipped
npm run build         # confirms vite-react-ssg prerender still works
grep 'data-server-rendered="true"' dist/index.html
npm run dev           # then in browser, exercise:
                      #   - reload on any route                 → pour-in-drop
                      #   - /  ↔ /writing or sibling top-level  → anchor-slide
                      #   - cross-fade route (where used)
                      #   - exit from a route with strung cards → string-cut-drop
```

No flicker expected on initial page load — spawning cards never paint at the layout anchor.

Closes #111