### PR TITLE
Slice 117: Controller bridge — useController + persistentMap (#117)

### DIFF
--- a/web/src/canvas/frame-edge.ts
+++ b/web/src/canvas/frame-edge.ts
@@ -3,6 +3,7 @@ export type FrameEdge = 'top' | 'bottom'
 export const FRAME_EDGE_STORAGE_KEY = 'chaipalaka.frame.edge'
 
 export interface FrameEdgeController {
+    get(): FrameEdge
     getEdge(): FrameEdge
     setEdge(edge: FrameEdge): void
     toggleEdge(): void
@@ -30,6 +31,8 @@ export function createFrameEdgeController(
     const listeners = new Set<(edge: FrameEdge) => void>()
 
     return {
+        get: () => current,
+
         getEdge() {
             return current
         },

--- a/web/src/canvas/gallery.ts
+++ b/web/src/canvas/gallery.ts
@@ -20,6 +20,7 @@ export interface GalleryDeps {
 }
 
 export interface BackgroundGallery {
+    get(): BackgroundScene
     getActive(): BackgroundScene
     setActive(id: string): void
     register(scene: BackgroundScene): void
@@ -66,6 +67,7 @@ export function createGallery(deps: GalleryDeps): BackgroundGallery {
     writeAccent(active)
 
     return {
+        get: () => active,
         getActive: () => active,
 
         setActive(id: string) {

--- a/web/src/canvas/useFrameEdge.ts
+++ b/web/src/canvas/useFrameEdge.ts
@@ -1,30 +1,19 @@
-import { useEffect, useState } from 'react'
 import {
     createFrameEdgeController,
     FRAME_EDGE_STORAGE_KEY,
 } from './frame-edge'
 import type { FrameEdge } from './frame-edge'
-
-function makeStorage(): Map<string, string> {
-    const m = new Map<string, string>()
-    if (typeof localStorage !== 'undefined') {
-        const persisted = localStorage.getItem(FRAME_EDGE_STORAGE_KEY)
-        if (persisted) m.set(FRAME_EDGE_STORAGE_KEY, persisted)
-        const original = m.set.bind(m)
-        m.set = (k, v) => {
-            localStorage.setItem(k, v)
-            return original(k, v)
-        }
-    }
-    return m
-}
+import { useController } from '../state/useController'
+import { persistentMap } from '../state/persistentMap'
 
 let controllerInstance: ReturnType<typeof createFrameEdgeController> | null =
     null
 
 function getController() {
     if (!controllerInstance) {
-        controllerInstance = createFrameEdgeController({ storage: makeStorage() })
+        controllerInstance = createFrameEdgeController({
+            storage: persistentMap(FRAME_EDGE_STORAGE_KEY),
+        })
     }
     return controllerInstance
 }
@@ -39,12 +28,7 @@ export function useFrameEdge(): {
     toggleEdge: () => void
 } {
     const ctrl = getController()
-    const [edge, setEdgeState] = useState(() => ctrl.getEdge())
-
-    useEffect(() => {
-        const unsub = ctrl.subscribe((e) => setEdgeState(e))
-        return unsub
-    }, [ctrl])
+    const edge = useController(getController)
 
     return {
         edge,

--- a/web/src/canvas/useGallery.ts
+++ b/web/src/canvas/useGallery.ts
@@ -1,9 +1,10 @@
-import { useEffect, useState } from 'react'
+import { useEffect } from 'react'
 import { backgroundScenes } from './scenes'
 import { createRegistry } from './registry'
 import { createGallery, STORAGE_KEY } from './gallery'
 import type { BackgroundGallery } from './gallery'
 import type { BackgroundScene } from './types'
+import { useController } from '../state/useController'
 
 declare global {
     interface Window {
@@ -51,15 +52,10 @@ export function useGallery(): {
     setActive: (id: string) => void
 } {
     const gallery = getGallery()
-    const [active, setActive] = useState(() => gallery.getActive())
+    const active = useController(getGallery)
 
     useEffect(() => {
-        // Install debug hook for QA and for slice-18 UI to override.
         window.__setBackground = (id: string) => gallery.setActive(id)
-        const unsub = gallery.subscribe((next) => setActive(next))
-        return () => {
-            unsub()
-        }
     }, [gallery])
 
     return { active, setActive: (id) => gallery.setActive(id) }

--- a/web/src/controls/theme.ts
+++ b/web/src/controls/theme.ts
@@ -3,6 +3,7 @@ export type Theme = 'dark' | 'light'
 export const THEME_STORAGE_KEY = 'chaipalaka.theme'
 
 export interface ThemeController {
+    get(): Theme
     getTheme(): Theme
     setTheme(theme: Theme): void
     cycleTheme(): void
@@ -37,6 +38,8 @@ export function createThemeController(
     const listeners = new Set<(theme: Theme) => void>()
 
     return {
+        get: () => current,
+
         getTheme() {
             return current
         },

--- a/web/src/controls/useTheme.test.ts
+++ b/web/src/controls/useTheme.test.ts
@@ -24,6 +24,23 @@ describe('useTheme', () => {
         expect(['dark', 'light']).toContain(result.current.theme)
     })
 
+    test('setTheme updates dataset.theme via the hook’s useEffect (not inside subscribe)', async () => {
+        const { renderHook, act, useTheme } = await setup()
+        const { result } = renderHook(() => useTheme())
+
+        act(() => {
+            result.current.setTheme('light')
+        })
+        expect(result.current.theme).toBe('light')
+        expect(document.documentElement.dataset.theme).toBe('light')
+
+        act(() => {
+            result.current.setTheme('dark')
+        })
+        expect(result.current.theme).toBe('dark')
+        expect(document.documentElement.dataset.theme).toBe('dark')
+    })
+
     test('cycleTheme updates the dataset attribute and the returned theme', async () => {
         const { renderHook, act, useTheme } = await setup()
         const { result } = renderHook(() => useTheme())

--- a/web/src/controls/useTheme.ts
+++ b/web/src/controls/useTheme.ts
@@ -1,20 +1,8 @@
-import { useEffect, useState } from 'react'
+import { useEffect } from 'react'
 import { createThemeController, THEME_STORAGE_KEY } from './theme'
 import type { Theme } from './theme'
-
-function makeStorage(): Map<string, string> {
-    const m = new Map<string, string>()
-    if (typeof localStorage !== 'undefined') {
-        const persisted = localStorage.getItem(THEME_STORAGE_KEY)
-        if (persisted) m.set(THEME_STORAGE_KEY, persisted)
-        const original = m.set.bind(m)
-        m.set = (k, v) => {
-            localStorage.setItem(k, v)
-            return original(k, v)
-        }
-    }
-    return m
-}
+import { useController } from '../state/useController'
+import { persistentMap } from '../state/persistentMap'
 
 function readSystemPreference(): Theme {
     if (typeof window === 'undefined' || !window.matchMedia) return 'dark'
@@ -28,7 +16,7 @@ let controllerInstance: ReturnType<typeof createThemeController> | null = null
 function getController() {
     if (!controllerInstance) {
         controllerInstance = createThemeController({
-            storage: makeStorage(),
+            storage: persistentMap(THEME_STORAGE_KEY),
             getSystemPreference: readSystemPreference,
         })
     }
@@ -41,21 +29,13 @@ export function useTheme(): {
     cycleTheme: () => void
 } {
     const ctrl = getController()
-    const [theme, setThemeState] = useState(() => ctrl.getTheme())
+    const theme = useController(getController)
 
     useEffect(() => {
-        const unsub = ctrl.subscribe((t) => {
-            setThemeState(t)
-            if (typeof document !== 'undefined') {
-                document.documentElement.dataset.theme = ctrl.getDataTheme()
-            }
-        })
-        // Apply on mount too
         if (typeof document !== 'undefined') {
             document.documentElement.dataset.theme = ctrl.getDataTheme()
         }
-        return unsub
-    }, [ctrl])
+    }, [theme, ctrl])
 
     return {
         theme,

--- a/web/src/state/persistentMap.test.ts
+++ b/web/src/state/persistentMap.test.ts
@@ -1,0 +1,41 @@
+import { describe, test, expect, beforeEach } from 'vitest'
+
+import { persistentMap } from './persistentMap'
+
+beforeEach(() => {
+    localStorage.clear()
+})
+
+describe('persistentMap', () => {
+    test('round-trips a value through get/set', () => {
+        const m = persistentMap('chaipalaka.test.key')
+        m.set('chaipalaka.test.key', 'hello')
+        expect(m.get('chaipalaka.test.key')).toBe('hello')
+    })
+
+    test('set writes through to localStorage', () => {
+        const m = persistentMap('chaipalaka.test.key')
+        m.set('chaipalaka.test.key', 'world')
+        expect(localStorage.getItem('chaipalaka.test.key')).toBe('world')
+    })
+
+    test('hydrates from an existing localStorage value on construction', () => {
+        localStorage.setItem('chaipalaka.test.key', 'persisted')
+        const m = persistentMap('chaipalaka.test.key')
+        expect(m.get('chaipalaka.test.key')).toBe('persisted')
+    })
+
+    test('returns a plain in-memory Map when localStorage is undefined (SSR)', () => {
+        const original = globalThis.localStorage
+        // simulate SSG/SSR — happy-dom defines localStorage; remove it for this test.
+        // @ts-expect-error narrow the global for this assertion
+        delete globalThis.localStorage
+        try {
+            const m = persistentMap('chaipalaka.test.key')
+            expect(() => m.set('chaipalaka.test.key', 'noop')).not.toThrow()
+            expect(m.get('chaipalaka.test.key')).toBe('noop')
+        } finally {
+            globalThis.localStorage = original
+        }
+    })
+})

--- a/web/src/state/persistentMap.ts
+++ b/web/src/state/persistentMap.ts
@@ -1,0 +1,13 @@
+export function persistentMap(key: string): Map<string, string> {
+    const m = new Map<string, string>()
+    if (typeof localStorage !== 'undefined') {
+        const persisted = localStorage.getItem(key)
+        if (persisted) m.set(key, persisted)
+        const original = m.set.bind(m)
+        m.set = (k, v) => {
+            localStorage.setItem(k, v)
+            return original(k, v)
+        }
+    }
+    return m
+}

--- a/web/src/state/useController.test.tsx
+++ b/web/src/state/useController.test.tsx
@@ -1,0 +1,82 @@
+import { describe, test, expect } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+
+import { useController, type Controller } from './useController'
+
+function makeFakeController<T>(initial: T): Controller<T> & {
+    emit: (next: T) => void
+} {
+    let current = initial
+    const listeners = new Set<(next: T) => void>()
+    return {
+        get: () => current,
+        subscribe(cb) {
+            listeners.add(cb)
+            return () => listeners.delete(cb)
+        },
+        emit(next) {
+            current = next
+            for (const cb of listeners) cb(current)
+        },
+    }
+}
+
+describe('useController', () => {
+    test('returns the controller’s current value on mount via get()', () => {
+        const ctrl = makeFakeController('initial')
+        const { result } = renderHook(() => useController(() => ctrl))
+        expect(result.current).toBe('initial')
+    })
+
+    test('re-renders the consumer when the controller emits a new value', () => {
+        const ctrl = makeFakeController('one')
+        const { result } = renderHook(() => useController(() => ctrl))
+        expect(result.current).toBe('one')
+
+        act(() => {
+            ctrl.emit('two')
+        })
+
+        expect(result.current).toBe('two')
+    })
+
+    test('two consumers sharing a singleton both update on emit', () => {
+        const ctrl = makeFakeController('one')
+        const getInstance = () => ctrl
+        const a = renderHook(() => useController(getInstance))
+        const b = renderHook(() => useController(getInstance))
+        expect(a.result.current).toBe('one')
+        expect(b.result.current).toBe('one')
+
+        act(() => {
+            ctrl.emit('two')
+        })
+
+        expect(a.result.current).toBe('two')
+        expect(b.result.current).toBe('two')
+    })
+
+    test('unsubscribes on unmount — no further notifications', () => {
+        const ctrl = makeFakeController('one')
+        let unsubCalls = 0
+        const originalSubscribe = ctrl.subscribe
+        ctrl.subscribe = (cb) => {
+            const unsub = originalSubscribe(cb)
+            return () => {
+                unsubCalls++
+                unsub()
+            }
+        }
+
+        const { result, unmount } = renderHook(() => useController(() => ctrl))
+        expect(unsubCalls).toBe(0)
+        unmount()
+        expect(unsubCalls).toBe(1)
+
+        // After unmount, emitting must not throw and must not affect the snapshot.
+        act(() => {
+            ctrl.emit('three')
+        })
+        expect(result.current).toBe('one')
+    })
+})

--- a/web/src/state/useController.ts
+++ b/web/src/state/useController.ts
@@ -1,0 +1,13 @@
+import { useEffect, useState } from 'react'
+
+export interface Controller<T> {
+    get(): T
+    subscribe(cb: (next: T) => void): () => void
+}
+
+export function useController<T>(getInstance: () => Controller<T>): T {
+    const ctrl = getInstance()
+    const [value, setValue] = useState<T>(() => ctrl.get())
+    useEffect(() => ctrl.subscribe(setValue), [ctrl])
+    return value
+}


### PR DESCRIPTION
## Summary

- Names the singleton-controller pattern in code: a 12-line
  `web/src/state/useController.ts` bridge plus a `Controller<T>` contract
  (`get(): T` + `subscribe(cb): () => void`). Three production hooks
  (`useGallery`, `useFrameEdge`, `useTheme`) now call this primitive
  instead of re-implementing the `useState + useEffect(subscribe)`
  ritual three times.
- Lifts the literally-duplicated `makeStorage()` helper out of
  `useFrameEdge.ts` and `useTheme.ts` into a single
  `web/src/state/persistentMap.ts`. TDD'd with round-trip, write-through,
  hydration, and SSR-no-localStorage coverage.
- Each Controller gains a one-line uniform `get(): T` alongside its
  existing domain getter (`getActive` / `getEdge` / `getTheme`), so
  the bridge matches the `Controller<T>` interface without renaming
  any domain API.
- `useTheme.ts`'s `document.documentElement.dataset.theme` write moves
  out of the subscribe listener and into a vanilla
  `useEffect([theme, ctrl])` — DOM writes are domain logic, not part
  of the primitive. `useGallery.ts`'s `window.__setBackground` debug
  installer similarly moves to its own effect.

## Notes / deviations

- **Issue body said no domain-side changes needed; this PR adds a one-line
  `get(): T` per controller.** TypeScript structural matching wouldn't
  otherwise bind `Controller<T>.get()` to the existing
  `getActive() / getEdge() / getTheme()` methods. The decision was
  confirmed in planning: add `get()` alongside the domain getter
  (~6 lines across 3 controllers) rather than rename existing API or
  thread a getter through the bridge as a second arg.
- The bridge is bare by design — no `select`, no `onChange`, no
  `createObservableStore` factory absorbing construction. Per the issue's
  Non-goals section, the escape hatches were motivated by minimize-registry
  consumers that #118 removed.
- The lazy-singleton (`let *Instance = null`) stays in each hook file per
  CONTEXT.md's **Lazy singleton** entry — the bridge does not absorb
  session identity.

## Acceptance criteria

- [x] `web/src/state/useController.ts` exists with signature
      `useController<T>(getInstance: () => Controller<T>): T`, plus a
      `Controller<T>` type export.
- [x] All three hook files call `useController`; the
      `let *Instance: T | null = null` lazy-singleton pattern still lives
      in each hook file.
- [x] `web/src/state/persistentMap.ts` exists; `useFrameEdge.ts` and
      `useTheme.ts` import from it instead of duplicating `makeStorage()`.
- [x] `useTheme.ts`'s DOM write lives in a vanilla `useEffect` inside
      the hook, not inside the controller's subscribe listener and not
      as a primitive option. Verified by a new test
      (`useTheme.test.ts:20`) asserting `document.documentElement.dataset.theme`
      updates when `setTheme()` is called.
- [x] No new production behaviour. Existing hook + controller test
      suites pass unchanged (apart from the new added setTheme test).
- [x] No `select` parameter on `useController`; no `onChange` parameter;
      no `createObservableStore`; no `useSyncExternalStore` switch; no
      new `reset()` exposed on controllers.
- [x] `grep -rn 'useMinimizedRegistry\|MinimizedRegistry' web/src/`
      returns zero matches.

## Test plan

From `web/`:

- `npm run typecheck` — passes (zero errors).
- `npm run test` — **563 tests pass, 1 skipped, 70 files** (4 new
  persistentMap, 4 new useController, 1 new setTheme assertion, all
  existing tests unchanged).
- `npm run build` — vite-react-ssg prerender succeeds for all 9 routes;
  `dist/index.html` has `data-server-rendered="true"`.
- Dev server (`npm run dev`) bound on `localhost:5173`; `/` HTML loads;
  all five touched/created modules transform through Vite's TS pipeline
  without error.

UI smoke checks I could not run from CLI (no headless browser) but are
covered transitively by unit tests:
- Theme cycle → `useTheme.test.ts` cycleTheme + setTheme assertions both
  verify `document.documentElement.dataset.theme` updates.
- Frame edge toggle persistence → `useFrameEdge.test.ts` localStorage
  hydration test still passes.
- Background scene swap + accent CSS write → `gallery.test.ts` still
  asserts both.

Worth a click-through before merging if you want fully-belt-and-suspenders
visual confirmation.

Closes #117