### PR TITLE
Refactor: introduce Subscribable<T> primitive + deepen Controllers (#142)

### DIFF
--- a/web/src/canvas/frame-edge.ts
+++ b/web/src/canvas/frame-edge.ts
@@ -1,3 +1,5 @@
+import { createSubscribable } from '../state/subscribable'
+
 export type FrameEdge = 'top' | 'bottom'
 
 export const FRAME_EDGE_STORAGE_KEY = 'chaipalaka.frame.edge'
@@ -27,31 +29,25 @@ export function createFrameEdgeController(
     deps: FrameEdgeControllerDeps,
 ): FrameEdgeController {
     const { storage } = deps
-    let current: FrameEdge = readEdge(storage)
-    const listeners = new Set<(edge: FrameEdge) => void>()
+    const state = createSubscribable<FrameEdge>(readEdge(storage))
+
+    function commit(next: FrameEdge) {
+        storage.set(FRAME_EDGE_STORAGE_KEY, next)
+        state.set(next)
+    }
 
     return {
-        get: () => current,
-
-        getEdge() {
-            return current
-        },
+        get: state.get,
+        getEdge: state.get,
 
         setEdge(edge: FrameEdge) {
-            current = edge
-            storage.set(FRAME_EDGE_STORAGE_KEY, current)
-            for (const l of listeners) l(current)
+            commit(edge)
         },
 
         toggleEdge() {
-            current = current === 'bottom' ? 'top' : 'bottom'
-            storage.set(FRAME_EDGE_STORAGE_KEY, current)
-            for (const l of listeners) l(current)
+            commit(state.get() === 'bottom' ? 'top' : 'bottom')
         },
 
-        subscribe(listener) {
-            listeners.add(listener)
-            return () => listeners.delete(listener)
-        },
+        subscribe: state.subscribe,
     }
 }

--- a/web/src/canvas/gallery.ts
+++ b/web/src/canvas/gallery.ts
@@ -1,3 +1,4 @@
+import { createSubscribable } from '../state/subscribable'
 import type { BackgroundScene } from './types'
 
 export const STORAGE_KEY = 'chaipalaka.background.activeId'
@@ -23,7 +24,6 @@ export interface BackgroundGallery {
     getActive(): BackgroundScene
     setActive(id: string): void
     subscribe(listener: (active: BackgroundScene) => void): () => void
-    destroy(): void
 }
 
 export function createGallery(deps: GalleryDeps): BackgroundGallery {
@@ -52,18 +52,18 @@ export function createGallery(deps: GalleryDeps): BackgroundGallery {
         return def
     }
 
-    let active = pickInitial()
-    const listeners = new Set<(active: BackgroundScene) => void>()
-
     function writeAccent(scene: BackgroundScene) {
         root?.style.setProperty('--color-accent', scene.accentColor)
     }
 
-    writeAccent(active)
+    const initial = pickInitial()
+    const state = createSubscribable<BackgroundScene>(initial)
+    state.subscribe(writeAccent)
+    writeAccent(initial)
 
     return {
-        get: () => active,
-        getActive: () => active,
+        get: state.get,
+        getActive: state.get,
 
         setActive(id: string) {
             const scene = sceneById.get(id)
@@ -71,19 +71,10 @@ export function createGallery(deps: GalleryDeps): BackgroundGallery {
                 console.warn(`BackgroundGallery.setActive: unknown id "${id}"`)
                 return
             }
-            active = scene
             storage?.setItem(STORAGE_KEY, id)
-            writeAccent(scene)
-            for (const l of listeners) l(scene)
+            state.set(scene)
         },
 
-        subscribe(listener: (active: BackgroundScene) => void) {
-            listeners.add(listener)
-            return () => listeners.delete(listener)
-        },
-
-        destroy() {
-            listeners.clear()
-        },
+        subscribe: state.subscribe,
     }
 }

--- a/web/src/controls/theme.ts
+++ b/web/src/controls/theme.ts
@@ -1,3 +1,5 @@
+import { createSubscribable } from '../state/subscribable'
+
 export type Theme = 'dark' | 'light'
 
 export const THEME_STORAGE_KEY = 'chaipalaka.theme'
@@ -34,35 +36,26 @@ export function createThemeController(
     deps: ThemeControllerDeps,
 ): ThemeController {
     const { storage, getSystemPreference } = deps
-    let current: Theme = readTheme(storage, getSystemPreference)
-    const listeners = new Set<(theme: Theme) => void>()
+    const state = createSubscribable<Theme>(readTheme(storage, getSystemPreference))
+
+    function commit(next: Theme) {
+        storage.set(THEME_STORAGE_KEY, next)
+        state.set(next)
+    }
 
     return {
-        get: () => current,
-
-        getTheme() {
-            return current
-        },
+        get: state.get,
+        getTheme: state.get,
+        getDataTheme: state.get,
 
         setTheme(theme: Theme) {
-            current = theme
-            storage.set(THEME_STORAGE_KEY, current)
-            for (const l of listeners) l(current)
+            commit(theme)
         },
 
         cycleTheme() {
-            current = current === 'dark' ? 'light' : 'dark'
-            storage.set(THEME_STORAGE_KEY, current)
-            for (const l of listeners) l(current)
+            commit(state.get() === 'dark' ? 'light' : 'dark')
         },
 
-        getDataTheme() {
-            return current
-        },
-
-        subscribe(listener) {
-            listeners.add(listener)
-            return () => listeners.delete(listener)
-        },
+        subscribe: state.subscribe,
     }
 }

--- a/web/src/state/subscribable.test.ts
+++ b/web/src/state/subscribable.test.ts
@@ -1,0 +1,65 @@
+import { describe, test, expect, vi } from 'vitest'
+
+import { createSubscribable } from './subscribable'
+
+describe('createSubscribable', () => {
+    test('get() returns the initial value', () => {
+        const s = createSubscribable(7)
+        expect(s.get()).toBe(7)
+    })
+
+    test('set(next) updates the stored value', () => {
+        const s = createSubscribable('a')
+        s.set('b')
+        expect(s.get()).toBe('b')
+    })
+
+    test('set(next) fires every subscriber with the next value', () => {
+        const s = createSubscribable(0)
+        const a = vi.fn()
+        const b = vi.fn()
+        s.subscribe(a)
+        s.subscribe(b)
+        s.set(42)
+        expect(a).toHaveBeenCalledTimes(1)
+        expect(a).toHaveBeenCalledWith(42)
+        expect(b).toHaveBeenCalledTimes(1)
+        expect(b).toHaveBeenCalledWith(42)
+    })
+
+    test('subscribe does not fire on registration', () => {
+        const s = createSubscribable('initial')
+        const listener = vi.fn()
+        s.subscribe(listener)
+        expect(listener).not.toHaveBeenCalled()
+    })
+
+    test('unsubscribe stops firing for that listener but not others', () => {
+        const s = createSubscribable(0)
+        const a = vi.fn()
+        const b = vi.fn()
+        const unsubA = s.subscribe(a)
+        s.subscribe(b)
+
+        s.set(1)
+        expect(a).toHaveBeenCalledTimes(1)
+        expect(b).toHaveBeenCalledTimes(1)
+
+        unsubA()
+        s.set(2)
+        expect(a).toHaveBeenCalledTimes(1)
+        expect(b).toHaveBeenCalledTimes(2)
+        expect(b).toHaveBeenLastCalledWith(2)
+    })
+
+    test('set with the same value still fires (no dedupe)', () => {
+        const s = createSubscribable('same')
+        const listener = vi.fn()
+        s.subscribe(listener)
+        s.set('same')
+        s.set('same')
+        expect(listener).toHaveBeenCalledTimes(2)
+        expect(listener).toHaveBeenNthCalledWith(1, 'same')
+        expect(listener).toHaveBeenNthCalledWith(2, 'same')
+    })
+})

--- a/web/src/state/subscribable.ts
+++ b/web/src/state/subscribable.ts
@@ -1,0 +1,23 @@
+export interface Subscribable<T> {
+    get(): T
+    set(next: T): void
+    subscribe(listener: (next: T) => void): () => void
+}
+
+export function createSubscribable<T>(initial: T): Subscribable<T> {
+    let current = initial
+    const listeners = new Set<(next: T) => void>()
+    return {
+        get: () => current,
+        set(next) {
+            current = next
+            for (const l of listeners) l(next)
+        },
+        subscribe(listener) {
+            listeners.add(listener)
+            return () => {
+                listeners.delete(listener)
+            }
+        },
+    }
+}


### PR DESCRIPTION
## Summary

- Extracts `Subscribable<T>` (state + listeners primitive) into `web/src/state/subscribable.ts`, with full test coverage in `subscribable.test.ts`.
- Refactors the three production Controllers — `canvas/gallery.ts`, `canvas/frame-edge.ts`, `controls/theme.ts` — to wrap a single `Subscribable` internally; `get`/`subscribe` delegate, domain mutators call `subscribable.set(next)` after their own validation/persistence/side effects.
- Load-bearing readability win in gallery: the `--color-accent` CSS write becomes an explicit top-level `state.subscribe(writeAccent)` wiring at construction, no longer a hidden side effect inside `setActive`.

This is the second deepening pass on the Controller pattern. Pass 1 (#117) extracted the React-side bridge (`useController`); this slice goes one level deeper and extracts the Controller-internal listener-plus-storage skeleton.

## Notes / deviations

- **Gallery's `destroy()` is dropped entirely.** The acceptance criteria left this open; the method was never invoked anywhere (`grep -r '\.destroy('` across `web/src` returns nothing — not even in gallery's own tests, which exercise unsubscribe via the function returned from `subscribe()`). Cleanest outcome.
- **`useController` is unchanged.** `Subscribable<T>` structurally satisfies the existing `Controller<T>` interface — no React-side rewiring.
- **No dedupe in `set`** (matches today's "always fire" semantics; regression-tested by `set with the same value still fires (no dedupe)`).
- **No `destroy()` method on the primitive itself** (Controllers are session-scoped lazy singletons that don't destroy in production).

## Acceptance criteria

- [x] New `web/src/state/subscribable.ts` exports `Subscribable<T>` interface and `createSubscribable<T>(initial)` factory. No dedupe; no `destroy()`.
- [x] New `web/src/state/subscribable.test.ts` covers: initial-value retrieval; `set` fires every subscriber with `next`; multiple subscribers; unsubscribe; `set` with same value still fires.
- [x] `canvas/gallery.ts` refactored: wraps `Subscribable<BackgroundScene>`; `get`/`subscribe` delegate; `setActive` calls `state.set(scene)` after id validation + storage persist; accent-CSS write registered as a top-level `state.subscribe(writeAccent)` at construction (plus one explicit `writeAccent(initial)` for the initial value).
- [x] `canvas/frame-edge.ts` refactored: wraps `Subscribable<FrameEdge>`; `setEdge`/`toggleEdge` call `state.set(...)`; storage read/write preserved verbatim.
- [x] `controls/theme.ts` refactored: wraps `Subscribable<Theme>`; `setTheme`/`cycleTheme` call `state.set(...)`; storage read with migration-from-`'system'` preserved verbatim in `readTheme`.
- [x] Gallery's existing `destroy()` method dropped (zero callers — no tests needed migration).
- [x] `useController` bridge hook unchanged. All existing Controller tests stay green.

## Test plan

In `web/`:

```sh
npm run typecheck   # tsc --noEmit, clean
npm run test        # 75 files, 607 tests pass (1 skipped, pre-existing)
npm run build       # vite-react-ssg prerender succeeds; data-server-rendered="true"
npm run dev         # boots clean on :5173
```

Then from repo root, the standard secret-leak grep — only test-fixture `'test-key'` literals in `api/src/adapters/LastFmAdapter.test.ts` (pre-existing, not real secrets).

The refactor is purely internal — no observable behaviour change at the React/UI layer. I did not click through every UI affordance in a real browser; coverage for theme/scene/edge persistence and listener notification is fully exercised by the 607 unit tests + the 8/13/13 controller-specific test counts on gallery/frame-edge/theme.

Closes #142