### PR TITLE
docs(context): add Controller / Lazy singleton vocab

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -162,6 +162,34 @@ Two families share the type:
 _Avoid_: step (too generic), animation (used for non-route animations
 like FrameBar idle).
 
+**Controller**:
+A domain-owned object exposing mutable state to the rest of the app
+through a uniform contract: a `getX(): T` reader for the current value,
+a `subscribe(cb: (next: T) => void): () => void` listener registration
+that fires synchronously on every change, and any domain-specific
+mutators. React-agnostic — every **Controller** must be constructible
+and unit-testable without React in scope. Production examples:
+`BackgroundGallery` (active background scene), `FrameEdgeController`
+(frame-bar edge selection), `ThemeController` (light/dark/system),
+`MinimizedRegistry` (minimized cards). Consumed by React through a
+single bridge hook (`useController`), never by re-implementing the
+subscribe ritual per call site.
+_Avoid_: store (drifts toward Redux/Zustand connotations the site does
+not adopt), service (backend-ish), manager (vague), context
+(React-coupled — a **Controller** can outlive any React tree).
+
+**Lazy singleton**:
+The SSR-safe module-level cache pattern used to hold one **Controller**
+instance per browser session: a `let instance: T | null` at module
+scope plus a `getInstance()` that constructs on first call, guarded so
+SSG/SSR (no `window`, no `localStorage`) doesn't throw. Lives in the
+React-side hook file that exposes the **Controller** to components,
+never inside the **Controller** module itself — the **Controller** is
+the unit of behaviour; the singleton is the unit of session-scoped
+identity, and the two should not be welded.
+_Avoid_: global (suggests ambient mutable state with no owner), module
+state (true but uninformative), instance hack.
+
 ## Relationships
 
 - A **Card** has at most one **Tether** to a parent; multiple **Card**s can


### PR DESCRIPTION
## Summary

- Adds two terms to `CONTEXT.md`'s Architecture section:
  - **Controller** — the contract for domain-owned subscribable state
    (`getX()`, `subscribe(cb)`, mutators). React-agnostic;
    unit-testable without React in scope. Production examples:
    `BackgroundGallery`, `FrameEdgeController`, `ThemeController`,
    `MinimizedRegistry`.
  - **Lazy singleton** — the SSR-safe module-level cache that holds
    one Controller per browser session, with the `window` /
    `localStorage` guards each domain hook currently re-implements.
- Vocabulary lands ahead of the two issues that consume it: #117
  (Controller bridge refactor — extract `useController`) and #118
  (minimize-card removal, which subsequently drops `MinimizedRegistry`
  from the Controller examples list in a same-PR `CONTEXT.md` edit).

## Notes / deviations

None. Doc-only change.

The Controller examples list includes `MinimizedRegistry` for now,
honestly reflecting the current production state. #118's PR will drop
that one entry from the list when the minimize-card feature is removed.

## Acceptance criteria

- [x] Two new entries added to `CONTEXT.md` under "Architecture."
- [x] Entries match the existing style (term in bold, definition,
      `_Avoid_:` synonyms list).
- [x] No code changes.
- [x] Secret-leak scan clean.

## Test plan

- Visual review of the two new entries in `CONTEXT.md`.
- Markdown-only change; no typecheck / test / build runs required.
- `grep -niE '(api[_-]?key|secret|token|password)\s*[:=]\s*"…"' CONTEXT.md`
  returns zero matches (verified locally).
