### PR TITLE
Docs: candidate-7 grill outcome — TextMeasure primitive + Font terms

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -235,6 +235,33 @@ identity, and the two should not be welded.
 _Avoid_: global (suggests ambient mutable state with no owner), module
 state (true but uninformative), instance hack.
 
+### Text and measurement
+
+**Font**:
+A named typographic specification — `{ family, size, weight, lineHeight }`
+plus a derived canvas font-string. Declared as a const value (e.g.
+`FONT_BODY`, `FONT_CARD_TITLE`) and imported by callers; not registered
+under a string key. The **Font**'s `family`, `size`, and `weight` must
+match the corresponding CSS token in `tokens.css` so that **TextMeasure**
+predicts the same dimensions the browser will paint — a drift test
+asserts this agreement in CI.
+_Avoid_: font key (string-keyed lookup is the older registry shape, now
+deprecated), font spec (drift from the existing **CardSpec** /
+**SceneParamSchema** pattern; **Font** is a value, not a "spec").
+
+**TextMeasure**:
+The pre-paint typographic measurement primitive: given **Font** + text +
+max width, returns the dimensions a paint would produce, without
+touching the DOM. Built on `@chenglou/pretext`'s canvas-based
+measurement; the implementation library is an internal detail of the
+**TextMeasure** module. Today's surface is `measure(text, font, maxWidth)
+→ { width, height, lines }`; future growth (variable-width line
+streaming for prose around physics-card obstacles, particle-glyph
+preparation for transitions) lives behind the same seam.
+_Avoid_: pretext (leaks the implementation library into the domain),
+font registry (the older shape, retired by this term — see drift bug
+in `text/registry.ts` discovered 2026-05-13).
+
 ## Relationships
 
 - A **Card** has at most one **Tether** to a parent; multiple **Card**s can

--- a/docs/architecture-deepening.md
+++ b/docs/architecture-deepening.md
@@ -371,6 +371,9 @@ gallery/useGallery split is the same hook-pattern smell.
 
 ## Candidate 7 — `text/PretextRegistry` has exactly one caller
 
+**Status: grilled 2026-05-13. Decision: reframe + narrow.** See "Grill
+outcome" below.
+
 **Files**
 - `web/src/text/PretextRegistry.ts` — the class
 - `web/src/text/registry.ts` — module-level eager singleton
@@ -399,6 +402,68 @@ re-introduce when the second caller appears."
 **Linkage.** Independent.
 
 **ADR conflict?** No.
+
+### Grill outcome (2026-05-13)
+
+**Reframe.** The module is not a "font registry." Its load-bearing surface
+is `measure(text, font, maxWidth)` — a pre-paint text-measurement
+primitive built on `@chenglou/pretext`. `getFont` / `getLineHeight` are
+dead Interface surface (no production callers). The framing "delete vs.
+commit as font source of truth" is wrong.
+
+**Assumption.** A future feature parked in
+`memory/project_pretext_use_cases.md` — (α) prose reflowed around physics
+cards — will make text-layout a tick-rate central concern. Under that
+assumption, the **delete** branch is off the table; the **commit as
+font-source-of-truth for CSS components** branch was always wrong (CSS
+cascade still does rendering); the answer is **reframe + narrow** with a
+shape designed for α's growth.
+
+**Drift bug discovered during the grill.** `registry.ts` declares
+`'Newsreader Variable'` for the `body` and `card-title` keys, but
+`base.css` `@font-face`s only `IBM Plex Sans` and `JetBrains Mono
+Variable`. CSS uses `--font-body = 'IBM Plex Sans'` to render. So today,
+blog-index card heights are measured with one family and painted with
+another — the canvas falls back to a generic when `Newsreader Variable`
+is requested. The unit-pinned font specs in `registry.test.ts` caught the
+*desired* value but never compared it to what CSS actually loads. This is
+the motivating example for the drift-discipline test in the new shape.
+
+**Module shape chosen.**
+- Shape: pure functions + value type (not a class, not a registry).
+- Naming: **Font** as a value type, **TextMeasure** as the measurement
+  operation. Both terms now in `CONTEXT.md` under "Text and measurement."
+- Files (proposed):
+  - `web/src/text/fonts.ts` — `Font` value type + `FONT_BODY`,
+    `FONT_MONO`, `FONT_CARD_TITLE` consts.
+  - `web/src/text/measure.ts` — `measure(text, font, maxWidth)` function.
+  - Both old files (`PretextRegistry.ts`, `registry.ts`) deleted.
+- Drift policy: **D3** — a unit test parses `tokens.css` for
+  `--font-body` / `--font-mono` and asserts agreement with `fonts.ts`.
+  Catches the discovered drift bug; cheap; no build-step infra needed.
+
+**Drift bug resolution (2026-05-13).** Chose **option (a) — drop the
+Newsreader Variable intent and align to IBM Plex Sans**, which is what
+the site actually paints today. `FONT_BODY` and `FONT_CARD_TITLE` will
+declare `'IBM Plex Sans'`. No visible change for users; cheapest fix;
+no bundle additions. The "editorial serif body" idea is parked and can
+return as a deliberate typography slice if Chai wants it later.
+
+**Today's slice deliverables (small):**
+1. Introduce `fonts.ts` and `measure.ts` as above; delete the old files.
+2. Migrate `BlogIndex.measure.ts` + `BlogIndex.tsx` to the new shape.
+3. Add the drift test.
+4. Apply option (a) — `FONT_BODY` / `FONT_CARD_TITLE` become IBM Plex
+   Sans to match `base.css`.
+5. `CONTEXT.md` already updated with **Font** + **TextMeasure**.
+
+**Deferred (lands with α):**
+- `layoutFlow(text, font, obstacles)` for variable-width line streaming.
+- A peer `Prose` / `TextField` module that consumes `layoutFlow`.
+- Domain term **ProseFlow** (or similar) added to `CONTEXT.md` at that
+  time.
+
+**Issue:** [#127](https://github.com/cpalaka/chaipalaka.com/issues/127)
 
 ---
 


### PR DESCRIPTION
## Summary

- Records the design artifacts produced by the 2026-05-13 grill of `docs/architecture-deepening.md` Candidate 7 (`text/PretextRegistry` has exactly one caller).
- `CONTEXT.md`: adds **Font** and **TextMeasure** under a new "Text and measurement" subsection in Architecture.
- `docs/architecture-deepening.md`: marks Candidate 7 grilled, records the *reframe + narrow* decision, documents the live drift bug discovered during the grill (`registry.ts` declares `'Newsreader Variable'`; `base.css` only loads `'IBM Plex Sans'`), and links the implementation slice (#127).

This PR is docs-only. Implementation of the new shape lives in #127.

## Notes / deviations

- The architecture doc originally claimed `CONTEXT.md` didn't exist; it did by the time the grill started — verification at the top of the grill caught that drift.
- Candidate 7's "delete vs. commit as font source of truth" framing was rejected during the grill; the answer is *reframe + narrow* under the assumption that a future (α) feature (`memory/project_pretext_use_cases.md`) will make text measurement central. The doc's grill-outcome section explains the assumption.
- Drift-bug resolution: option (a) — drop the Newsreader Variable intent, align to `'IBM Plex Sans'` (what `base.css` actually loads). No visible change for users.

## Acceptance criteria

- [x] `CONTEXT.md` includes **Font** and **TextMeasure** definitions under a new "Text and measurement" subsection.
- [x] `docs/architecture-deepening.md` Candidate 7 marked *grilled 2026-05-13*, decision *reframe + narrow*, drift bug recorded, issue #127 linked.
- [x] No code changed.

## Test plan

- Read `CONTEXT.md` § "Text and measurement" — confirm Font/TextMeasure read coherently against the surrounding glossary.
- Read `docs/architecture-deepening.md` § "Candidate 7" + "Grill outcome (2026-05-13)" — confirm the reframe, drift bug, and slice scope all make sense.

Refs #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)