### PR TITLE
Refactor: extract CardImpl math helpers + relocate resolveParent (#136)

### DIFF
--- a/web/src/card/CardImpl.tsx
+++ b/web/src/card/CardImpl.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useRef } from 'react'
 import { usePhysicsWorld } from '../physics/PhysicsContext'
-import { wireTetherFor } from '../physics/Tether'
+import { resolveParent, wireTetherFor } from '../physics/Tether'
 import type { PhysicsHandle } from '../physics/PhysicsWorld'
 import type { TetherHandle } from '../physics/Tether'
 import type { CardEntry } from './CardRegistry'
+import { computeFlingImpulse } from './flingImpulse'
+import { computeSpawnOffset } from './spawnOffset'
 import './Card.css'
 
 interface CardImplProps {
@@ -42,17 +44,15 @@ export function CardImpl({ entry }: CardImplProps) {
         const el = elRef.current
         if (!el) return
 
-        const { x, y } = anchorRef.current
         const w = width
         const h = height
 
         const SPAWN_OFFSET = 20
-        const g = world.getGravityVector()
-        const gLen = Math.hypot(g.x, g.y)
-        const gx = gLen > 0 ? g.x / gLen : 0
-        const gy = gLen > 0 ? g.y / gLen : 1
-        const sx = x + gx * SPAWN_OFFSET
-        const sy = y + gy * SPAWN_OFFSET
+        const { x: sx, y: sy } = computeSpawnOffset(
+            anchorRef.current,
+            world.getGravityVector(),
+            SPAWN_OFFSET,
+        )
 
         el.style.width = `${w}px`
         el.style.height = `${h}px`
@@ -76,7 +76,7 @@ export function CardImpl({ entry }: CardImplProps) {
         let trailRafId = 0
         if (parent) {
             const resolved = resolveParent(world, parent)
-            if (resolved.handle != null) {
+            if (resolved !== null) {
                 tetherHandleRef.current = wireTetherFor(
                     world,
                     resolved.handle,
@@ -87,7 +87,7 @@ export function CardImpl({ entry }: CardImplProps) {
             } else {
                 rafId = requestAnimationFrame(() => {
                     const retried = resolveParent(world, parent)
-                    if (retried.handle == null) {
+                    if (retried === null) {
                         console.warn(
                             `Card: parent "${parent}" not found after one frame; tether skipped`,
                         )
@@ -105,7 +105,7 @@ export function CardImpl({ entry }: CardImplProps) {
         }
         if (trail) {
             const resolved = resolveParent(world, trail)
-            if (resolved.handle != null) {
+            if (resolved !== null) {
                 trailTetherHandleRef.current = wireTetherFor(
                     world,
                     resolved.handle,
@@ -116,7 +116,7 @@ export function CardImpl({ entry }: CardImplProps) {
             } else {
                 trailRafId = requestAnimationFrame(() => {
                     const retried = resolveParent(world, trail)
-                    if (retried.handle == null) {
+                    if (retried === null) {
                         console.warn(
                             `Card: trail "${trail}" not found after one frame; tether skipped`,
                         )
@@ -137,8 +137,9 @@ export function CardImpl({ entry }: CardImplProps) {
         let lastX = 0
         let lastY = 0
         let lastT = 0
-        let velX = 0
-        let velY = 0
+        let lastDx = 0
+        let lastDy = 0
+        let lastDt = 0
         const FLING_VELOCITY_SCALE = 16
         const FLING_PAUSE_MS = 50
 
@@ -154,8 +155,9 @@ export function CardImpl({ entry }: CardImplProps) {
             lastX = e.clientX
             lastY = e.clientY
             lastT = e.timeStamp
-            velX = 0
-            velY = 0
+            lastDx = 0
+            lastDy = 0
+            lastDt = 0
             world.setDragging(handle, true)
             el.setPointerCapture(e.pointerId)
             el.style.cursor = 'grabbing'
@@ -164,9 +166,9 @@ export function CardImpl({ entry }: CardImplProps) {
             if (!dragging) return
             const dx = e.clientX - lastX
             const dy = e.clientY - lastY
-            const dt = Math.max(e.timeStamp - lastT, 1)
-            velX = dx / dt
-            velY = dy / dt
+            lastDx = dx
+            lastDy = dy
+            lastDt = e.timeStamp - lastT
             const cur = world.getPosition(handle)
             world.setPosition(handle, { x: cur.x + dx, y: cur.y + dy })
             lastX = e.clientX
@@ -177,15 +179,12 @@ export function CardImpl({ entry }: CardImplProps) {
             if (!dragging) return
             dragging = false
             world.setDragging(handle, false)
-            const sinceLastMove = e.timeStamp - lastT
-            if (sinceLastMove > FLING_PAUSE_MS) {
-                velX = 0
-                velY = 0
-            }
-            world.setVelocity(handle, {
-                x: velX * FLING_VELOCITY_SCALE,
-                y: velY * FLING_VELOCITY_SCALE,
-            })
+            const impulse = computeFlingImpulse(
+                { dx: lastDx, dy: lastDy, dtMs: lastDt },
+                e.timeStamp - lastT,
+                { scale: FLING_VELOCITY_SCALE, pauseMs: FLING_PAUSE_MS },
+            )
+            world.setVelocity(handle, { x: impulse.vx, y: impulse.vy })
             el.releasePointerCapture(e.pointerId)
             el.style.cursor = 'grab'
         }
@@ -224,7 +223,7 @@ export function CardImpl({ entry }: CardImplProps) {
             world.tether.remove(tetherHandleRef.current)
             tetherHandleRef.current = null
             const resolved = resolveParent(world, parent)
-            if (resolved.handle != null) {
+            if (resolved !== null) {
                 tetherHandleRef.current = wireTetherFor(
                     world,
                     resolved.handle,
@@ -238,7 +237,7 @@ export function CardImpl({ entry }: CardImplProps) {
             world.tether.remove(trailTetherHandleRef.current)
             trailTetherHandleRef.current = null
             const resolved = resolveParent(world, trail)
-            if (resolved.handle != null) {
+            if (resolved !== null) {
                 trailTetherHandleRef.current = wireTetherFor(
                     world,
                     resolved.handle,
@@ -271,20 +270,4 @@ export function CardImpl({ entry }: CardImplProps) {
             {children ?? text}
         </article>
     )
-}
-
-import type { ParentRef } from '../physics/PageSpec'
-import type { PhysicsWorld } from '../physics/PhysicsWorld'
-
-type ParentKind = 'ceiling' | 'floor' | 'card'
-
-function resolveParent(
-    world: PhysicsWorld,
-    p: ParentRef,
-): { handle: PhysicsHandle | null; kind: ParentKind } {
-    if (p === 'ceiling') return { handle: world.ceilingHandle, kind: 'ceiling' }
-    if (p === 'floor') return { handle: world.floorHandle, kind: 'floor' }
-    if (p == null) return { handle: null, kind: 'card' }
-    const h = world.getHandleById(p)
-    return { handle: h ?? null, kind: 'card' }
 }

--- a/web/src/card/flingImpulse.test.ts
+++ b/web/src/card/flingImpulse.test.ts
@@ -1,0 +1,37 @@
+import { describe, test, expect } from 'vitest'
+import { computeFlingImpulse } from './flingImpulse'
+
+describe('computeFlingImpulse', () => {
+    test('normal fling: scales raw delta by config.scale / dtMs', () => {
+        // dx=10 over dt=16ms → vx = 10/16; * scale 16 = 10
+        const out = computeFlingImpulse(
+            { dx: 10, dy: 0, dtMs: 16 },
+            5,
+            { scale: 16, pauseMs: 50 },
+        )
+        expect(out.vx).toBeCloseTo(10, 10)
+        expect(out.vy).toBeCloseTo(0, 10)
+    })
+
+    test('zero impulse when sinceLastMoveMs exceeds pauseMs (paused before release)', () => {
+        const out = computeFlingImpulse(
+            { dx: 100, dy: 100, dtMs: 16 },
+            80,
+            { scale: 16, pauseMs: 50 },
+        )
+        expect(out.vx).toBe(0)
+        expect(out.vy).toBe(0)
+    })
+
+    test('zero dtMs is clamped to 1 — no divide-by-zero', () => {
+        const out = computeFlingImpulse(
+            { dx: 5, dy: 0, dtMs: 0 },
+            5,
+            { scale: 16, pauseMs: 50 },
+        )
+        // dt clamped to 1 → vx = (5/1)*16 = 80
+        expect(out.vx).toBe(80)
+        expect(out.vy).toBe(0)
+        expect(Number.isFinite(out.vx)).toBe(true)
+    })
+})

--- a/web/src/card/flingImpulse.ts
+++ b/web/src/card/flingImpulse.ts
@@ -1,0 +1,12 @@
+export function computeFlingImpulse(
+    delta: { dx: number; dy: number; dtMs: number },
+    sinceLastMoveMs: number,
+    config: { scale: number; pauseMs: number },
+): { vx: number; vy: number } {
+    if (sinceLastMoveMs > config.pauseMs) return { vx: 0, vy: 0 }
+    const dt = Math.max(delta.dtMs, 1)
+    return {
+        vx: (delta.dx / dt) * config.scale,
+        vy: (delta.dy / dt) * config.scale,
+    }
+}

--- a/web/src/card/spawnOffset.test.ts
+++ b/web/src/card/spawnOffset.test.ts
@@ -1,0 +1,28 @@
+import { describe, test, expect } from 'vitest'
+import { computeSpawnOffset } from './spawnOffset'
+
+describe('computeSpawnOffset', () => {
+    test('down gravity shifts anchor along +y by offsetPx', () => {
+        const out = computeSpawnOffset({ x: 100, y: 50 }, { x: 0, y: 1 }, 20)
+        expect(out.x).toBeCloseTo(100, 10)
+        expect(out.y).toBeCloseTo(70, 10)
+    })
+
+    test('sideways gravity shifts anchor along +x by offsetPx', () => {
+        const out = computeSpawnOffset({ x: 100, y: 50 }, { x: 1, y: 0 }, 20)
+        expect(out.x).toBeCloseTo(120, 10)
+        expect(out.y).toBeCloseTo(50, 10)
+    })
+
+    test('non-unit gravity is normalised before applying offset', () => {
+        const out = computeSpawnOffset({ x: 0, y: 0 }, { x: 3, y: 4 }, 20)
+        expect(out.x).toBeCloseTo(12, 10)
+        expect(out.y).toBeCloseTo(16, 10)
+    })
+
+    test('zero-length gravity falls back to (0, 1) direction', () => {
+        const out = computeSpawnOffset({ x: 10, y: 10 }, { x: 0, y: 0 }, 20)
+        expect(out.x).toBeCloseTo(10, 10)
+        expect(out.y).toBeCloseTo(30, 10)
+    })
+})

--- a/web/src/card/spawnOffset.ts
+++ b/web/src/card/spawnOffset.ts
@@ -1,0 +1,10 @@
+export function computeSpawnOffset(
+    anchor: { x: number; y: number },
+    gravity: { x: number; y: number },
+    offsetPx: number,
+): { x: number; y: number } {
+    const gLen = Math.hypot(gravity.x, gravity.y)
+    const gx = gLen > 0 ? gravity.x / gLen : 0
+    const gy = gLen > 0 ? gravity.y / gLen : 1
+    return { x: anchor.x + gx * offsetPx, y: anchor.y + gy * offsetPx }
+}

--- a/web/src/physics/Tether.test.ts
+++ b/web/src/physics/Tether.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect } from 'vitest'
-import { TETHER_STIFFNESS, Tether } from './Tether'
+import { TETHER_STIFFNESS, Tether, resolveParent } from './Tether'
 import type { BodyForceSource } from './BodyForceSource'
-import type { PhysicsHandle, Vec2 } from './PhysicsWorld'
+import type { PhysicsHandle, PhysicsWorld, Vec2 } from './PhysicsWorld'
 
 class FakeBodyForceSource implements BodyForceSource {
     private bodies = new Map<
@@ -342,5 +342,64 @@ describe('Tether applyRopeForces', () => {
         tether.add(1, 2, 80)
         expect(tether.removeReferencing(99)).toBe(0)
         expect(tether.records()).toHaveLength(1)
+    })
+})
+
+describe('resolveParent', () => {
+    function makeWorldStub(opts: {
+        ceilingHandle: PhysicsHandle
+        floorHandle: PhysicsHandle
+        registered: ReadonlyMap<string, PhysicsHandle>
+    }): PhysicsWorld {
+        return {
+            ceilingHandle: opts.ceilingHandle,
+            floorHandle: opts.floorHandle,
+            getHandleById: (id: string) => opts.registered.get(id),
+        } as unknown as PhysicsWorld
+    }
+
+    test("'ceiling' resolves to world.ceilingHandle with kind 'ceiling'", () => {
+        const world = makeWorldStub({
+            ceilingHandle: 7,
+            floorHandle: 8,
+            registered: new Map(),
+        })
+        expect(resolveParent(world, 'ceiling')).toEqual({
+            handle: 7,
+            kind: 'ceiling',
+        })
+    })
+
+    test("'floor' resolves to world.floorHandle with kind 'floor'", () => {
+        const world = makeWorldStub({
+            ceilingHandle: 7,
+            floorHandle: 8,
+            registered: new Map(),
+        })
+        expect(resolveParent(world, 'floor')).toEqual({
+            handle: 8,
+            kind: 'floor',
+        })
+    })
+
+    test('registered card-id resolves to its handle with kind \'card\'', () => {
+        const world = makeWorldStub({
+            ceilingHandle: 7,
+            floorHandle: 8,
+            registered: new Map([['card-a', 42]]),
+        })
+        expect(resolveParent(world, 'card-a')).toEqual({
+            handle: 42,
+            kind: 'card',
+        })
+    })
+
+    test('missing card-id resolves to null', () => {
+        const world = makeWorldStub({
+            ceilingHandle: 7,
+            floorHandle: 8,
+            registered: new Map(),
+        })
+        expect(resolveParent(world, 'never-registered')).toBeNull()
     })
 })

--- a/web/src/physics/Tether.ts
+++ b/web/src/physics/Tether.ts
@@ -1,9 +1,20 @@
 import type { BodyForceSource } from './BodyForceSource'
+import type { ParentRef } from './PageSpec'
 import type { PhysicsHandle, PhysicsWorld, Vec2 } from './PhysicsWorld'
 
 export type TetherHandle = number
 
 export type TetherParentKind = 'ceiling' | 'floor' | 'card'
+
+export function resolveParent(
+    world: PhysicsWorld,
+    ref: NonNullable<ParentRef>,
+): { handle: PhysicsHandle; kind: TetherParentKind } | null {
+    if (ref === 'ceiling') return { handle: world.ceilingHandle, kind: 'ceiling' }
+    if (ref === 'floor') return { handle: world.floorHandle, kind: 'floor' }
+    const h = world.getHandleById(ref)
+    return h !== undefined ? { handle: h, kind: 'card' } : null
+}
 
 export function wireTetherFor(
     world: PhysicsWorld,


### PR DESCRIPTION
## Summary

- Extracts two pieces of pure math out of `card/CardImpl.tsx` into their own files: `computeSpawnOffset` (`card/spawnOffset.ts`) and `computeFlingImpulse` (`card/flingImpulse.ts`). Each is a 10-line standalone helper with anonymous structural types and zero `react`/`physics/` imports, so they're tested in pure isolation.
- Relocates `resolveParent` out of `card/CardImpl.tsx` and into `physics/Tether.ts` (where its sole consumer `wireTetherFor` already lives). New signature takes `NonNullable<ParentRef>` and returns `{handle, kind} | null` — the old `p == null` branch becomes unreachable at the type level (existing `if (parent)` / `if (trail)` guards in `CardImpl` already covered it). Free cleanup per grill decision 4.
- Path A from the candidate-10 grill recorded in `docs/architecture-deepening.md` on 2026-05-14. No new module, no new seam, no production interface change.

## Notes / deviations

- **LOC drop is 17, not the issue's projected ~40.** Landed at 273 LOC vs. the issue's "~250" target. The remaining gap lives in the two near-identical parent/trail tether wiring blocks (lines 77–134) — deduplicating those is **out of scope** for this slice. The issue scope explicitly is "extract pure helpers + relocate `resolveParent`"; wiring-block dedup would be a separate slice (and Path B if it ever motivates a real seam).
- **Anonymous structural types over `Vec2` imports.** The new pure helpers use inline `{ x: number; y: number }` / `{ vx: number; vy: number }` rather than importing `Vec2` from `physics/`. The issue body specifies anonymous types in the signatures, and skipping even a type-only `physics/` import honors the "no imports from `physics/`" acceptance criterion in both spirit and letter.
- **Fling-math closure-locals changed shape.** Today: `velX`, `velY` (pre-divided per move, scaled at release). After: `lastDx`, `lastDy`, `lastDt` (raw per move; helper does the divide-and-scale at release). Numerically identical: `(dx/dt) * scale == (dx * scale) / dt`. `CardImpl.test.tsx` passes unchanged — behavioural identity confirmed.

## Acceptance criteria

- [x] `web/src/card/spawnOffset.ts` exists with `computeSpawnOffset` exported. Pure (no `react`/`physics/` imports).
- [x] `web/src/card/spawnOffset.test.ts` covers down-gravity, sideways-gravity, non-unit-gravity normalisation, zero-length-gravity fallback.
- [x] `web/src/card/flingImpulse.ts` exists with `computeFlingImpulse` exported. Pure.
- [x] `web/src/card/flingImpulse.test.ts` covers normal fling, paused-before-release zero-out, zero-`dtMs` divide-by-zero guard.
- [x] `resolveParent` exported from `physics/Tether.ts` with tightened signature. Bottom-of-file block in `card/CardImpl.tsx` deleted.
- [x] `physics/Tether.test.ts` covers `'ceiling'`, `'floor'`, registered-card-id, missing-card-id (returns `null`).
- [x] `card/CardImpl.tsx` imports and calls the three helpers; `SPAWN_OFFSET = 20` is at the call site.
- [ ] `card/CardImpl.tsx` LOC drops to roughly 250. **Landed at 273** — see Notes above.
- [x] `card/CardImpl.test.tsx` continues to pass unchanged.
- [x] `npm run typecheck` clean.
- [x] `npm run test` clean (586 tests pass, 73 files; +11 new cases from this PR).
- [x] `npm run build` succeeds (vite-react-ssg prerender confirmed; `data-server-rendered="true"` present in `dist/index.html`).

## Test plan

- `cd web && npm run typecheck` — clean.
- `cd web && npm run test` — 586 passing, including the 11 new cases (4 spawnOffset, 3 flingImpulse, 4 resolveParent).
- `cd web && npm run build` — succeeds; prerender output unchanged.
- `cd web && npm run dev` — smoke routes `/`, `/lifelog`, `/blog`, `/blog/<a slug>`, `/stuff`, `/stuff/flash`:
  - [ ] Drag a card; fling it — trajectory matches pre-refactor (reviewer to verify visually).
  - [ ] Drag a card onto its header bar — `[data-card-header], a, button` exclusion still works.
  - [ ] `/blog`: confirm the trail-tethered next-nav card wires correctly on first render.
  - [ ] Trigger a route transition involving a tethered card — spawn-offset bias unchanged.

Closes #136