### PR TITLE
Read CONTEXT.md and docs/adr/ before planning

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,11 @@ When asked to work on issue `N`:
    may have been merged since the previous session ended, and branching
    from a stale base wastes everyone's time. Do not skip this step.
 2. Read the issue: `gh issue view N --repo cpalaka/chaipalaka.com`.
-3. Re-read the relevant section(s) of `PRD.md` for design context.
+3. Re-read the relevant section(s) of `PRD.md` for design context, plus
+   `CONTEXT.md` for the domain glossary + current architecture overview, and
+   any relevant entries in `docs/adr/` for ratified architectural decisions.
+   These three together are the authoritative design record — read them
+   before planning, not just before code review.
 4. Create the feature branch: `git checkout -b <branch-name>` (see naming
    below). You should already be on freshly-pulled `main` from step 1.
 5. Plan briefly in the chat (1–5 bullets is fine). Ask only the questions that


### PR DESCRIPTION
## Summary

- Extend step 3 of CLAUDE.md's "Standing process for an issue" to also point sessions at `CONTEXT.md` (domain glossary + architecture overview) and `docs/adr/` (ratified architectural decisions), alongside the existing `PRD.md` reference.
- Motivation: future sessions should ground their plans in the project's vocabulary and prior commitments **before** writing code, not just before code review. This was missed during the #148 planning session — flagged in conversation and fixed here as a one-line process tweak so it sticks for everyone.

## Notes / deviations

- One-line process doc tweak; no code touched.
- Intentionally scoped to step 3 only (not session-init / sandbox section) to keep the rule next to the existing PRD reference.

## Acceptance criteria

- [x] Step 3 of CLAUDE.md's "Standing process for an issue" mentions CONTEXT.md and docs/adr/.

## Test plan

- Read the updated section of `CLAUDE.md` and confirm the new sentence reads naturally next to step 2 and step 4.

Refs #148